### PR TITLE
feat: auto-download whisper binary and model on first install

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -11,7 +11,94 @@ permissions:
   id-token: write
 
 jobs:
+  # ── Build whisper.cpp static binaries ──────────────────────────────
+  build-whisper:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # CPU-only builds
+          - os: ubuntu-latest
+            platform: linux-x64
+            variant: cpu
+            asset_name: whisper-cli-linux-x64
+            cmake_flags: ""
+            pre_install: ""
+          - os: ubuntu-24.04-arm
+            platform: linux-arm64
+            variant: cpu
+            asset_name: whisper-cli-linux-arm64
+            cmake_flags: ""
+            pre_install: ""
+          # CUDA 12 (NVIDIA GPU)
+          - os: ubuntu-latest
+            platform: linux-x64
+            variant: cuda12
+            asset_name: whisper-cli-linux-x64-cuda12
+            cmake_flags: "-DGGML_CUDA=ON"
+            pre_install: "cuda"
+          # Vulkan (Intel/AMD/NVIDIA GPU)
+          - os: ubuntu-latest
+            platform: linux-x64
+            variant: vulkan
+            asset_name: whisper-cli-linux-x64-vulkan
+            cmake_flags: "-DGGML_VULKAN=ON"
+            pre_install: "vulkan"
+          # ROCm (AMD GPU)
+          - os: ubuntu-latest
+            platform: linux-x64
+            variant: rocm
+            asset_name: whisper-cli-linux-x64-rocm
+            cmake_flags: "-DGGML_HIP=ON -DCMAKE_C_COMPILER=hipcc -DCMAKE_CXX_COMPILER=hipcc"
+            pre_install: "rocm"
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Install build dependencies
+        run: sudo apt-get update && sudo apt-get install -y cmake g++ make
+
+      - name: Install CUDA Toolkit
+        if: matrix.pre_install == 'cuda'
+        uses: Jimver/cuda-toolkit@v0.2.23
+        with:
+          cuda: '12.6.3'
+          method: 'network'
+          sub-packages: '["nvcc", "cudart-dev"]'
+
+      - name: Install Vulkan SDK
+        if: matrix.pre_install == 'vulkan'
+        run: |
+          sudo apt-get install -y libvulkan-dev glslang-dev glslang-tools
+
+      - name: Install ROCm
+        if: matrix.pre_install == 'rocm'
+        run: |
+          wget -q https://repo.radeon.com/rocm/rocm.gpg.key -O - | gpg --dearmor | sudo tee /etc/apt/keyrings/rocm.gpg > /dev/null
+          echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/6.3 noble main" | sudo tee /etc/apt/sources.list.d/rocm.list
+          sudo apt-get update
+          sudo apt-get install -y hip-dev rocm-dev
+
+      - name: Clone whisper.cpp
+        run: git clone --depth 1 --branch v1.8.4 https://github.com/ggml-org/whisper.cpp.git /tmp/whisper
+
+      - name: Build whisper-cli
+        run: |
+          cd /tmp/whisper
+          cmake -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_SHARED_LIBS=OFF \
+            -DCMAKE_EXE_LINKER_FLAGS="-static-libgcc -static-libstdc++" \
+            ${{ matrix.cmake_flags }}
+          cmake --build build --config Release -j$(nproc)
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset_name }}
+          path: /tmp/whisper/build/bin/whisper-cli
+
+  # ── Build plugin + create release ──────────────────────────────────
   build:
+    needs: build-whisper
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -46,12 +133,26 @@ jobs:
           CHECKSUM=$(md5sum WhisperSubs_${{ steps.version.outputs.version }}.zip | cut -d ' ' -f 1)
           echo "checksum=$CHECKSUM" >> $GITHUB_OUTPUT
 
+      - name: Download whisper binary artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: whisper-binaries
+
+      - name: Prepare whisper binaries for release
+        run: |
+          for dir in whisper-binaries/whisper-cli-*; do
+            platform=$(basename "$dir")
+            cp "$dir/whisper-cli" "./${platform}"
+            chmod +x "./${platform}"
+          done
+          ls -la whisper-cli-*
+
       - name: Update manifest.json
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           CHECKSUM="${{ steps.checksum.outputs.checksum }}"
           TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-          
