### PR TITLE
feat: experimental lyrics (.lrc) generation for music libraries

### DIFF
--- a/Api/SubtitleController.cs
+++ b/Api/SubtitleController.cs
@@ -87,7 +87,9 @@ namespace WhisperSubs.Api
                     return NotFound(new { error = "Library not found" });
                 }
 
-                var includeTypes = GetBaseItemKinds("Movie,Episode");
+                var config = Plugin.Instance.Configuration;
+                var typeStr = config.EnableLyricsGeneration ? "Movie,Episode,Audio" : "Movie,Episode";
+                var includeTypes = GetBaseItemKinds(typeStr);
                 var allItems = _libraryManager.GetItemList(new MediaBrowser.Controller.Entities.InternalItemsQuery
                 {
                     ParentId = library.Id,
@@ -106,7 +108,7 @@ namespace WhisperSubs.Api
                         Name = item.Name,
                         Type = item.GetType().Name,
                         Path = item.Path,
-                        HasSubtitles = item is Video video && video.HasSubtitles
+                        HasSubtitles = item is Video v ? v.HasSubtitles : CheckLyricsExist(item.Path)
                     })
                     .ToList();
 
@@ -141,18 +143,20 @@ namespace WhisperSubs.Api
                     return NotFound(new { error = "Item not found" });
                 }
 
-                if (!(item is Video video))
+                var config = Plugin.Instance.Configuration;
+                var isAudio = item is MediaBrowser.Controller.Entities.Audio.Audio;
+
+                if (!(item is Video) && !(isAudio && config.EnableLyricsGeneration))
                 {
-                    return BadRequest(new { error = "Item is not a video" });
+                    return BadRequest(new { error = "Item is not a supported media type" });
                 }
 
-                var config = Plugin.Instance.Configuration;
                 var targetLanguage = language ?? config.DefaultLanguage;
                 var queue = SubtitleQueueService.Instance;
 
-                queue.Enqueue(video, targetLanguage);
-                _logger.LogInformation("Queued subtitle generation for {ItemName} [{Language}]. Queue size: {Count}",
-                    item.Name, targetLanguage, queue.PriorityCount);
+                queue.Enqueue(item, targetLanguage);
+                _logger.LogInformation("Queued {Action} generation for {ItemName} [{Language}]. Queue size: {Count}",
+                    isAudio ? "lyrics" : "subtitle", item.Name, targetLanguage, queue.PriorityCount);
 
                 // Ensure the background drain worker is running
                 var manager = GetSubtitleManager();
@@ -165,7 +169,7 @@ namespace WhisperSubs.Api
 
                 return Accepted(new
                 {
-                    message = "Queued for subtitle generation",
+                    message = isAudio ? "Queued for lyrics generation" : "Queued for subtitle generation",
                     item = item.Name,
                     language = targetLanguage,
                     queueSize = queue.PriorityCount
@@ -369,6 +373,16 @@ namespace WhisperSubs.Api
             }
 
             return result.ToArray();
+        }
+
+        private static bool CheckLyricsExist(string? path)
+        {
+            if (string.IsNullOrEmpty(path)) return false;
+            var dir = System.IO.Path.GetDirectoryName(path);
+            var baseName = System.IO.Path.GetFileNameWithoutExtension(path);
+            if (dir == null) return false;
+            try { return System.IO.Directory.GetFiles(dir, baseName + ".*.lrc").Length > 0; }
+            catch { return false; }
         }
     }
 

--- a/Api/SubtitleController.cs
+++ b/Api/SubtitleController.cs
@@ -381,7 +381,12 @@ namespace WhisperSubs.Api
             var dir = System.IO.Path.GetDirectoryName(path);
             var baseName = System.IO.Path.GetFileNameWithoutExtension(path);
             if (dir == null) return false;
-            try { return System.IO.Directory.GetFiles(dir, baseName + ".*.lrc").Length > 0; }
+            try
+            {
+                // Check Jellyfin-standard track.lrc and language-tagged track.*.lrc
+                var exactLrc = System.IO.Path.Combine(dir, baseName + ".lrc");
+                return System.IO.File.Exists(exactLrc) || System.IO.Directory.GetFiles(dir, baseName + ".*.lrc").Length > 0;
+            }
             catch { return false; }
         }
     }

--- a/Configuration/PluginConfiguration.cs
+++ b/Configuration/PluginConfiguration.cs
@@ -22,6 +22,13 @@ namespace WhisperSubs.Configuration
         public SubtitleMode SubtitleMode { get; set; } = SubtitleMode.Full;
 
         /// <summary>
