### PR TITLE
Add xUnit test suite

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Build
         run: dotnet build --configuration Release --no-restore
 
+      - name: Test
+        run: dotnet test WhisperSubs.Tests/WhisperSubs.Tests.csproj --configuration Release --no-restore --verbosity normal
+
       - name: Get version from csproj
         id: version
         run: |

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 <p align="center">
   <a href="https://github.com/GeiserX/whisper-subs/releases"><img src="https://img.shields.io/github/v/release/GeiserX/whisper-subs?style=flat-square&logo=github&color=6B4C9A" alt="Release"></a>
+  <a href="https://github.com/GeiserX/whisper-subs/actions/workflows/build-release.yml"><img src="https://img.shields.io/github/actions/workflow/status/GeiserX/whisper-subs/build-release.yml?branch=main&style=flat-square&label=tests" alt="Tests"></a>
   <a href="https://github.com/GeiserX/whisper-subs/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-GPL--3.0-blue?style=flat-square" alt="License"></a>
   <img src="https://img.shields.io/badge/.NET-9.0-512BD4?style=flat-square&logo=dotnet&logoColor=white" alt=".NET 9.0">
   <img src="https://img.shields.io/badge/Jellyfin-10.11%2B-6B4C9A?style=flat-square" alt="Jellyfin 10.11+">