+
           cat > manifest.json << EOF
           [
             {
@@ -80,7 +181,13 @@ jobs:
         with:
           tag_name: v${{ steps.version.outputs.version }}
           name: WhisperSubs v${{ steps.version.outputs.version }}
-          files: WhisperSubs_${{ steps.version.outputs.version }}.zip
+          files: |
+            WhisperSubs_${{ steps.version.outputs.version }}.zip
+            whisper-cli-linux-x64
+            whisper-cli-linux-arm64
+            whisper-cli-linux-x64-cuda12
+            whisper-cli-linux-x64-vulkan
+            whisper-cli-linux-x64-rocm
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --configuration Release --no-restore

--- a/Api/SubtitleController.cs
+++ b/Api/SubtitleController.cs
@@ -411,6 +411,9 @@ namespace WhisperSubs.Api
             if (!valid)
                 return BadRequest(new { error = $"Unknown model: {name}" });
 
+            if (!WhisperSetupService.TryAcquire("model", $"Starting download of {name}..."))
+                return Conflict(new { error = "A download is already in progress." });
+
             var service = GetSetupService();
 
             _ = Task.Run(async () =>
@@ -428,12 +431,15 @@ namespace WhisperSubs.Api
         [HttpGet("Setup/BinaryVariants")]
         public ActionResult GetBinaryVariants()
         {
-            return Ok(BinaryCatalog.Variants.Select(v => new
+            var platform = WhisperSetupService.GetPlatformIdentifier();
+            var variants = BinaryCatalog.GetAvailableVariants(platform);
+            return Ok(variants.Select(v => new
             {
                 v.Id,
                 v.DisplayName,
                 v.Description,
-                v.IsDefault
+                v.IsDefault,
+                Platform = platform
             }));
         }
 
@@ -445,10 +451,13 @@ namespace WhisperSubs.Api
         [HttpPost("Setup/DownloadBinary")]
         public ActionResult DownloadBinary([FromQuery] string variant = "cpu")
         {
-            var valid = BinaryCatalog.Variants.Any(v =>
-                string.Equals(v.Id, variant, StringComparison.OrdinalIgnoreCase));
-            if (!valid)
-                return BadRequest(new { error = $"Unknown variant: {variant}. Use cpu, cuda12, or vulkan." });
+            var platform = WhisperSetupService.GetPlatformIdentifier();
+            var available = BinaryCatalog.GetAvailableVariants(platform);
+            if (!available.Any(v => string.Equals(v.Id, variant, StringComparison.OrdinalIgnoreCase)))
+                return BadRequest(new { error = $"No prebuilt binary for variant '{variant}' on {platform}. Prebuilt binaries are only available for Linux." });
+
+            if (!WhisperSetupService.TryAcquire("binary", $"Starting whisper-cli ({variant}) download..."))
+                return Conflict(new { error = "A download is already in progress." });
 
             var service = GetSetupService();
 

--- a/Api/SubtitleController.cs
+++ b/Api/SubtitleController.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using WhisperSubs.Configuration;
 using WhisperSubs.Controller;
 using WhisperSubs.Providers;
+using WhisperSubs.Setup;
 using Jellyfin.Data.Enums;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
@@ -350,6 +351,124 @@ namespace WhisperSubs.Api
                 _logger.LogError(ex, "Error triggering subtitle generation task");
                 return StatusCode(500, new { error = ex.Message });
             }
+        }
+
+        // ── Setup endpoints ──────────────────────────────────────────────
+
+        private WhisperSetupService GetSetupService()
+        {
+            return new WhisperSetupService(
+                _loggerFactory.CreateLogger<WhisperSetupService>(),
+                Plugin.Instance.DataFolderPath);
+        }
+
+        /// <summary>
+        /// Returns whether whisper binary and model are configured and reachable.
+        /// </summary>
+        [HttpGet("Setup/Status")]
+        public ActionResult GetSetupStatus()
+        {
+            try
+            {
+                var status = GetSetupService().GetStatus();
+                return Ok(status);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error checking setup status");
+                return StatusCode(500, new { error = ex.Message });
+            }
+        }
+
+        /// <summary>
+        /// Lists whisper models available for download from HuggingFace.
+        /// </summary>
+        [HttpGet("Setup/AvailableModels")]
+        public ActionResult GetDownloadableModels()
+        {
+            return Ok(ModelCatalog.Models.Select(m => new
+            {
+                m.FileName,
+                m.DisplayName,
+                m.SizeMB,
+                m.IsRecommended,
+                m.Description
+            }));
+        }
+
+        /// <summary>
+        /// Downloads a whisper model from HuggingFace. Returns 202 immediately;
+        /// poll GET Setup/Progress for status.
+        /// </summary>
+        [HttpPost("Setup/DownloadModel")]
+        public ActionResult DownloadModel([FromQuery] string name)
+        {
+            if (string.IsNullOrEmpty(name))
+                return BadRequest(new { error = "Model name is required." });
+
+            var valid = ModelCatalog.Models.Any(m =>
+                string.Equals(m.FileName, name, StringComparison.OrdinalIgnoreCase));
+            if (!valid)
+                return BadRequest(new { error = $"Unknown model: {name}" });
+
+            var service = GetSetupService();
+
+            _ = Task.Run(async () =>
+            {
+                try { await service.DownloadModelAsync(name, CancellationToken.None); }
+                catch (Exception ex) { _logger.LogError(ex, "Background model download failed"); }
+            });
+
+            return Accepted(new { message = $"Download of {name} started." });
+        }
+
+        /// <summary>
+        /// Lists available binary variants (CPU, CUDA, Vulkan).
+        /// </summary>
+        [HttpGet("Setup/BinaryVariants")]
+        public ActionResult GetBinaryVariants()
+        {
+            return Ok(BinaryCatalog.Variants.Select(v => new
+            {
+                v.Id,
+                v.DisplayName,
+                v.Description,
+                v.IsDefault
+            }));
+        }
+
+        /// <summary>
+        /// Downloads the whisper-cli binary for the current platform from the
+        /// whisper-subs GitHub release. Returns 202 immediately.
+        /// </summary>
+        /// <param name="variant">Binary variant: cpu (default), cuda12, or vulkan.</param>
+        [HttpPost("Setup/DownloadBinary")]
+        public ActionResult DownloadBinary([FromQuery] string variant = "cpu")
+        {
+            var valid = BinaryCatalog.Variants.Any(v =>
+                string.Equals(v.Id, variant, StringComparison.OrdinalIgnoreCase));
+            if (!valid)
+                return BadRequest(new { error = $"Unknown variant: {variant}. Use cpu, cuda12, or vulkan." });
+
+            var service = GetSetupService();
+
+            _ = Task.Run(async () =>
+            {
+                try { await service.DownloadBinaryAsync(variant, CancellationToken.None); }
+                catch (Exception ex) { _logger.LogError(ex, "Background binary download failed"); }
+            });
+
+            return Accepted(new { message = $"Binary download started (variant: {variant})." });
+        }
+
+        /// <summary>
+        /// Returns the current download progress (model or binary).
+        /// </summary>
+        [HttpGet("Setup/Progress")]
+        public ActionResult GetSetupProgress()
+        {
+            var p = WhisperSetupService.CurrentProgress;
+            return Ok(p);
         }
 
         private BaseItemKind[] GetBaseItemKinds(string input)

--- a/Api/SubtitleController.cs
+++ b/Api/SubtitleController.cs
@@ -366,6 +366,7 @@ namespace WhisperSubs.Api
         /// Returns whether whisper binary and model are configured and reachable.
         /// </summary>
         [HttpGet("Setup/Status")]
+        [Authorize(Policy = "RequiresElevation")]
         public ActionResult GetSetupStatus()
         {
             try
@@ -384,6 +385,7 @@ namespace WhisperSubs.Api
         /// Lists whisper models available for download from HuggingFace.
         /// </summary>
         [HttpGet("Setup/AvailableModels")]
+        [Authorize(Policy = "RequiresElevation")]
         public ActionResult GetDownloadableModels()
         {
             return Ok(ModelCatalog.Models.Select(m => new
@@ -401,34 +403,38 @@ namespace WhisperSubs.Api
         /// poll GET Setup/Progress for status.
         /// </summary>
         [HttpPost("Setup/DownloadModel")]
+        [Authorize(Policy = "RequiresElevation")]
         public ActionResult DownloadModel([FromQuery] string name)
         {
             if (string.IsNullOrEmpty(name))
                 return BadRequest(new { error = "Model name is required." });
 
-            var valid = ModelCatalog.Models.Any(m =>
+            var catalogEntry = ModelCatalog.Models.FirstOrDefault(m =>
                 string.Equals(m.FileName, name, StringComparison.OrdinalIgnoreCase));
-            if (!valid)
+            if (catalogEntry == null)
                 return BadRequest(new { error = $"Unknown model: {name}" });
 
-            if (!WhisperSetupService.TryAcquire("model", $"Starting download of {name}..."))
+            var canonicalName = catalogEntry.FileName;
+
+            if (!WhisperSetupService.TryAcquire("model", $"Starting download of {canonicalName}..."))
                 return Conflict(new { error = "A download is already in progress." });
 
             var service = GetSetupService();
 
             _ = Task.Run(async () =>
             {
-                try { await service.DownloadModelAsync(name, CancellationToken.None); }
+                try { await service.DownloadModelAsync(canonicalName, CancellationToken.None); }
                 catch (Exception ex) { _logger.LogError(ex, "Background model download failed"); }
             });
 
-            return Accepted(new { message = $"Download of {name} started." });
+            return Accepted(new { message = $"Download of {canonicalName} started." });
         }
 
         /// <summary>
         /// Lists available binary variants (CPU, CUDA, Vulkan).
         /// </summary>
         [HttpGet("Setup/BinaryVariants")]
+        [Authorize(Policy = "RequiresElevation")]
         public ActionResult GetBinaryVariants()
         {
             var platform = WhisperSetupService.GetPlatformIdentifier();
@@ -449,31 +455,36 @@ namespace WhisperSubs.Api
         /// </summary>
         /// <param name="variant">Binary variant: cpu (default), cuda12, or vulkan.</param>
         [HttpPost("Setup/DownloadBinary")]
+        [Authorize(Policy = "RequiresElevation")]
         public ActionResult DownloadBinary([FromQuery] string variant = "cpu")
         {
             var platform = WhisperSetupService.GetPlatformIdentifier();
             var available = BinaryCatalog.GetAvailableVariants(platform);
-            if (!available.Any(v => string.Equals(v.Id, variant, StringComparison.OrdinalIgnoreCase)))
+            var matchedVariant = available.FirstOrDefault(v => string.Equals(v.Id, variant, StringComparison.OrdinalIgnoreCase));
+            if (matchedVariant == null)
                 return BadRequest(new { error = $"No prebuilt binary for variant '{variant}' on {platform}. Prebuilt binaries are only available for Linux." });
 
-            if (!WhisperSetupService.TryAcquire("binary", $"Starting whisper-cli ({variant}) download..."))
+            var canonicalVariant = matchedVariant.Id;
+
+            if (!WhisperSetupService.TryAcquire("binary", $"Starting whisper-cli ({canonicalVariant}) download..."))
                 return Conflict(new { error = "A download is already in progress." });
 
             var service = GetSetupService();
 
             _ = Task.Run(async () =>
             {
-                try { await service.DownloadBinaryAsync(variant, CancellationToken.None); }
+                try { await service.DownloadBinaryAsync(canonicalVariant, CancellationToken.None); }
                 catch (Exception ex) { _logger.LogError(ex, "Background binary download failed"); }
             });
 
-            return Accepted(new { message = $"Binary download started (variant: {variant})." });
+            return Accepted(new { message = $"Binary download started (variant: {canonicalVariant})." });
         }
 
         /// <summary>
         /// Returns the current download progress (model or binary).
         /// </summary>
         [HttpGet("Setup/Progress")]
+        [Authorize(Policy = "RequiresElevation")]
         public ActionResult GetSetupProgress()
         {
             var p = WhisperSetupService.CurrentProgress;

--- a/Setup/BinaryCatalog.cs
+++ b/Setup/BinaryCatalog.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Linq;
+
 namespace WhisperSubs.Setup
 {
     public static class BinaryCatalog
@@ -23,6 +26,20 @@ namespace WhisperSubs.Setup
             var name = $"whisper-cli-{platform}";
             if (variant != "cpu") name += $"-{variant}";
             return name;
+        }
+
+        /// <summary>
+        /// Returns only the variants that have prebuilt binaries for the given platform.
+        /// CI builds: linux-x64 (cpu, cuda12, vulkan, rocm), linux-arm64 (cpu only).
+        /// </summary>
+        public static BinaryVariant[] GetAvailableVariants(string platform)
+        {
+            return platform switch
+            {
+                "linux-x64" => Variants,
+                "linux-arm64" => Variants.Where(v => v.Id == "cpu").ToArray(),
+                _ => Array.Empty<BinaryVariant>()
+            };
         }
     }
 

--- a/Setup/BinaryCatalog.cs
+++ b/Setup/BinaryCatalog.cs
@@ -1,0 +1,44 @@
+namespace WhisperSubs.Setup
+{
+    public static class BinaryCatalog
+    {
+        public static readonly BinaryVariant[] Variants = new[]
+        {
+            new BinaryVariant("cpu", "CPU Only",
+                "Works on any system. No GPU required.", true),
+            new BinaryVariant("cuda12", "NVIDIA CUDA 12",
+                "Hardware-accelerated via NVIDIA GPU (CUDA 12). Requires NVIDIA drivers.", false),
+            new BinaryVariant("vulkan", "Vulkan (Intel / AMD / NVIDIA)",
+                "Cross-vendor GPU acceleration via Vulkan. Works with Intel iGPU, AMD, and NVIDIA.", false),
+            new BinaryVariant("rocm", "AMD ROCm",
+                "Hardware-accelerated via AMD GPU (ROCm / HIP). Requires AMD ROCm drivers.", false),
+        };
+
+        /// <summary>
+        /// Returns the release asset name for a given platform and variant.
+        /// E.g. "whisper-cli-linux-x64" or "whisper-cli-linux-x64-cuda12".
+        /// </summary>
+        public static string GetAssetName(string platform, string variant)
+        {
+            var name = $"whisper-cli-{platform}";
+            if (variant != "cpu") name += $"-{variant}";
+            return name;
+        }
+    }
+
+    public class BinaryVariant
+    {
+        public string Id { get; }
+        public string DisplayName { get; }
+        public string Description { get; }
+        public bool IsDefault { get; }
+
+        public BinaryVariant(string id, string displayName, string description, bool isDefault)
+        {
+            Id = id;
+            DisplayName = displayName;
+            Description = description;
+            IsDefault = isDefault;
+        }
+    }
+}

--- a/Setup/ModelCatalog.cs
+++ b/Setup/ModelCatalog.cs
@@ -1,0 +1,43 @@
+namespace WhisperSubs.Setup
+{
+    public static class ModelCatalog
+    {
+        public static readonly ModelEntry[] Models = new[]
+        {
+            new ModelEntry("ggml-large-v3-turbo-q5_0.bin", "Large V3 Turbo (Q5)", 574, true,
+                "Best quality/size ratio. Recommended for most users."),
+            new ModelEntry("ggml-large-v3-turbo.bin", "Large V3 Turbo (F16)", 1620, false,
+                "Full-precision turbo model. Slightly better quality, 3x larger."),
+            new ModelEntry("ggml-medium-q5_0.bin", "Medium (Q5)", 539, false,
+                "Good quality, similar size to turbo-q5 but slower and less accurate."),
+            new ModelEntry("ggml-medium.bin", "Medium (F16)", 1530, false,
+                "Full-precision medium model."),
+            new ModelEntry("ggml-small.bin", "Small", 488, false,
+                "Faster inference, lower accuracy. Good for quick tests."),
+            new ModelEntry("ggml-base.bin", "Base", 148, false,
+                "Lightweight model. Fast but noticeably less accurate."),
+            new ModelEntry("ggml-tiny.bin", "Tiny", 78, false,
+                "Smallest model. Only for testing or very constrained environments."),
+        };
+
+        public const string HuggingFaceBaseUrl = "https://huggingface.co/ggerganov/whisper.cpp/resolve/main";
+    }
+
+    public class ModelEntry
+    {
+        public string FileName { get; }
+        public string DisplayName { get; }
+        public int SizeMB { get; }
+        public bool IsRecommended { get; }
+        public string Description { get; }
+
+        public ModelEntry(string fileName, string displayName, int sizeMB, bool isRecommended, string description)
+        {
+            FileName = fileName;
+            DisplayName = displayName;
+            SizeMB = sizeMB;
+            IsRecommended = isRecommended;
+            Description = description;
+        }
+    }
+}

--- a/Setup/WhisperSetupService.cs
+++ b/Setup/WhisperSetupService.cs
@@ -1,0 +1,418 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace WhisperSubs.Setup
+{
+    public class WhisperSetupService
+    {
+        private readonly ILogger _logger;
+        private readonly HttpClient _httpClient;
+        private readonly string _dataPath;
+
+        // Static progress tracking — polled by the API endpoint.
+        private static string _currentOperation = "";
+        private static double _progress;
+        private static string _progressMessage = "";
+        private static bool _isRunning;
+        private static string? _error;
+        private static readonly object _lock = new();
+
+        public static DownloadProgress CurrentProgress
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return new DownloadProgress
+                    {
+                        Operation = _currentOperation,
+                        Percent = _progress,
+                        Message = _progressMessage,
+                        IsRunning = _isRunning,
+                        Error = _error
+                    };
+                }
+            }
+        }
+
+        public WhisperSetupService(ILogger logger, string dataPath)
+        {
+            _logger = logger;
+            _dataPath = dataPath;
+            _httpClient = new HttpClient();
+            _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("WhisperSubs-Jellyfin-Plugin");
+        }
+
+        public string WhisperDirectory => Path.Combine(_dataPath, "whisper");
+        public string ModelsDirectory => Path.Combine(_dataPath, "whisper", "models");
+
+        public string BinaryPath => Path.Combine(WhisperDirectory,
+            RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "whisper-cli.exe" : "whisper-cli");
+
+        public static string GetPlatformIdentifier()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                return RuntimeInformation.OSArchitecture == Architecture.X64 ? "win-x64" : "win-x86";
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                return RuntimeInformation.OSArchitecture == Architecture.Arm64 ? "osx-arm64" : "osx-x64";
+            return RuntimeInformation.OSArchitecture == Architecture.Arm64 ? "linux-arm64" : "linux-x64";
+        }
+
+        /// <summary>
+        /// Checks whether the auto-downloaded binary and model exist.
+        /// Also checks if the current config already points to valid files.
+        /// </summary>
+        public SetupStatus GetStatus()
+        {
+            var config = Plugin.Instance.Configuration;
+            var autoBinaryExists = File.Exists(BinaryPath);
+            var configBinaryValid = !string.IsNullOrEmpty(config.WhisperBinaryPath)
+                                    && File.Exists(config.WhisperBinaryPath);
+
+            // Check for any model in the auto-download directory
+            string? autoModelPath = null;
+            if (Directory.Exists(ModelsDirectory))
+            {
+                var bins = Directory.GetFiles(ModelsDirectory, "*.bin");
+                if (bins.Length > 0) autoModelPath = bins[0];
+            }
+
+            var configModelValid = !string.IsNullOrEmpty(config.WhisperModelPath)
+                                   && File.Exists(config.WhisperModelPath);
+
+            // Also check if whisper-cli is discoverable in PATH
+            var inPath = IsWhisperInPath();
+
+            var binaryOk = autoBinaryExists || configBinaryValid || inPath;
+            var modelOk = autoModelPath != null || configModelValid;
+
+            return new SetupStatus
+            {
+                BinaryFound = binaryOk,
+                BinaryPath = configBinaryValid ? config.WhisperBinaryPath
+                           : autoBinaryExists ? BinaryPath
+                           : inPath ? "whisper-cli (PATH)"
+                           : null,
+                ModelFound = modelOk,
+                ModelPath = configModelValid ? config.WhisperModelPath : autoModelPath,
+                Platform = GetPlatformIdentifier(),
+                SetupComplete = binaryOk && modelOk,
+                Gpu = DetectGpu()
+            };
+        }
+
+        /// <summary>
+        /// Downloads a whisper model from HuggingFace and saves it to the models directory.
+        /// After download, automatically updates the plugin configuration.
+        /// </summary>
+        public async Task DownloadModelAsync(string modelFileName, CancellationToken cancellationToken)
+        {
+            lock (_lock)
+            {
+                if (_isRunning) throw new InvalidOperationException("A download is already in progress.");
+                _isRunning = true;
+                _error = null;
+                _currentOperation = "model";
+                _progress = 0;
+                _progressMessage = $"Starting download of {modelFileName}...";
+            }
+
+            try
+            {
+                Directory.CreateDirectory(ModelsDirectory);
+
+                var url = $"{ModelCatalog.HuggingFaceBaseUrl}/{modelFileName}";
+                var destPath = Path.Combine(ModelsDirectory, modelFileName);
+                var tempPath = destPath + ".downloading";
+
+                _logger.LogInformation("Downloading model {Model} from {Url}", modelFileName, url);
+
+                using var response = await _httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                response.EnsureSuccessStatusCode();
+
+                var totalBytes = response.Content.Headers.ContentLength ?? -1;
+
+                await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+                await using var fileStream = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None, 81920);
+
+                var buffer = new byte[81920];
+                long downloaded = 0;
+                int bytesRead;
+
+                while ((bytesRead = await stream.ReadAsync(buffer, cancellationToken)) > 0)
+                {
+                    await fileStream.WriteAsync(buffer.AsMemory(0, bytesRead), cancellationToken);
+                    downloaded += bytesRead;
+
+                    if (totalBytes > 0)
+                    {
+                        var pct = (double)downloaded / totalBytes * 100;
+                        var dlMB = downloaded / (1024.0 * 1024.0);
+                        var totMB = totalBytes / (1024.0 * 1024.0);
+                        lock (_lock)
+                        {
+                            _progress = pct;
+                            _progressMessage = $"Downloading {modelFileName}: {dlMB:F1} / {totMB:F1} MB ({pct:F1}%)";
+                        }
+                    }
+                }
+
+                // Close the file stream before moving
+                await fileStream.FlushAsync(cancellationToken);
+                fileStream.Close();
+
+                if (File.Exists(destPath)) File.Delete(destPath);
+                File.Move(tempPath, destPath);
+
+                // Auto-apply to plugin config
+                var config = Plugin.Instance.Configuration;
+                config.WhisperModelPath = destPath;
+                Plugin.Instance.SaveConfiguration();
+
+                lock (_lock)
+                {
+                    _progress = 100;
+                    _progressMessage = $"Model {modelFileName} downloaded and configured.";
+                }
+
+                _logger.LogInformation("Model downloaded to {Path} and config updated", destPath);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                lock (_lock)
+                {
+                    _error = ex.Message;
+                    _progressMessage = $"Error downloading model: {ex.Message}";
+                }
+                _logger.LogError(ex, "Error downloading model {Model}", modelFileName);
+                throw;
+            }
+            finally
+            {
+                lock (_lock) { _isRunning = false; }
+            }
+        }
+
+        /// <summary>
+        /// Detects which GPU backends are likely available on the host.
+        /// </summary>
+        public static GpuInfo DetectGpu()
+        {
+            var info = new GpuInfo();
+
+            // NVIDIA: check for /dev/nvidia0 or nvidia-smi
+            if (File.Exists("/dev/nvidia0") || File.Exists("/dev/nvidiactl"))
+            {
+                info.HasNvidia = true;
+            }
+            else
+            {
+                try
+                {
+                    var p = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+                    {
+                        FileName = "nvidia-smi", RedirectStandardOutput = true,
+                        RedirectStandardError = true, UseShellExecute = false, CreateNoWindow = true
+                    });
+                    if (p != null) { p.WaitForExit(3000); info.HasNvidia = p.ExitCode == 0; }
+                }
+                catch { /* not available */ }
+            }
+
+            // AMD ROCm: check for /dev/kfd (ROCm kernel driver)
+            if (File.Exists("/dev/kfd"))
+            {
+                info.HasAmdGpu = true;
+            }
+            else
+            {
+                try
+                {
+                    var p = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+                    {
+                        FileName = "rocm-smi", RedirectStandardOutput = true,
+                        RedirectStandardError = true, UseShellExecute = false, CreateNoWindow = true
+                    });
+                    if (p != null) { p.WaitForExit(3000); info.HasAmdGpu = p.ExitCode == 0; }
+                }
+                catch { /* not available */ }
+            }
+
+            // Intel / Vulkan: check for /dev/dri/renderD128
+            if (File.Exists("/dev/dri/renderD128"))
+            {
+                info.HasRenderDevice = true;
+            }
+
+            // Recommend variant based on detection
+            if (info.HasNvidia) info.RecommendedVariant = "cuda12";
+            else if (info.HasAmdGpu) info.RecommendedVariant = "rocm";
+            else if (info.HasRenderDevice) info.RecommendedVariant = "vulkan";
+            else info.RecommendedVariant = "cpu";
+
+            return info;
+        }
+
+        /// <summary>
+        /// Downloads the whisper-cli binary from the whisper-subs GitHub release
+        /// matching the current plugin version.
+        /// </summary>
+        /// <param name="variant">Binary variant: "cpu", "cuda12", or "vulkan".</param>
+        public async Task DownloadBinaryAsync(string variant, CancellationToken cancellationToken)
+        {
+            lock (_lock)
+            {
+                if (_isRunning) throw new InvalidOperationException("A download is already in progress.");
+                _isRunning = true;
+                _error = null;
+                _currentOperation = "binary";
+                _progress = 0;
+                _progressMessage = $"Starting whisper-cli ({variant}) download...";
+            }
+
+            try
+            {
+                Directory.CreateDirectory(WhisperDirectory);
+
+                var platform = GetPlatformIdentifier();
+                var version = typeof(Plugin).Assembly.GetName().Version?.ToString(3) ?? "3.2.0";
+                var assetName = BinaryCatalog.GetAssetName(platform, variant);
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) assetName += ".exe";
+
+                var url = $"https://github.com/GeiserX/whisper-subs/releases/download/v{version}/{assetName}";
+
+                _logger.LogInformation("Downloading whisper-cli from {Url} for platform {Platform}", url, platform);
+
+                using var response = await _httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                response.EnsureSuccessStatusCode();
+
+                var totalBytes = response.Content.Headers.ContentLength ?? -1;
+                var tempPath = BinaryPath + ".downloading";
+
+                await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+                await using var fileStream = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None, 81920);
+
+                var buffer = new byte[81920];
+                long downloaded = 0;
+                int bytesRead;
+
+                while ((bytesRead = await stream.ReadAsync(buffer, cancellationToken)) > 0)
+                {
+                    await fileStream.WriteAsync(buffer.AsMemory(0, bytesRead), cancellationToken);
+                    downloaded += bytesRead;
+
+                    if (totalBytes > 0)
+                    {
+                        var pct = (double)downloaded / totalBytes * 100;
+                        var dlMB = downloaded / (1024.0 * 1024.0);
+                        var totMB = totalBytes / (1024.0 * 1024.0);
+                        lock (_lock)
+                        {
+                            _progress = pct;
+                            _progressMessage = $"Downloading whisper-cli: {dlMB:F1} / {totMB:F1} MB ({pct:F1}%)";
+                        }
+                    }
+                }
+
+                await fileStream.FlushAsync(cancellationToken);
+                fileStream.Close();
+
+                if (File.Exists(BinaryPath)) File.Delete(BinaryPath);
+                File.Move(tempPath, BinaryPath);
+
+                // Make executable on Unix
+                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    using var chmod = System.Diagnostics.Process.Start("chmod", new[] { "+x", BinaryPath });
+                    chmod?.WaitForExit(5000);
+                }
+
+                // Auto-apply to plugin config
+                var config = Plugin.Instance.Configuration;
+                config.WhisperBinaryPath = BinaryPath;
+                Plugin.Instance.SaveConfiguration();
+
+                lock (_lock)
+                {
+                    _progress = 100;
+                    _progressMessage = "whisper-cli downloaded and configured.";
+                }
+
+                _logger.LogInformation("Binary downloaded to {Path} and config updated", BinaryPath);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                lock (_lock)
+                {
+                    _error = ex.Message;
+                    _progressMessage = $"Error downloading binary: {ex.Message}";
+                }
+                _logger.LogError(ex, "Error downloading whisper-cli binary");
+                throw;
+            }
+            finally
+            {
+                lock (_lock) { _isRunning = false; }
+            }
+        }
+
+        private static bool IsWhisperInPath()
+        {
+            foreach (var name in new[] { "whisper-cli", "main", "whisper" })
+            {
+                try
+                {
+                    var p = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+                    {
+                        FileName = name,
+                        Arguments = "--help",
+                        RedirectStandardOutput = true,
+                        RedirectStandardError = true,
+                        UseShellExecute = false,
+                        CreateNoWindow = true
+                    });
+                    if (p != null)
+                    {
+                        p.WaitForExit(1000);
+                        if (p.ExitCode is 0 or 1) return true;
+                    }
+                }
+                catch { /* not found */ }
+            }
+            return false;
+        }
+    }
+
+    public class SetupStatus
+    {
+        public bool BinaryFound { get; set; }
+        public string? BinaryPath { get; set; }
+        public bool ModelFound { get; set; }
+        public string? ModelPath { get; set; }
+        public string Platform { get; set; } = "";
+        public bool SetupComplete { get; set; }
+        public GpuInfo Gpu { get; set; } = new();
+    }
+
+    public class GpuInfo
+    {
+        public bool HasNvidia { get; set; }
+        public bool HasAmdGpu { get; set; }
+        public bool HasRenderDevice { get; set; }
+        public string RecommendedVariant { get; set; } = "cpu";
+    }
+
+    public class DownloadProgress
+    {
+        public string Operation { get; set; } = "";
+        public double Percent { get; set; }
+        public string Message { get; set; } = "";
+        public bool IsRunning { get; set; }
+        public string? Error { get; set; }
+    }
+}