+        /// When enabled, music libraries are scanned and audio tracks receive
+        /// .lrc lyrics files generated via whisper transcription.
+        /// Experimental: whisper models are optimized for speech, not singing.
+        /// </summary>
+        public bool EnableLyricsGeneration { get; set; } = false;
+
+        /// <summary>
         /// Number of threads for whisper.cpp inference. 0 = whisper default (4).
         /// Higher values use more CPU cores for faster transcription.
         /// </summary>

--- a/Controller/SubtitleManager.cs
+++ b/Controller/SubtitleManager.cs
@@ -31,6 +31,13 @@ namespace WhisperSubs.Controller
         {
             if (item == null) throw new ArgumentNullException(nameof(item));
 
+            // Route audio items to lyrics generation
+            if (item is MediaBrowser.Controller.Entities.Audio.Audio)
+            {
+                await GenerateLyricsAsync(item, provider, language, cancellationToken);
+                return;
+            }
+
             var mediaPath = item.Path;
             if (string.IsNullOrEmpty(mediaPath) || !File.Exists(mediaPath))
             {
@@ -363,6 +370,123 @@ namespace WhisperSubs.Controller
                     _logger.LogWarning(ex, "Failed to cleanup temp directory: {Path}", tempDir);
                 }
             }
+        }
+
+        // ────────────────────────────────────────────────────────────
+        //  Lyrics (LRC) generation for Audio items
+        // ────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Generates LRC lyrics for an audio item by transcribing with whisper
+        /// and converting the SRT output to LRC format.
+        /// </summary>
+        private async Task GenerateLyricsAsync(BaseItem item, ISubtitleProvider provider, string language, CancellationToken cancellationToken)
+        {
+            var mediaPath = item.Path;
+            if (string.IsNullOrEmpty(mediaPath) || !File.Exists(mediaPath))
+            {
+                _logger.LogWarning("Media file not found for item {ItemName}", item.Name);
+                return;
+            }
+
+            var languages = await ResolveLanguagesAsync(mediaPath, language, cancellationToken);
+
+            foreach (var lang in languages)
+            {
+                await GenerateLyricsForLanguageAsync(item, provider, lang, mediaPath, cancellationToken);
+            }
+
+            await item.RefreshMetadata(cancellationToken);
+        }
+
+        private async Task GenerateLyricsForLanguageAsync(
+            BaseItem item, ISubtitleProvider provider, string lang,
+            string mediaPath, CancellationToken cancellationToken)
+        {
+            var baseName = Path.GetFileNameWithoutExtension(mediaPath);
+            var dir = Path.GetDirectoryName(mediaPath)!;
+            var lrcPath = Path.Combine(dir, $"{baseName}.{lang}.lrc");
+
+            if (File.Exists(lrcPath))
+            {
+                _logger.LogInformation("Lyrics already exist for {ItemName} [{Language}], skipping", item.Name, lang);
+                return;
+            }
+
+            var tempAudioPath = Path.Combine(Path.GetTempPath(), $"{item.Id}_{Guid.NewGuid()}.wav");
+            _logger.LogInformation("Generating lyrics for {ItemName} [{Language}]", item.Name, lang);
+
+            try
+            {
+                await ExtractAudioAsync(mediaPath, tempAudioPath, lang, cancellationToken);
+                string srtContent = await provider.TranscribeAsync(tempAudioPath, lang, cancellationToken);
+                string lrcContent = ConvertSrtToLrc(srtContent, item.Name);
+
+                await File.WriteAllTextAsync(lrcPath, lrcContent, CancellationToken.None);
+                _logger.LogInformation("Saved lyrics to {LrcPath}", lrcPath);
+            }
+            catch (OperationCanceledException)
+            {
+                _logger.LogInformation("Cancelled lyrics generation for {ItemName} [{Language}]", item.Name, lang);
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error generating lyrics for {ItemName} [{Language}]", item.Name, lang);
+            }
+            finally
+            {
+                if (File.Exists(tempAudioPath))
+                {
+                    try { File.Delete(tempAudioPath); }
+                    catch (Exception ex) { _logger.LogWarning(ex, "Failed to delete temp audio: {Path}", tempAudioPath); }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Converts SRT subtitle content to LRC lyrics format.
+        /// LRC uses [MM:SS.cc] timestamps (start only, no end timestamps).
+        /// </summary>
+        internal static string ConvertSrtToLrc(string srtContent, string? title = null)
+        {
+            var sb = new StringBuilder();
+
+            if (!string.IsNullOrEmpty(title))
+                sb.AppendLine($"[ti:{title}]");
+            sb.AppendLine("[by:WhisperSubs]");
+            sb.AppendLine();
+
+            var entries = Regex.Split(srtContent.Trim(), @"\r?\n\r?\n");
+            foreach (var entry in entries)
+            {
+                if (string.IsNullOrWhiteSpace(entry)) continue;
+
+                var lines = entry.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+                if (lines.Length < 3) continue;
+
+                // Line 0: sequence number
+                // Line 1: timestamp (00:01:23,456 --> 00:01:25,789)
+                // Line 2+: text
+                var timestampMatch = Regex.Match(lines[1], @"(\d{2}):(\d{2}):(\d{2})[,.](\d{3})");
+                if (!timestampMatch.Success) continue;
+
+                int hours = int.Parse(timestampMatch.Groups[1].Value);
+                int minutes = int.Parse(timestampMatch.Groups[2].Value);
+                int seconds = int.Parse(timestampMatch.Groups[3].Value);
+                int millis = int.Parse(timestampMatch.Groups[4].Value);
+
+                int totalMinutes = hours * 60 + minutes;
+                int centiseconds = millis / 10;
+
+                var text = string.Join(" ", lines.Skip(2)).Trim();
+                if (!string.IsNullOrEmpty(text))
+                {
+                    sb.AppendLine($"[{totalMinutes:D2}:{seconds:D2}.{centiseconds:D2}]{text}");
+                }
+            }
+
+            return sb.ToString();
         }
 
         // ────────────────────────────────────────────────────────────

--- a/Controller/SubtitleManager.cs
+++ b/Controller/SubtitleManager.cs
@@ -389,27 +389,28 @@ namespace WhisperSubs.Controller
                 return;
             }
 
+            // Resolve transcription language (use first detected or configured).
+            // Jellyfin expects a single track.lrc sidecar, not per-language files.
             var languages = await ResolveLanguagesAsync(mediaPath, language, cancellationToken);
+            var transcriptionLang = languages.FirstOrDefault() ?? "auto";
 
-            foreach (var lang in languages)
-            {
-                await GenerateLyricsForLanguageAsync(item, provider, lang, mediaPath, cancellationToken);
-            }
+            await GenerateLyricsForTrackAsync(item, provider, transcriptionLang, mediaPath, cancellationToken);
 
             await item.RefreshMetadata(cancellationToken);
         }
 
-        private async Task GenerateLyricsForLanguageAsync(
+        private async Task GenerateLyricsForTrackAsync(
             BaseItem item, ISubtitleProvider provider, string lang,
             string mediaPath, CancellationToken cancellationToken)
         {
             var baseName = Path.GetFileNameWithoutExtension(mediaPath);
             var dir = Path.GetDirectoryName(mediaPath)!;
-            var lrcPath = Path.Combine(dir, $"{baseName}.{lang}.lrc");
+            // Jellyfin's LyricResolver expects track.lrc (matching the audio filename)
+            var lrcPath = Path.Combine(dir, $"{baseName}.lrc");
 
             if (File.Exists(lrcPath))
             {
-                _logger.LogInformation("Lyrics already exist for {ItemName} [{Language}], skipping", item.Name, lang);
+                _logger.LogInformation("Lyrics already exist for {ItemName}, skipping", item.Name);
                 return;
             }
 

--- a/ScheduledTasks/SubtitleGenerationTask.cs
+++ b/ScheduledTasks/SubtitleGenerationTask.cs
@@ -162,17 +162,29 @@ namespace WhisperSubs.ScheduledTasks
                 // For Audio items (lyrics), skip if .lrc already exists
                 if (item is MediaBrowser.Controller.Entities.Audio.Audio)
                 {
-                    var audioPath = item.Path;
-                    if (!string.IsNullOrEmpty(audioPath))
+                    try
                     {
-                        var audioDir = System.IO.Path.GetDirectoryName(audioPath);
-                        var audioBase = System.IO.Path.GetFileNameWithoutExtension(audioPath);
-                        if (audioDir != null && System.IO.Directory.GetFiles(audioDir, audioBase + ".*.lrc").Length > 0)
+                        var audioPath = item.Path;
+                        if (!string.IsNullOrEmpty(audioPath))
                         {
-                            completed++;
-                            progress.Report((double)completed / allItems.Count * 100);
-                            continue;
+                            var audioDir = System.IO.Path.GetDirectoryName(audioPath);
+                            var audioBase = System.IO.Path.GetFileNameWithoutExtension(audioPath);
+                            if (audioDir != null)
+                            {
+                                // Check Jellyfin-standard track.lrc and language-tagged track.*.lrc
+                                var exactLrc = System.IO.Path.Combine(audioDir, audioBase + ".lrc");
+                                if (System.IO.File.Exists(exactLrc) || System.IO.Directory.GetFiles(audioDir, audioBase + ".*.lrc").Length > 0)
+                                {
+                                    completed++;
+                                    progress.Report((double)completed / allItems.Count * 100);
+                                    continue;
+                                }
+                            }
                         }
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Error checking lyrics for {ItemName}, will attempt generation", item.Name);
                     }
                 }
 

--- a/ScheduledTasks/SubtitleGenerationTask.cs
+++ b/ScheduledTasks/SubtitleGenerationTask.cs
@@ -104,22 +104,34 @@ namespace WhisperSubs.ScheduledTasks
             var needsForced = config.SubtitleMode == Configuration.SubtitleMode.ForcedOnly
                 || config.SubtitleMode == Configuration.SubtitleMode.FullAndForced;
 
-            var allItems = new List<Video>();
+            var includeKinds = new List<BaseItemKind> { BaseItemKind.Movie, BaseItemKind.Episode };
+            if (config.EnableLyricsGeneration)
+            {
+                includeKinds.Add(BaseItemKind.Audio);
+            }
+
+            var allItems = new List<BaseItem>();
             foreach (var libraryId in enabledLibraryIds)
             {
                 var items = _libraryManager.GetItemList(new InternalItemsQuery
                 {
                     ParentId = libraryId,
-                    IncludeItemTypes = new[] { BaseItemKind.Movie, BaseItemKind.Episode },
+                    IncludeItemTypes = includeKinds.ToArray(),
                     Recursive = true
-                }).OfType<Video>();
+                });
 
-                if (!needsForced)
+                foreach (var queryItem in items)
                 {
-                    items = items.Where(v => !v.HasSubtitles);
+                    if (queryItem is Video video)
+                    {
+                        if (!needsForced && video.HasSubtitles) continue;
+                        allItems.Add(video);
+                    }
+                    else if (queryItem is MediaBrowser.Controller.Entities.Audio.Audio)
+                    {
+                        allItems.Add(queryItem);
+                    }
                 }
-
-                allItems.AddRange(items.ToList());
             }
 
             _logger.LogInformation("Found {Count} candidate items across {LibCount} libraries",
@@ -146,6 +158,23 @@ namespace WhisperSubs.ScheduledTasks
                 }
 
                 var item = allItems[i];
+
+                // For Audio items (lyrics), skip if .lrc already exists
+                if (item is MediaBrowser.Controller.Entities.Audio.Audio)
+                {
+                    var audioPath = item.Path;
+                    if (!string.IsNullOrEmpty(audioPath))
+                    {
+                        var audioDir = System.IO.Path.GetDirectoryName(audioPath);
+                        var audioBase = System.IO.Path.GetFileNameWithoutExtension(audioPath);
+                        if (audioDir != null && System.IO.Directory.GetFiles(audioDir, audioBase + ".*.lrc").Length > 0)
+                        {
+                            completed++;
+                            progress.Report((double)completed / allItems.Count * 100);
+                            continue;
+                        }
+                    }
+                }
 
                 // Skip if subtitle was already generated (e.g. from a previous run before restart)
                 var mediaPath = item.Path;

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -117,6 +117,22 @@
                         </div>
                     </div>
 
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label>
+                            <input is="emby-checkbox" type="checkbox" id="chkEnableLyricsGeneration" name="EnableLyricsGeneration" />
+                            <span>Enable Lyrics Generation (Experimental)</span>
+                        </label>
+                        <div class="fieldDescription">
+                            When enabled, music libraries are included in scanning and audio tracks receive
+                            <code>.lrc</code> lyrics files generated via whisper transcription.
+                            Jellyfin automatically picks up <code>.lrc</code> files placed next to audio files.
+                            <br />
+                            <strong>Note:</strong> Whisper models are trained on speech, not singing.
+                            Lyrics accuracy varies widely &mdash; clean vocals with minimal instrumentation work best.
+                            Future whisper models may improve music transcription significantly.
+                        </div>
+                    </div>
+
                     <button is="emby-button" type="submit" class="raised button-submit block">
                         <span>Save</span>
                     </button>
@@ -142,7 +158,7 @@
                             <tr>
                                 <th style="text-align: left;">Name</th>
                                 <th style="text-align: left;">Type</th>
-                                <th style="text-align: center;">Subtitles</th>
+                                <th style="text-align: center;">Subs / Lyrics</th>
                                 <th style="text-align: left;">Language</th>
                                 <th style="text-align: right;">Actions</th>
                             </tr>
@@ -222,6 +238,7 @@
                             page.querySelector('#selectDefaultLanguage').value = config.DefaultLanguage || 'auto';
                             page.querySelector('#selectSubtitleMode').value = (config.SubtitleMode != null ? config.SubtitleMode : 0).toString();
                             page.querySelector('#chkEnableAutoGeneration').checked = config.EnableAutoGeneration || false;
+                            page.querySelector('#chkEnableLyricsGeneration').checked = config.EnableLyricsGeneration || false;
                         }
                         WhisperSubsConfig.loadModels();
                         WhisperSubsConfig.loadLibraries();