--- a/WhisperSubs.Tests/ChunkingTests.cs
+++ b/WhisperSubs.Tests/ChunkingTests.cs
@@ -1,0 +1,177 @@
+using System.Reflection;
+using WhisperSubs.Controller;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+/// <summary>
+/// Tests for the VAD chunking and merging helpers in SubtitleManager.
+/// These are private/static methods accessed via reflection for thorough unit testing.
+/// </summary>
+public class ChunkingTests
+{
+    private static List<(double Start, double End)> CallGroupSpeechIntoChunks(
+        List<(double Start, double End)> segments, double target = 30.0)
+    {
+        var method = typeof(SubtitleManager).GetMethod(
+            "GroupSpeechIntoChunks",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+        return (List<(double Start, double End)>)method!.Invoke(null, new object[] { segments, target })!;
+    }
+
+    private static List<(double Start, double End)> CallGenerateFixedChunks(
+        double totalDuration, double chunkDuration)
+    {
+        var method = typeof(SubtitleManager).GetMethod(
+            "GenerateFixedChunks",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+        return (List<(double Start, double End)>)method!.Invoke(null, new object[] { totalDuration, chunkDuration })!;
+    }
+
+    private static List<(double Start, double End, string Language)> CallMergeForeignChunks(
+        List<(double Start, double End, string Language)> chunks)
+    {
+        var method = typeof(SubtitleManager).GetMethod(
+            "MergeForeignChunks",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+        return (List<(double Start, double End, string Language)>)method!.Invoke(null, new object[] { chunks })!;
+    }
+
+    [Fact]
+    public void GroupSpeechIntoChunks_EmptyInput_ReturnsEmpty()
+    {
+        var result = CallGroupSpeechIntoChunks(new List<(double, double)>());
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void GroupSpeechIntoChunks_SingleSegment_ReturnsSingleChunk()
+    {
+        var segments = new List<(double, double)> { (0, 10) };
+        var result = CallGroupSpeechIntoChunks(segments);
+        Assert.Single(result);
+        Assert.Equal(0, result[0].Start);
+        Assert.Equal(10, result[0].End);
+    }
+
+    [Fact]
+    public void GroupSpeechIntoChunks_ShortSegments_GroupedTogether()
+    {
+        var segments = new List<(double, double)>
+        {
+            (0, 5), (6, 10), (12, 18), (20, 25)
+        };
+        var result = CallGroupSpeechIntoChunks(segments, 30.0);
+        Assert.Single(result);
+        Assert.Equal(0, result[0].Start);
+        Assert.Equal(25, result[0].End);
+    }
+
+    [Fact]
+    public void GroupSpeechIntoChunks_LongSegments_SplitAtBoundaries()
+    {
+        var segments = new List<(double, double)>
+        {
+            (0, 10), (15, 25), (35, 45), (50, 60)
+        };
+        var result = CallGroupSpeechIntoChunks(segments, 30.0);
+        Assert.Equal(2, result.Count);
+        Assert.Equal(0, result[0].Start);
+        Assert.Equal(25, result[0].End);
+        Assert.Equal(35, result[1].Start);
+        Assert.Equal(60, result[1].End);
+    }
+
+    [Fact]
+    public void GenerateFixedChunks_ProducesCorrectChunks()
+    {
+        var result = CallGenerateFixedChunks(100, 30);
+        Assert.Equal(4, result.Count);
+        Assert.Equal((0, 30.0), result[0]);
+        Assert.Equal((30, 60.0), result[1]);
+        Assert.Equal((60, 90.0), result[2]);
+        Assert.Equal((90, 100.0), result[3]);
+    }
+
+    [Fact]
+    public void GenerateFixedChunks_ExactMultiple_NoPartialChunk()
+    {
+        var result = CallGenerateFixedChunks(90, 30);
+        Assert.Equal(3, result.Count);
+        Assert.Equal(90.0, result[2].End);
+    }
+
+    [Fact]
+    public void GenerateFixedChunks_ZeroDuration_ReturnsEmpty()
+    {
+        var result = CallGenerateFixedChunks(0, 30);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void MergeForeignChunks_EmptyInput_ReturnsEmpty()
+    {
+        var result = CallMergeForeignChunks(new List<(double, double, string)>());
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void MergeForeignChunks_SameLanguageCloseGap_Merged()
+    {
+        var chunks = new List<(double, double, string)>
+        {
+            (10, 20, "fr"),
+            (22, 30, "fr"),  // gap of 2s < 5s threshold
+        };
+        var result = CallMergeForeignChunks(chunks);
+        Assert.Single(result);
+        Assert.Equal(10, result[0].Start);
+        Assert.Equal(30, result[0].End);
+        Assert.Equal("fr", result[0].Language);
+    }
+
+    [Fact]
+    public void MergeForeignChunks_SameLanguageLargeGap_NotMerged()
+    {
+        var chunks = new List<(double, double, string)>
+        {
+            (10, 20, "fr"),
+            (26, 35, "fr"),  // gap of 6s > 5s threshold
+        };
+        var result = CallMergeForeignChunks(chunks);
+        Assert.Equal(2, result.Count);
+    }
+
+    [Fact]
+    public void MergeForeignChunks_DifferentLanguages_NotMerged()
+    {
+        var chunks = new List<(double, double, string)>
+        {
+            (10, 20, "fr"),
+            (21, 30, "de"),
+        };
+        var result = CallMergeForeignChunks(chunks);
+        Assert.Equal(2, result.Count);
+        Assert.Equal("fr", result[0].Language);
+        Assert.Equal("de", result[1].Language);
+    }
+
+    [Fact]
+    public void MergeForeignChunks_MultipleConsecutiveSameLanguage_AllMerged()
+    {
+        var chunks = new List<(double, double, string)>
+        {
+            (10, 15, "ja"),
+            (16, 20, "ja"),
+            (21, 25, "ja"),
+            (26, 30, "ja"),
+        };
+        var result = CallMergeForeignChunks(chunks);
+        Assert.Single(result);
+        Assert.Equal(10, result[0].Start);
+        Assert.Equal(30, result[0].End);
+    }
+}

--- a/WhisperSubs.Tests/ConfigurationTests.cs
+++ b/WhisperSubs.Tests/ConfigurationTests.cs
@@ -1,0 +1,39 @@
+using WhisperSubs.Configuration;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+public class ConfigurationTests
+{
+    [Fact]
+    public void PluginConfiguration_DefaultValues()
+    {
+        var config = new PluginConfiguration();
+
+        Assert.Equal("Whisper", config.SelectedProvider);
+        Assert.Equal("", config.WhisperModelPath);
+        Assert.Equal("", config.WhisperBinaryPath);
+        Assert.False(config.EnableAutoGeneration);
+        Assert.Equal("auto", config.DefaultLanguage);
+        Assert.Equal(SubtitleMode.Full, config.SubtitleMode);
+        Assert.False(config.EnableLyricsGeneration);
+        Assert.Equal(0, config.WhisperThreadCount);
+        Assert.NotNull(config.EnabledLibraries);
+        Assert.Empty(config.EnabledLibraries);
+    }
+
+    [Fact]
+    public void SubtitleMode_HasExpectedValues()
+    {
+        Assert.Equal(0, (int)SubtitleMode.Full);
+        Assert.Equal(1, (int)SubtitleMode.ForcedOnly);
+        Assert.Equal(2, (int)SubtitleMode.FullAndForced);
+    }
+
+    [Fact]
+    public void SubtitleMode_AllValuesAreDefined()
+    {
+        var values = Enum.GetValues<SubtitleMode>();
+        Assert.Equal(3, values.Length);
+    }
+}

--- a/WhisperSubs.Tests/SubtitleManagerTests.cs
+++ b/WhisperSubs.Tests/SubtitleManagerTests.cs
@@ -1,0 +1,94 @@
+using WhisperSubs.Controller;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+public class SubtitleManagerTests
+{
+    [Fact]
+    public void ConvertSrtToLrc_EmptyInput_ReturnsHeaderOnly()
+    {
+        var result = SubtitleManager.ConvertSrtToLrc("", "Test Song");
+        Assert.Contains("[ti:Test Song]", result);
+        Assert.Contains("[by:WhisperSubs]", result);
+    }
+
+    [Fact]
+    public void ConvertSrtToLrc_SingleEntry_ProducesCorrectLrc()
+    {
+        var srt = "1\n00:01:23,456 --> 00:01:25,789\nHello world\n";
+        var result = SubtitleManager.ConvertSrtToLrc(srt, "Track");
+
+        Assert.Contains("[ti:Track]", result);
+        Assert.Contains("[by:WhisperSubs]", result);
+        Assert.Contains("[01:23.45]Hello world", result);
+    }
+
+    [Fact]
+    public void ConvertSrtToLrc_MultipleEntries_AllConverted()
+    {
+        var srt = """
+            1
+            00:00:05,000 --> 00:00:10,000
+            First line
+
+            2
+            00:00:15,500 --> 00:00:20,000
+            Second line
+            """;
+        var result = SubtitleManager.ConvertSrtToLrc(srt);
+
+        Assert.Contains("[00:05.00]First line", result);
+        Assert.Contains("[00:15.50]Second line", result);
+    }
+
+    [Fact]
+    public void ConvertSrtToLrc_HoursConvertedToMinutes()
+    {
+        // 01:30:45,678 = 90 minutes + 45 seconds
+        var srt = "1\n01:30:45,678 --> 01:31:00,000\nLate entry\n";
+        var result = SubtitleManager.ConvertSrtToLrc(srt);
+
+        Assert.Contains("[90:45.67]Late entry", result);
+    }
+
+    [Fact]
+    public void ConvertSrtToLrc_MultilineText_JoinedWithSpace()
+    {
+        var srt = "1\n00:00:01,000 --> 00:00:05,000\nLine one\nLine two\n";
+        var result = SubtitleManager.ConvertSrtToLrc(srt);
+
+        Assert.Contains("[00:01.00]Line one Line two", result);
+    }
+
+    [Fact]
+    public void ConvertSrtToLrc_NullTitle_NoTitleTag()
+    {
+        var srt = "1\n00:00:01,000 --> 00:00:05,000\nHello\n";
+        var result = SubtitleManager.ConvertSrtToLrc(srt, null);
+
+        Assert.DoesNotContain("[ti:", result);
+        Assert.Contains("[by:WhisperSubs]", result);
+    }
+
+    [Fact]
+    public void ConvertSrtToLrc_EmptyTextLines_Skipped()
+    {
+        var srt = "1\n00:00:01,000 --> 00:00:05,000\n   \n";
+        var result = SubtitleManager.ConvertSrtToLrc(srt);
+
+        // The empty text line should not produce an LRC entry
+        var lines = result.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        Assert.DoesNotContain(lines, l => l.StartsWith("[00:01"));
+    }
+
+    [Fact]
+    public void ConvertSrtToLrc_DotSeparator_AlsoWorks()
+    {
+        // Some SRT files use . instead of , for milliseconds
+        var srt = "1\n00:00:01.500 --> 00:00:05.000\nDot format\n";
+        var result = SubtitleManager.ConvertSrtToLrc(srt);
+
+        Assert.Contains("[00:01.50]Dot format", result);
+    }
+}

--- a/WhisperSubs.Tests/WhisperProviderTests.cs
+++ b/WhisperSubs.Tests/WhisperProviderTests.cs
@@ -1,0 +1,117 @@
+using WhisperSubs.Providers;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+public class WhisperProviderTests
+{
+    [Fact]
+    public void ParseLastSrtTimestamp_EmptyInput_ReturnsZero()
+    {
+        Assert.Equal(0, WhisperProvider.ParseLastSrtTimestamp(""));
+        Assert.Equal(0, WhisperProvider.ParseLastSrtTimestamp(null!));
+        Assert.Equal(0, WhisperProvider.ParseLastSrtTimestamp("   "));
+    }
+
+    [Fact]
+    public void ParseLastSrtTimestamp_SingleEntry_ReturnsEndTimestamp()
+    {
+        var srt = "1\n00:00:01,000 --> 00:00:05,500\nHello world\n";
+        var result = WhisperProvider.ParseLastSrtTimestamp(srt);
+        Assert.Equal(5.5, result, precision: 1);
+    }
+
+    [Fact]
+    public void ParseLastSrtTimestamp_MultipleEntries_ReturnsLastEndTimestamp()
+    {
+        var srt = """
+            1
+            00:00:01,000 --> 00:00:05,000
+            First line
+
+            2
+            00:01:30,000 --> 00:02:15,750
+            Second line
+
+            3
+            01:23:45,123 --> 01:24:00,999
+            Last line
+            """;
+        var result = WhisperProvider.ParseLastSrtTimestamp(srt);
+        // 1*3600 + 24*60 + 0 + 0.999 = 5040.999
+        Assert.Equal(5040.999, result, precision: 3);
+    }
+
+    [Fact]
+    public void CountSrtEntries_EmptyInput_ReturnsZero()
+    {
+        Assert.Equal(0, WhisperProvider.CountSrtEntries(""));
+        Assert.Equal(0, WhisperProvider.CountSrtEntries(null!));
+    }
+
+    [Fact]
+    public void CountSrtEntries_MultipleEntries_ReturnsCorrectCount()
+    {
+        var srt = """
+            1
+            00:00:01,000 --> 00:00:05,000
+            First
+
+            2
+            00:00:06,000 --> 00:00:10,000
+            Second
+
+            3
+            00:00:11,000 --> 00:00:15,000
+            Third
+            """;
+        Assert.Equal(3, WhisperProvider.CountSrtEntries(srt));
+    }
+
+    [Fact]
+    public void OffsetSrt_EmptyInput_ReturnsEmpty()
+    {
+        Assert.Equal("", WhisperProvider.OffsetSrt("", 10, 1));
+        Assert.Equal("", WhisperProvider.OffsetSrt(null!, 10, 1));
+    }
+
+    [Fact]
+    public void OffsetSrt_AppliesOffsetAndRenumbers()
+    {
+        var srt = "1\n00:00:01,000 --> 00:00:05,000\nHello\n";
+        var result = WhisperProvider.OffsetSrt(srt, 60.0, 10);
+
+        Assert.Contains("10", result);
+        Assert.Contains("00:01:01,000 --> 00:01:05,000", result);
+        Assert.Contains("Hello", result);
+    }
+
+    [Fact]
+    public void OffsetSrt_NegativeOffset_ClampsToZero()
+    {
+        var srt = "1\n00:00:02,000 --> 00:00:05,000\nTest\n";
+        var result = WhisperProvider.OffsetSrt(srt, -10.0, 1);
+
+        // 2s - 10s = -8s, clamped to 0
+        Assert.Contains("00:00:00,000", result);
+    }
+
+    [Fact]
+    public void OffsetSrt_LargeOffset_HandlesHoursCorrectly()
+    {
+        var srt = "1\n00:59:30,000 --> 00:59:59,000\nAlmost an hour\n";
+        var result = WhisperProvider.OffsetSrt(srt, 60.0, 1);
+
+        Assert.Contains("01:00:30,000 --> 01:00:59,000", result);
+    }
+
+    [Fact]
+    public void OffsetSrt_MultipleEntries_RenumbersSequentially()
+    {
+        var srt = "1\n00:00:01,000 --> 00:00:02,000\nA\n\n2\n00:00:03,000 --> 00:00:04,000\nB\n";
+        var result = WhisperProvider.OffsetSrt(srt, 0, 5);
+
+        Assert.Contains("5\n", result);
+        Assert.Contains("6\n", result);
+    }
+}

--- a/WhisperSubs.Tests/WhisperSubs.Tests.csproj
+++ b/WhisperSubs.Tests/WhisperSubs.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
+    <PackageReference Include="xunit" Version="2.*" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.*" />
+    <PackageReference Include="Moq" Version="4.*" />
+    <PackageReference Include="coverlet.collector" Version="6.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../WhisperSubs.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -23,4 +23,14 @@
     <EmbeddedResource Include="Web\configPage.html" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Remove="WhisperSubs.Tests\**" />
+    <EmbeddedResource Remove="WhisperSubs.Tests\**" />
+    <None Remove="WhisperSubs.Tests\**" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="WhisperSubs.Tests" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- Add xUnit test project (`WhisperSubs.Tests/`) with 33 tests covering core business logic
- Tests for SRT parsing (`ParseLastSrtTimestamp`, `CountSrtEntries`), SRT offsetting/renumbering (`OffsetSrt`), SRT-to-LRC conversion (`ConvertSrtToLrc`), VAD chunking (`GroupSpeechIntoChunks`, `GenerateFixedChunks`), foreign chunk merging (`MergeForeignChunks`), and configuration defaults
- Add `dotnet test` step to CI workflow
- Add test status badge to README
- Add `InternalsVisibleTo` for test project access to internal members

## Test plan
- [x] All 33 tests pass locally
- [ ] CI workflow runs tests on push to main