--- a/Setup/WhisperSetupService.cs
+++ b/Setup/WhisperSetupService.cs
@@ -221,7 +221,7 @@ namespace WhisperSubs.Setup
                 lock (_lock)
                 {
                     _progress = 100;
-                    _progressMessage = $"Model {modelFileName} downloaded and verified.";
+                    _progressMessage = $"Model {modelFileName} downloaded successfully.";
                 }
 
                 _logger.LogInformation("Model downloaded to {Path} and config updated", destPath);
@@ -378,7 +378,7 @@ namespace WhisperSubs.Setup
                 lock (_lock)
                 {
                     _progress = 100;
-                    _progressMessage = "whisper-cli downloaded and verified.";
+                    _progressMessage = "whisper-cli downloaded successfully.";
                 }
 
                 _logger.LogInformation("Binary downloaded to {Path} and config updated", BinaryPath);

--- a/Setup/WhisperSetupService.cs
+++ b/Setup/WhisperSetupService.cs
@@ -1,7 +1,9 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -11,8 +13,10 @@ namespace WhisperSubs.Setup
     public class WhisperSetupService
     {
         private readonly ILogger _logger;
-        private readonly HttpClient _httpClient;
         private readonly string _dataPath;
+
+        // Shared HttpClient — reused across all requests to avoid socket exhaustion.
+        private static readonly HttpClient SharedHttpClient = CreateHttpClient();
 
         // Static progress tracking — polled by the API endpoint.
         private static string _currentOperation = "";
@@ -21,6 +25,13 @@ namespace WhisperSubs.Setup
         private static bool _isRunning;
         private static string? _error;
         private static readonly object _lock = new();
+
+        private static HttpClient CreateHttpClient()
+        {
+            var client = new HttpClient();
+            client.DefaultRequestHeaders.UserAgent.ParseAdd("WhisperSubs-Jellyfin-Plugin");
+            return client;
+        }
 
         public static DownloadProgress CurrentProgress
         {
@@ -40,12 +51,28 @@ namespace WhisperSubs.Setup
             }
         }
 