@@ -238,6 +255,7 @@
                         config.DefaultLanguage = page.querySelector('#selectDefaultLanguage').value;
                         config.SubtitleMode = parseInt(page.querySelector('#selectSubtitleMode').value, 10);
                         config.EnableAutoGeneration = page.querySelector('#chkEnableAutoGeneration').checked;
+                        config.EnableLyricsGeneration = page.querySelector('#chkEnableLyricsGeneration').checked;
                         ApiClient.updatePluginConfiguration(WhisperSubsConfig.pluginId, config).then(function (result) {
                             Dashboard.processPluginConfigurationUpdateResult(result);
                             WhisperSubsConfig.loadModels();
@@ -392,7 +410,7 @@
                             var generateBtn = document.createElement('button');
                             generateBtn.setAttribute('is', 'emby-button');
                             generateBtn.className = 'raised';
-                            generateBtn.innerHTML = '<span>Generate</span>';
+                            generateBtn.innerHTML = item.Type === 'Audio' ? '<span>Generate Lyrics</span>' : '<span>Generate</span>';
                             generateBtn.onclick = (function (id, name) {
                                 return function () { WhisperSubsConfig.generateSubtitle(id, name); };
                             })(item.Id, item.Name);

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -410,10 +410,17 @@
                             var generateBtn = document.createElement('button');
                             generateBtn.setAttribute('is', 'emby-button');
                             generateBtn.className = 'raised';
-                            generateBtn.innerHTML = item.Type === 'Audio' ? '<span>Generate Lyrics</span>' : '<span>Generate</span>';
-                            generateBtn.onclick = (function (id, name) {
-                                return function () { WhisperSubsConfig.generateSubtitle(id, name); };
-                            })(item.Id, item.Name);
+                            var isAudioItem = item.Type === 'Audio';
+                            generateBtn.innerHTML = isAudioItem ? '<span>Generate Lyrics</span>' : '<span>Generate</span>';
+                            // Hide lyrics button for Audio items that already have .lrc files
+                            if (isAudioItem && item.HasSubtitles) {
+                                generateBtn.disabled = true;
+                                generateBtn.innerHTML = '<span>Lyrics exist</span>';
+                                generateBtn.title = 'LRC lyrics file already exists for this track';
+                            }
+                            generateBtn.onclick = (function (id, name, type) {
+                                return function () { WhisperSubsConfig.generateSubtitle(id, name, type); };
+                            })(item.Id, item.Name, item.Type);
                             actionsCell.appendChild(generateBtn);
 
                             row.appendChild(nameCell);
@@ -444,12 +451,15 @@
                     });
                 },
 