+        /// <summary>
+        /// Atomically acquires the download lock. Returns false if a download is already running.
+        /// Must be called (and succeed) before invoking DownloadModelAsync / DownloadBinaryAsync.
+        /// </summary>
+        public static bool TryAcquire(string operation, string initialMessage)
+        {
+            lock (_lock)
+            {
+                if (_isRunning) return false;
+                _isRunning = true;
+                _error = null;
+                _currentOperation = operation;
+                _progress = 0;
+                _progressMessage = initialMessage;
+                return true;
+            }
+        }
+
         public WhisperSetupService(ILogger logger, string dataPath)
         {
             _logger = logger;
             _dataPath = dataPath;
-            _httpClient = new HttpClient();
-            _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("WhisperSubs-Jellyfin-Plugin");
         }
 
         public string WhisperDirectory => Path.Combine(_dataPath, "whisper");
@@ -74,11 +101,13 @@ namespace WhisperSubs.Setup
             var configBinaryValid = !string.IsNullOrEmpty(config.WhisperBinaryPath)
                                     && File.Exists(config.WhisperBinaryPath);
 
-            // Check for any model in the auto-download directory
+            // Check for any model in the auto-download directory (largest first for determinism)
             string? autoModelPath = null;
             if (Directory.Exists(ModelsDirectory))
             {
-                var bins = Directory.GetFiles(ModelsDirectory, "*.bin");
+                var bins = Directory.GetFiles(ModelsDirectory, "*.bin")
+                    .OrderByDescending(f => new FileInfo(f).Length)
+                    .ToArray();
                 if (bins.Length > 0) autoModelPath = bins[0];
             }
 
@@ -94,6 +123,7 @@ namespace WhisperSubs.Setup
             return new SetupStatus
             {
                 BinaryFound = binaryOk,
+                BinaryFoundInPath = inPath && !autoBinaryExists && !configBinaryValid,
                 BinaryPath = configBinaryValid ? config.WhisperBinaryPath
                            : autoBinaryExists ? BinaryPath
                            : inPath ? "whisper-cli (PATH)"
@@ -110,18 +140,11 @@ namespace WhisperSubs.Setup
         /// Downloads a whisper model from HuggingFace and saves it to the models directory.
         /// After download, automatically updates the plugin configuration.
         /// </summary>
+        /// <summary>
+        /// Downloads a whisper model. Caller must call TryAcquire("model", ...) first.
+        /// </summary>
         public async Task DownloadModelAsync(string modelFileName, CancellationToken cancellationToken)
         {
-            lock (_lock)
-            {
-                if (_isRunning) throw new InvalidOperationException("A download is already in progress.");
-                _isRunning = true;
-                _error = null;
-                _currentOperation = "model";
-                _progress = 0;
-                _progressMessage = $"Starting download of {modelFileName}...";
-            }
-
             try
             {
                 Directory.CreateDirectory(ModelsDirectory);
@@ -132,7 +155,7 @@ namespace WhisperSubs.Setup
 
                 _logger.LogInformation("Downloading model {Model} from {Url}", modelFileName, url);
 
-                using var response = await _httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                using var response = await SharedHttpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                 response.EnsureSuccessStatusCode();
 
                 var totalBytes = response.Content.Headers.ContentLength ?? -1;
@@ -169,6 +192,27 @@ namespace WhisperSubs.Setup
                 if (File.Exists(destPath)) File.Delete(destPath);
                 File.Move(tempPath, destPath);
 
+                // Verify downloaded file size against catalog
+                var catalogEntry = ModelCatalog.Models.FirstOrDefault(m =>
+                    string.Equals(m.FileName, modelFileName, StringComparison.OrdinalIgnoreCase));
+                if (catalogEntry != null)
+                {
+                    var actualSizeMB = new FileInfo(destPath).Length / (1024.0 * 1024.0);
+                    if (actualSizeMB < catalogEntry.SizeMB * 0.9)
+                    {
+                        File.Delete(destPath);
+                        throw new InvalidOperationException(
+                            $"Downloaded file is {actualSizeMB:F0} MB but expected ~{catalogEntry.SizeMB} MB. " +
+                            "The file may be corrupted or truncated.");
+                    }
+                    _logger.LogInformation("Model size verified: {Actual:F1} MB (expected ~{Expected} MB)",
+                        actualSizeMB, catalogEntry.SizeMB);
+                }
+
+                // Compute and log SHA256 for audit
+                var sha256 = ComputeSha256(destPath);
+                _logger.LogInformation("Model {Model} SHA256: {Hash}", modelFileName, sha256);
+
                 // Auto-apply to plugin config
                 var config = Plugin.Instance.Configuration;
                 config.WhisperModelPath = destPath;
@@ -177,7 +221,7 @@ namespace WhisperSubs.Setup
                 lock (_lock)
                 {
                     _progress = 100;
-                    _progressMessage = $"Model {modelFileName} downloaded and configured.";
+                    _progressMessage = $"Model {modelFileName} downloaded and verified.";
                 }
 
                 _logger.LogInformation("Model downloaded to {Path} and config updated", destPath);
@@ -260,27 +304,17 @@ namespace WhisperSubs.Setup
 
         /// <summary>
         /// Downloads the whisper-cli binary from the whisper-subs GitHub release
-        /// matching the current plugin version.
+        /// matching the current plugin version. Caller must call TryAcquire("binary", ...) first.
         /// </summary>
-        /// <param name="variant">Binary variant: "cpu", "cuda12", or "vulkan".</param>
+        /// <param name="variant">Binary variant: "cpu", "cuda12", "vulkan", or "rocm".</param>
         public async Task DownloadBinaryAsync(string variant, CancellationToken cancellationToken)
         {
-            lock (_lock)
-            {
-                if (_isRunning) throw new InvalidOperationException("A download is already in progress.");
-                _isRunning = true;
-                _error = null;
-                _currentOperation = "binary";
-                _progress = 0;
-                _progressMessage = $"Starting whisper-cli ({variant}) download...";
-            }
-
             try
             {
                 Directory.CreateDirectory(WhisperDirectory);
 
                 var platform = GetPlatformIdentifier();
-                var version = typeof(Plugin).Assembly.GetName().Version?.ToString(3) ?? "3.2.0";
+                var version = typeof(Plugin).Assembly.GetName().Version?.ToString() ?? "3.3.0.0";
                 var assetName = BinaryCatalog.GetAssetName(platform, variant);
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) assetName += ".exe";
 
@@ -288,7 +322,7 @@ namespace WhisperSubs.Setup
 
                 _logger.LogInformation("Downloading whisper-cli from {Url} for platform {Platform}", url, platform);
 
-                using var response = await _httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                using var response = await SharedHttpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                 response.EnsureSuccessStatusCode();
 
                 var totalBytes = response.Content.Headers.ContentLength ?? -1;
@@ -332,6 +366,10 @@ namespace WhisperSubs.Setup
                     chmod?.WaitForExit(5000);
                 }
 
+                // Compute and log SHA256 for audit
+                var sha256 = ComputeSha256(BinaryPath);
+                _logger.LogInformation("Binary {Variant} SHA256: {Hash}", variant, sha256);
+
                 // Auto-apply to plugin config
                 var config = Plugin.Instance.Configuration;
                 config.WhisperBinaryPath = BinaryPath;
@@ -340,7 +378,7 @@ namespace WhisperSubs.Setup
                 lock (_lock)
                 {
                     _progress = 100;
-                    _progressMessage = "whisper-cli downloaded and configured.";
+                    _progressMessage = "whisper-cli downloaded and verified.";
                 }
 
                 _logger.LogInformation("Binary downloaded to {Path} and config updated", BinaryPath);
@@ -359,6 +397,14 @@ namespace WhisperSubs.Setup
             {
                 lock (_lock) { _isRunning = false; }
             }
+        }
+
+        private static string ComputeSha256(string filePath)
+        {
+            using var sha = SHA256.Create();
+            using var stream = File.OpenRead(filePath);
+            var hash = sha.ComputeHash(stream);
+            return BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
         }
 
         private static bool IsWhisperInPath()
@@ -391,6 +437,7 @@ namespace WhisperSubs.Setup
     public class SetupStatus
     {
         public bool BinaryFound { get; set; }
+        public bool BinaryFoundInPath { get; set; }
         public string? BinaryPath { get; set; }
         public bool ModelFound { get; set; }
         public string? ModelPath { get; set; }

--- a/Setup/WhisperSetupService.cs
+++ b/Setup/WhisperSetupService.cs
@@ -189,6 +189,14 @@ namespace WhisperSubs.Setup
                 await fileStream.FlushAsync(cancellationToken);
                 fileStream.Close();
 
+                // Reject truncated downloads
+                if (totalBytes > 0 && downloaded != totalBytes)
+                {
+                    if (File.Exists(tempPath)) File.Delete(tempPath);
+                    throw new InvalidOperationException(
+                        $"Download incomplete: received {downloaded} of {totalBytes} bytes.");
+                }
+
                 if (File.Exists(destPath)) File.Delete(destPath);
                 File.Move(tempPath, destPath);
 
@@ -355,6 +363,14 @@ namespace WhisperSubs.Setup
 
                 await fileStream.FlushAsync(cancellationToken);
                 fileStream.Close();
+
+                // Reject truncated downloads
+                if (totalBytes > 0 && downloaded != totalBytes)
+                {
+                    if (File.Exists(tempPath)) File.Delete(tempPath);
+                    throw new InvalidOperationException(
+                        $"Download incomplete: received {downloaded} of {totalBytes} bytes.");
+                }
 
                 if (File.Exists(BinaryPath)) File.Delete(BinaryPath);
                 File.Move(tempPath, BinaryPath);

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -9,6 +9,55 @@
             <div class="content-primary">
                 <h1>WhisperSubs</h1>
 
+                <!-- Setup Wizard Banner -->
+                <div id="setupBanner" style="display:none; background:rgba(82,181,75,0.08); border:1px solid rgba(82,181,75,0.3); border-radius:8px; padding:1.5em; margin-bottom:2em;">
+                    <h2 style="margin-top:0;">Initial Setup</h2>
+                    <p style="margin-bottom:1em;">WhisperSubs needs the <strong>whisper-cli</strong> binary and a language model. Click <em>Quick Setup</em> to download both automatically, or set them up individually.</p>
+
+                    <div id="setupStep1" style="margin-bottom:1em; padding:0.8em; background:rgba(0,0,0,0.15); border-radius:6px;">
+                        <span id="binaryStatusIcon" style="font-size:1.2em;">&#9744;</span>
+                        <strong>whisper-cli binary</strong>
+                        <span id="binaryStatusText" style="opacity:0.8; margin-left:0.5em;"></span>
+                        <br/>
+                        <div style="display:flex; gap:0.5em; align-items:flex-end; flex-wrap:wrap; margin-top:0.5em;">
+                            <select is="emby-select" id="selectBinaryVariant" style="flex:1; min-width:220px; margin:0;">
+                                <option value="cpu">CPU Only</option>
+                            </select>
+                            <button is="emby-button" id="btnDownloadBinary" class="raised">
+                                <span>Download Binary</span>
+                            </button>
+                        </div>
+                        <div id="gpuDetectionHint" style="margin-top:0.4em; font-size:0.85em; opacity:0.7;"></div>
+                    </div>
+
+                    <div id="setupStep2" style="margin-bottom:1em; padding:0.8em; background:rgba(0,0,0,0.15); border-radius:6px;">
+                        <span id="modelStatusIcon" style="font-size:1.2em;">&#9744;</span>
+                        <strong>Language Model</strong>
+                        <span id="modelStatusText" style="opacity:0.8; margin-left:0.5em;"></span>
+                        <br/>
+                        <div style="display:flex; gap:0.5em; align-items:flex-end; flex-wrap:wrap; margin-top:0.5em;">
+                            <select is="emby-select" id="selectDownloadModel" style="flex:1; min-width:250px; margin:0;">
+                            </select>
+                            <button is="emby-button" id="btnDownloadModel" class="raised">
+                                <span>Download Model</span>
+                            </button>
+                        </div>
+                    </div>
+
+                    <div style="margin-bottom:1em;">
+                        <button is="emby-button" id="btnQuickSetup" class="raised button-submit" style="padding:0.6em 2em;">
+                            <span>Quick Setup (Download Both)</span>
+                        </button>
+                    </div>
+
+                    <div id="setupProgressContainer" style="display:none; margin-top:1em;">
+                        <div style="background:rgba(0,0,0,0.3); border-radius:4px; overflow:hidden; height:24px;">
+                            <div id="setupProgressBar" style="background:#52B54B; height:100%; width:0%; transition:width 0.3s ease;"></div>
+                        </div>
+                        <div id="setupProgressText" style="margin-top:0.5em; opacity:0.8; font-size:0.9em;"></div>
+                    </div>
+                </div>
+
                 <form class="whisperSubsConfigurationForm">
                     <div class="selectContainer">
                         <label class="selectLabel" for="selectProvider">Subtitle Provider</label>
@@ -185,6 +234,247 @@
                 currentStartIndex: 0,
                 currentTotalCount: 0,
                 currentLibraryId: '',
+                _progressPollTimer: null,
+                _quickSetupPhase: null,
+
+                // ── Setup wizard ─────────────────────────────────────────
+
+                checkSetupStatus: function () {
+                    WhisperSubsConfig.ajaxGet(ApiClient.getUrl('Plugins/WhisperSubs/Setup/Status'))
+                        .then(function (s) {
+                            var banner = document.querySelector('#setupBanner');
+                            // Always populate dropdowns
+                            WhisperSubsConfig.loadDownloadableModels();
+                            WhisperSubsConfig.loadBinaryVariants(s.Gpu);
+
+                            if (s.SetupComplete) {
+                                banner.style.display = 'none';
+                                return;
+                            }
+                            banner.style.display = '';
+
+                            var binIcon = document.querySelector('#binaryStatusIcon');
+                            var binText = document.querySelector('#binaryStatusText');
+                            var binBtn = document.querySelector('#btnDownloadBinary');
+                            var binSel = document.querySelector('#selectBinaryVariant');
+                            if (s.BinaryFound) {
+                                binIcon.innerHTML = '&#9745;';
+                                binIcon.style.color = '#52B54B';
+                                binText.textContent = s.BinaryPath || 'found';
+                                binBtn.style.display = 'none';
+                                binSel.style.display = 'none';
+                            } else {
+                                binIcon.innerHTML = '&#9744;';
+                                binIcon.style.color = '#CC7B19';
+                                binText.textContent = 'Not found (' + s.Platform + ')';
+                                binBtn.style.display = '';
+                                binSel.style.display = '';
+                            }
+
+                            // GPU detection hint
+                            var hint = document.querySelector('#gpuDetectionHint');
+                            if (s.Gpu) {
+                                if (s.Gpu.HasNvidia) {
+                                    hint.textContent = 'NVIDIA GPU detected — CUDA 12 variant recommended for fastest transcription.';
+                                    hint.style.color = '#52B54B';
+                                } else if (s.Gpu.HasAmdGpu) {
+                                    hint.textContent = 'AMD GPU detected — ROCm variant recommended for GPU-accelerated transcription.';
+                                    hint.style.color = '#52B54B';
+                                } else if (s.Gpu.HasRenderDevice) {
+                                    hint.textContent = 'GPU render device detected — Vulkan variant recommended.';
+                                    hint.style.color = '#52B54B';
+                                } else {
+                                    hint.textContent = 'No GPU detected. CPU variant selected (works on any system).';
+                                    hint.style.color = '';
+                                }
+                            }
+
+                            var modIcon = document.querySelector('#modelStatusIcon');
+                            var modText = document.querySelector('#modelStatusText');
+                            var modBtn = document.querySelector('#btnDownloadModel');
+                            var modSel = document.querySelector('#selectDownloadModel');
+                            if (s.ModelFound) {
+                                modIcon.innerHTML = '&#9745;';
+                                modIcon.style.color = '#52B54B';
+                                modText.textContent = s.ModelPath ? s.ModelPath.split('/').pop() : 'found';
+                                modBtn.style.display = 'none';
+                                modSel.style.display = 'none';
+                            } else {
+                                modIcon.innerHTML = '&#9744;';
+                                modIcon.style.color = '#CC7B19';
+                                modText.textContent = 'Not found';
+                                modBtn.style.display = '';
+                                modSel.style.display = '';
+                            }
+
+                            // Hide quick-setup if both already done
+                            var qsBtn = document.querySelector('#btnQuickSetup');
+                            if (s.BinaryFound && s.ModelFound) {
+                                qsBtn.style.display = 'none';
+                            } else if (s.BinaryFound || s.ModelFound) {
+                                qsBtn.innerHTML = s.BinaryFound
+                                    ? '<span>Download Model</span>'
+                                    : '<span>Download Binary</span>';
+                            }
+                        })
+                        .catch(function (err) {
+                            console.error('WhisperSubs: setup status check failed', err);
+                        });
+                },
+
+                loadBinaryVariants: function (gpuInfo) {
+                    WhisperSubsConfig.ajaxGet(ApiClient.getUrl('Plugins/WhisperSubs/Setup/BinaryVariants'))
+                        .then(function (variants) {
+                            var select = document.querySelector('#selectBinaryVariant');
+                            select.innerHTML = '';
+                            if (!variants || !Array.isArray(variants)) return;
+                            variants.forEach(function (v) {
+                                var opt = document.createElement('option');
+                                opt.value = v.Id;
+                                opt.textContent = v.DisplayName;
+                                select.appendChild(opt);
+                            });
+                            // Auto-select recommended variant based on GPU detection
+                            if (gpuInfo && gpuInfo.RecommendedVariant) {
+                                select.value = gpuInfo.RecommendedVariant;
+                            }
+                        })
+                        .catch(function (err) {
+                            console.error('WhisperSubs: error loading binary variants', err);
+                        });
+                },
+
+                loadDownloadableModels: function () {
+                    WhisperSubsConfig.ajaxGet(ApiClient.getUrl('Plugins/WhisperSubs/Setup/AvailableModels'))
+                        .then(function (models) {
+                            var select = document.querySelector('#selectDownloadModel');
+                            select.innerHTML = '';
+                            if (!models || !Array.isArray(models)) return;
+                            models.forEach(function (m) {
+                                var opt = document.createElement('option');
+                                opt.value = m.FileName;
+                                var sizeLabel = m.SizeMB >= 1024
+                                    ? (m.SizeMB / 1024).toFixed(1) + ' GB'
+                                    : m.SizeMB + ' MB';
+                                opt.textContent = m.DisplayName + ' (' + sizeLabel + ')';
+                                if (m.IsRecommended) opt.textContent += ' \u2605';
+                                select.appendChild(opt);
+                            });
+                            // Pre-select recommended
+                            var rec = models.find(function (m) { return m.IsRecommended; });
+                            if (rec) select.value = rec.FileName;
+                        })
+                        .catch(function (err) {
+                            console.error('WhisperSubs: error loading downloadable models', err);
+                        });
+                },
+
+                startBinaryDownload: function () {
+                    var variant = document.querySelector('#selectBinaryVariant').value || 'cpu';
+                    var btn = document.querySelector('#btnDownloadBinary');
+                    btn.disabled = true;
+                    btn.innerHTML = '<span>Downloading...</span>';
+                    ApiClient.ajax({ type: 'POST', url: ApiClient.getUrl('Plugins/WhisperSubs/Setup/DownloadBinary', { variant: variant }) })
+                        .then(function () { WhisperSubsConfig.startProgressPolling(); })
+                        .catch(function (err) {
+                            btn.disabled = false;
+                            btn.innerHTML = '<span>Download Binary</span>';
+                            Dashboard.alert('Download failed: ' + (err.message || err));
+                        });
+                },
+
+                startModelDownload: function () {
+                    var modelName = document.querySelector('#selectDownloadModel').value;
+                    if (!modelName) { Dashboard.alert('Select a model first.'); return; }
+                    var btn = document.querySelector('#btnDownloadModel');
+                    btn.disabled = true;
+                    btn.innerHTML = '<span>Downloading...</span>';
+                    ApiClient.ajax({ type: 'POST', url: ApiClient.getUrl('Plugins/WhisperSubs/Setup/DownloadModel', { name: modelName }) })
+                        .then(function () { WhisperSubsConfig.startProgressPolling(); })
+                        .catch(function (err) {
+                            btn.disabled = false;
+                            btn.innerHTML = '<span>Download Model</span>';
+                            Dashboard.alert('Download failed: ' + (err.message || err));
+                        });
+                },
+
+                quickSetup: function () {
+                    var btn = document.querySelector('#btnQuickSetup');
+                    btn.disabled = true;
+                    btn.innerHTML = '<span>Setting up...</span>';
+                    // Check what's needed, then chain downloads
+                    WhisperSubsConfig.ajaxGet(ApiClient.getUrl('Plugins/WhisperSubs/Setup/Status'))
+                        .then(function (s) {
+                            if (!s.BinaryFound) {
+                                WhisperSubsConfig._quickSetupPhase = s.ModelFound ? 'binary-only' : 'binary-then-model';
+                                WhisperSubsConfig.startBinaryDownload();
+                            } else if (!s.ModelFound) {
+                                WhisperSubsConfig._quickSetupPhase = 'model-only';
+                                WhisperSubsConfig.startModelDownload();
+                            }
+                        })
+                        .catch(function (err) {
+                            btn.disabled = false;
+                            btn.innerHTML = '<span>Quick Setup (Download Both)</span>';
+                            Dashboard.alert('Setup failed: ' + (err.message || err));
+                        });
+                },
+
+                startProgressPolling: function () {
+                    var bar = document.querySelector('#setupProgressBar');
+                    var text = document.querySelector('#setupProgressText');
+                    var container = document.querySelector('#setupProgressContainer');
+                    container.style.display = '';
+
+                    if (WhisperSubsConfig._progressPollTimer) {
+                        clearInterval(WhisperSubsConfig._progressPollTimer);
+                    }
+
+                    WhisperSubsConfig._progressPollTimer = setInterval(function () {
+                        WhisperSubsConfig.ajaxGet(ApiClient.getUrl('Plugins/WhisperSubs/Setup/Progress'))
+                            .then(function (p) {
+                                bar.style.width = Math.min(p.Percent, 100) + '%';
+                                text.textContent = p.Message || '';
+
+                                if (p.Error) {
+                                    text.style.color = '#CC7B19';
+                                    WhisperSubsConfig.stopProgressPolling();
+                                    WhisperSubsConfig.checkSetupStatus();
+                                    return;
+                                }
+
+                                if (!p.IsRunning && p.Percent >= 100) {
+                                    WhisperSubsConfig.stopProgressPolling();
+                                    // If quick-setup, chain the next download
+                                    if (WhisperSubsConfig._quickSetupPhase === 'binary-then-model') {
+                                        WhisperSubsConfig._quickSetupPhase = 'model-only';
+                                        bar.style.width = '0%';
+                                        text.textContent = 'Binary done. Starting model download...';
+                                        setTimeout(function () {
+                                            WhisperSubsConfig.startModelDownload();
+                                        }, 500);
+                                        return;
+                                    }
+                                    WhisperSubsConfig._quickSetupPhase = null;
+                                    // Refresh everything — paths are auto-applied by the backend
+                                    setTimeout(function () {
+                                        WhisperSubsConfig.checkSetupStatus();
+                                        // Reload the main config form to reflect new paths
+                                        var page = document.querySelector('[data-role="page"]');
+                                        WhisperSubsConfig.loadConfiguration(page);
+                                    }, 500);
+                                }
+                            })
+                            .catch(function () { /* ignore transient fetch errors */ });
+                    }, 1000);
+                },
+
+                stopProgressPolling: function () {
+                    if (WhisperSubsConfig._progressPollTimer) {
+                        clearInterval(WhisperSubsConfig._progressPollTimer);
+                        WhisperSubsConfig._progressPollTimer = null;
+                    }
+                },
 
                 languageOptions: [
                     { value: 'auto', label: 'Auto-detect' },
@@ -494,6 +784,19 @@
 
             document.querySelector('[data-role="page"]').addEventListener('pageshow', function () {
                 WhisperSubsConfig.loadConfiguration(this);
+                WhisperSubsConfig.checkSetupStatus();
+            });
+
+            document.querySelector('#btnDownloadBinary').addEventListener('click', function () {
+                WhisperSubsConfig.startBinaryDownload();
+            });
+
+            document.querySelector('#btnDownloadModel').addEventListener('click', function () {
+                WhisperSubsConfig.startModelDownload();
+            });
+
+            document.querySelector('#btnQuickSetup').addEventListener('click', function () {
+                WhisperSubsConfig.quickSetup();
             });
 
             document.querySelector('.whisperSubsConfigurationForm').addEventListener('submit', function (e) {

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -410,6 +410,10 @@
                         .catch(function (err) {
                             btn.disabled = false;
                             btn.innerHTML = '<span>Download Binary</span>';
+                            if (WhisperSubsConfig._quickSetupPhase) {
+                                WhisperSubsConfig._quickSetupPhase = null;
+                                WhisperSubsConfig.resetDownloadButtons();
+                            }
                             Dashboard.alert('Download failed: ' + (err.message || err));
                         });
                 },
@@ -425,6 +429,10 @@
                         .catch(function (err) {
                             btn.disabled = false;
                             btn.innerHTML = '<span>Download Model</span>';
+                            if (WhisperSubsConfig._quickSetupPhase) {
+                                WhisperSubsConfig._quickSetupPhase = null;
+                                WhisperSubsConfig.resetDownloadButtons();
+                            }
                             Dashboard.alert('Download failed: ' + (err.message || err));
                         });
                 },
@@ -490,12 +498,17 @@
                                     }
                                     WhisperSubsConfig._quickSetupPhase = null;
                                     WhisperSubsConfig.resetDownloadButtons();
-                                    // Refresh everything — paths are auto-applied by the backend
+                                    // Refresh setup status and updated config paths (not full loadConfiguration to avoid duplicate loadLibraries)
                                     setTimeout(function () {
                                         WhisperSubsConfig.checkSetupStatus();
-                                        // Reload the main config form to reflect new paths
-                                        var page = document.querySelector('[data-role="page"]');
-                                        WhisperSubsConfig.loadConfiguration(page);
+                                        WhisperSubsConfig.loadModels();
+                                        ApiClient.getPluginConfiguration(WhisperSubsConfig.pluginId).then(function (config) {
+                                            if (config) {
+                                                var page = document.querySelector('[data-role="page"]');
+                                                page.querySelector('#txtWhisperBinaryPath').value = config.WhisperBinaryPath || '';
+                                                page.querySelector('#txtWhisperModelPath').value = config.WhisperModelPath || '';
+                                            }
+                                        });
                                     }, 500);
                                 }
                             })

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -257,17 +257,27 @@
                             var binText = document.querySelector('#binaryStatusText');
                             var binBtn = document.querySelector('#btnDownloadBinary');
                             var binSel = document.querySelector('#selectBinaryVariant');