-                generateSubtitle: function (itemId, itemName) {
+                generateSubtitle: function (itemId, itemName, itemType) {
+                    var isAudio = itemType === 'Audio';
+                    var actionLabel = isAudio ? 'lyrics' : 'subtitle';
+                    var btnLabel = isAudio ? 'Generate Lyrics' : 'Generate';
                     var langSelect = document.querySelector('#lang_' + itemId);
                     var lang = langSelect ? langSelect.value : 'auto';
                     var langLabel = lang === 'auto' ? 'auto-detect' : lang;
 
-                    if (!confirm('Queue subtitle generation for:\n\n"' + (itemName || itemId) + '"\nLanguage: ' + langLabel + '\n\nThe item will be added to the front of the processing queue.')) {
+                    if (!confirm('Queue ' + actionLabel + ' generation for:\n\n"' + (itemName || itemId) + '"\nLanguage: ' + langLabel + '\n\nThe item will be added to the front of the processing queue.')) {
                         return;
                     }
 
@@ -467,16 +477,16 @@
                             btn.innerHTML = '<span>Queued &#10003;</span>';
                             setTimeout(function () {
                                 btn.disabled = false;
-                                btn.innerHTML = '<span>Generate</span>';
+                                btn.innerHTML = '<span>' + btnLabel + '</span>';
                             }, 3000);
                         }
-                        Dashboard.alert('Queued "' + itemName + '" for subtitle generation (priority).');
+                        Dashboard.alert('Queued "' + itemName + '" for ' + actionLabel + ' generation (priority).');
                     }).catch(function (error) {
                         if (btn) {
                             btn.disabled = false;
-                            btn.innerHTML = '<span>Generate</span>';
+                            btn.innerHTML = '<span>' + btnLabel + '</span>';
                         }
-                        console.error('WhisperSubs: error queuing subtitle', error);
+                        console.error('WhisperSubs: error queuing ' + actionLabel, error);
                         Dashboard.alert('Error queuing subtitle. Check the server log for details.');
                     });
                 }

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.1.5.0</Version>
+    <Version>3.2.0.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
## Summary