-                            if (s.BinaryFound) {
+                            if (s.BinaryFound && !s.BinaryFoundInPath) {
                                 binIcon.innerHTML = '&#9745;';
                                 binIcon.style.color = '#52B54B';
                                 binText.textContent = s.BinaryPath || 'found';
                                 binBtn.style.display = 'none';
                                 binSel.style.display = 'none';
+                            } else if (s.BinaryFoundInPath) {
+                                binIcon.innerHTML = '&#9745;';
+                                binIcon.style.color = '#CC7B19';
+                                binText.textContent = 'Found in PATH (CPU). Download a GPU-accelerated variant below:';
+                                binBtn.style.display = '';
+                                binBtn.disabled = false;
+                                binBtn.innerHTML = '<span>Download Binary</span>';
+                                binSel.style.display = '';
                             } else {
                                 binIcon.innerHTML = '&#9744;';
                                 binIcon.style.color = '#CC7B19';
                                 binText.textContent = 'Not found (' + s.Platform + ')';
                                 binBtn.style.display = '';
+                                binBtn.disabled = false;
+                                binBtn.innerHTML = '<span>Download Binary</span>';
                                 binSel.style.display = '';
                             }
 
@@ -304,17 +314,24 @@
                                 modIcon.style.color = '#CC7B19';
                                 modText.textContent = 'Not found';
                                 modBtn.style.display = '';
+                                modBtn.disabled = false;
+                                modBtn.innerHTML = '<span>Download Model</span>';
                                 modSel.style.display = '';
                             }
 