Adds opt-in support for generating `.lrc` lyrics files from audio tracks using whisper transcription. Closes #6.

- **New config toggle** `EnableLyricsGeneration` (off by default) — when enabled, music libraries are included in scheduled scans and Audio items appear in the browse/generate UI
- **SRT→LRC conversion** — whisper outputs SRT, which is converted to standard `[MM:SS.cc]` LRC format that Jellyfin natively picks up
- **Scheduled task** includes `BaseItemKind.Audio` when lyrics enabled, skips items that already have `.lrc` files
- **API endpoint** accepts Audio items for on-demand generation (returns 400 for Audio when lyrics disabled)
- **Config page** adds checkbox with experimental warning about whisper accuracy on music

### Architecture

The feature reuses the existing whisper transcription pipeline — Audio items are routed through `GenerateSubtitleAsync()` which detects the item type and delegates to `GenerateLyricsAsync()`. This means the queue, priority system, transcription lock, and resume-on-restart all work for lyrics out of the box.

### Whisper accuracy caveat

Whisper models are trained on speech, not singing. Lyrics accuracy varies widely:
- **Clean vocals** (acoustic, spoken word, podcasts with music): decent results
- **Heavy instrumentation** (rock, electronic, metal): poor accuracy
- Future whisper models and music-specific fine-tunes may improve this significantly

### Files changed (5)
- `Configuration/PluginConfiguration.cs` — new `EnableLyricsGeneration` bool
- `Controller/SubtitleManager.cs` — `GenerateLyricsAsync()`, `ConvertSrtToLrc()`
- `ScheduledTasks/SubtitleGenerationTask.cs` — Audio item scanning + .lrc skip logic
- `Api/SubtitleController.cs` — Audio support in Generate + GetLibraryItems endpoints
- `Web/configPage.html` — lyrics checkbox, save/load, "Generate Lyrics" button for Audio items

## Test plan
- [ ] Enable lyrics generation in config page, verify checkbox saves/loads correctly
- [ ] Browse a music library in the plugin page — Audio items should appear with "Generate Lyrics" button
- [ ] Generate lyrics for a single audio track — verify `.lrc` file is created next to the audio file
- [ ] Verify Jellyfin picks up the generated `.lrc` file in the track's lyrics view
- [ ] Run scheduled task with lyrics enabled — verify Audio items are processed and existing `.lrc` files are skipped
- [ ] With lyrics disabled, verify Audio items don't appear in browse and API rejects Audio items

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional lyrics generation for audio files, producing .lrc sidecars via transcription
  * Experimental setting to enable/disable lyrics generation

* **Enhancements**
  * Scans audio libraries when enabled and avoids re-generating existing lyrics files
  * UI updates: "Generate Lyrics" vs "Generate"; buttons reflect existing lyrics state and show appropriate confirmations and messages

* **Chores**
  * Project version bumped to 3.2.0.0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->