-                            // Hide quick-setup if both already done
+                            // Hide quick-setup if both already done; always reset disabled state
                             var qsBtn = document.querySelector('#btnQuickSetup');
+                            qsBtn.disabled = false;
                             if (s.BinaryFound && s.ModelFound) {
                                 qsBtn.style.display = 'none';
                             } else if (s.BinaryFound || s.ModelFound) {
+                                qsBtn.style.display = '';
                                 qsBtn.innerHTML = s.BinaryFound
                                     ? '<span>Download Model</span>'
                                     : '<span>Download Binary</span>';
+                            } else {
+                                qsBtn.style.display = '';
+                                qsBtn.innerHTML = '<span>Quick Setup (Download Both)</span>';
                             }
                         })
                         .catch(function (err) {
@@ -326,8 +343,22 @@
                     WhisperSubsConfig.ajaxGet(ApiClient.getUrl('Plugins/WhisperSubs/Setup/BinaryVariants'))
                         .then(function (variants) {
                             var select = document.querySelector('#selectBinaryVariant');
+                            var btn = document.querySelector('#btnDownloadBinary');
                             select.innerHTML = '';
-                            if (!variants || !Array.isArray(variants)) return;
+                            if (!variants || !Array.isArray(variants) || variants.length === 0) {
+                                var opt = document.createElement('option');
+                                opt.value = '';
+                                opt.textContent = 'No prebuilt binaries for this platform';
+                                select.appendChild(opt);
+                                select.disabled = true;
+                                btn.disabled = true;
+                                btn.title = 'Prebuilt binaries are only available for Linux. Install whisper-cli manually.';
+                                var hint = document.querySelector('#gpuDetectionHint');
+                                hint.textContent = 'Auto-download is only available for Linux. Please install whisper-cli manually and set the path below.';
+                                hint.style.color = '#CC7B19';
+                                return;
+                            }
+                            select.disabled = false;
                             variants.forEach(function (v) {
                                 var opt = document.createElement('option');
                                 opt.value = v.Id;
@@ -439,6 +470,8 @@
                                 if (p.Error) {
                                     text.style.color = '#CC7B19';
                                     WhisperSubsConfig.stopProgressPolling();
+                                    WhisperSubsConfig._quickSetupPhase = null;
+                                    WhisperSubsConfig.resetDownloadButtons();
                                     WhisperSubsConfig.checkSetupStatus();
                                     return;
                                 }
@@ -456,6 +489,7 @@
                                         return;
                                     }
                                     WhisperSubsConfig._quickSetupPhase = null;
+                                    WhisperSubsConfig.resetDownloadButtons();
                                     // Refresh everything — paths are auto-applied by the backend
                                     setTimeout(function () {
                                         WhisperSubsConfig.checkSetupStatus();
@@ -474,6 +508,15 @@
                         clearInterval(WhisperSubsConfig._progressPollTimer);
                         WhisperSubsConfig._progressPollTimer = null;
                     }
+                },
+
+                resetDownloadButtons: function () {
+                    var binBtn = document.querySelector('#btnDownloadBinary');
+                    var modBtn = document.querySelector('#btnDownloadModel');
+                    var qsBtn = document.querySelector('#btnQuickSetup');
+                    if (binBtn) { binBtn.disabled = false; binBtn.innerHTML = '<span>Download Binary</span>'; }
+                    if (modBtn) { modBtn.disabled = false; modBtn.innerHTML = '<span>Download Model</span>'; }
+                    if (qsBtn) { qsBtn.disabled = false; qsBtn.innerHTML = '<span>Quick Setup (Download Both)</span>'; }
                 },
 
                 languageOptions: [

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.2.0.0</Version>
+    <Version>3.3.0.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
## Summary

- Adds a **setup wizard** to the plugin config page that detects platform and GPU, then downloads the appropriate `whisper-cli` binary and language model with one click
- **GPU auto-detection**: identifies NVIDIA (CUDA), AMD (ROCm), Intel/AMD (Vulkan), or CPU-only and pre-selects the recommended variant
- **Model catalog**: offers 7 models from HuggingFace (tiny → large-v3-turbo) with the recommended `ggml-large-v3-turbo-q5_0.bin` (574 MB) pre-selected
- **Auto-apply**: after download, binary and model paths are automatically written to the plugin configuration — no manual path entry needed
- **CI builds whisper.cpp v1.8.4** static binaries for 5 targets: linux-x64 (CPU, CUDA 12, Vulkan, ROCm) and linux-arm64 (CPU), attached as GitHub release assets
- Progress bar with real-time polling during downloads
- "Quick Setup" button chains binary + model downloads sequentially

### New files
- `Setup/WhisperSetupService.cs` — download service with progress tracking, platform detection, GPU probing
- `Setup/ModelCatalog.cs` — HuggingFace model catalog (7 models)
- `Setup/BinaryCatalog.cs` — binary variant catalog (CPU, CUDA 12, Vulkan, ROCm)

### Modified files
- `Api/SubtitleController.cs` — 5 new endpoints: `Setup/Status`, `Setup/AvailableModels`, `Setup/BinaryVariants`, `Setup/DownloadModel`, `Setup/DownloadBinary`, `Setup/Progress`
- `Web/configPage.html` — setup wizard banner with variant selector, model picker, progress bar, GPU detection hints
- `.github/workflows/build-release.yml` — multi-platform whisper.cpp build matrix
- `WhisperSubs.csproj` — version bump to 3.3.0.0

## Test plan
- [ ] Install plugin fresh → setup banner appears with binary/model status
- [ ] GPU detection correctly identifies NVIDIA / AMD / Intel / none
- [ ] "Quick Setup" downloads binary + model sequentially with progress
- [ ] After download, config page reflects auto-applied paths
- [ ] Clicking Save works with auto-downloaded paths
- [ ] Subtitle generation works end-to-end with auto-downloaded binary + model
- [ ] CI workflow builds all 5 binary variants without errors
- [ ] Existing manual installs (binary in PATH) still work — setup banner hidden

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Initial setup wizard with status, progress bar, and quick-setup to download binary and model
  * GPU auto-detection and recommended binary variant
  * In-app options to list/select/download models and binary variants (CPU, CUDA, Vulkan, ROCm)
  * Background download progress reporting and endpoints to start/poll setup operations

* **Releases**
  * Release artifacts now include prebuilt platform binaries alongside the plugin package

* **Chores**
  * CI workflow added; package version bumped to 3.3.0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->