### PR TITLE
fix: Windows process launch — trust configured path, set WorkingDirectory, flush pipes

### DIFF
--- a/Controller/SubtitleManager.cs
+++ b/Controller/SubtitleManager.cs
@@ -509,19 +509,22 @@ namespace WhisperSubs.Controller
             }
 
             // silencedetect: noise threshold -30dB, minimum silence duration 0.5s
-            var arguments = $"-i \"{audioPath}\" -af silencedetect=noise=-30dB:d=0.5 -f null -";
-            var process = new Process
+            var startInfo = new ProcessStartInfo
             {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = ffmpegPath,
-                    Arguments = arguments,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                }
+                FileName = ffmpegPath,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
             };
+            startInfo.ArgumentList.Add("-i");
+            startInfo.ArgumentList.Add(audioPath);
+            startInfo.ArgumentList.Add("-af");
+            startInfo.ArgumentList.Add("silencedetect=noise=-30dB:d=0.5");
+            startInfo.ArgumentList.Add("-f");
+            startInfo.ArgumentList.Add("null");
+            startInfo.ArgumentList.Add("-");
+            var process = new Process { StartInfo = startInfo };
 
             var errorBuilder = new StringBuilder();
             process.ErrorDataReceived += (_, e) => { if (e.Data != null) errorBuilder.AppendLine(e.Data); };
@@ -684,21 +687,30 @@ namespace WhisperSubs.Controller
             var ffmpegPath = FindFfmpegExecutable();
             if (ffmpegPath == null) throw new InvalidOperationException("FFmpeg not found");
 
-            var arguments = $"-ss {startSeconds:F3} -t {durationSeconds:F3} -i \"{sourceAudioPath}\" " +
-                            $"-acodec pcm_s16le -ac 1 -ar 16000 -y \"{outputPath}\"";
-
-            var process = new Process
+            var startInfo = new ProcessStartInfo
             {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = ffmpegPath,
-                    Arguments = arguments,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                }
+                FileName = ffmpegPath,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
             };
+            startInfo.ArgumentList.Add("-ss");
+            startInfo.ArgumentList.Add(startSeconds.ToString("F3"));
+            startInfo.ArgumentList.Add("-t");
+            startInfo.ArgumentList.Add(durationSeconds.ToString("F3"));
+            startInfo.ArgumentList.Add("-i");
+            startInfo.ArgumentList.Add(sourceAudioPath);
+            startInfo.ArgumentList.Add("-acodec");
+            startInfo.ArgumentList.Add("pcm_s16le");
+            startInfo.ArgumentList.Add("-ac");
+            startInfo.ArgumentList.Add("1");
+            startInfo.ArgumentList.Add("-ar");
+            startInfo.ArgumentList.Add("16000");
+            startInfo.ArgumentList.Add("-y");
+            startInfo.ArgumentList.Add(outputPath);
+
+            var process = new Process { StartInfo = startInfo };
 
             process.Start();
             process.BeginErrorReadLine();
@@ -751,19 +763,24 @@ namespace WhisperSubs.Controller
                 return new List<string>();
             }
 
-            var arguments = $"-v quiet -print_format json -show_streams -select_streams a \"{mediaPath}\"";
-            var process = new Process
+            var probeInfo = new ProcessStartInfo
             {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = ffprobePath,
-                    Arguments = arguments,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                }
+                FileName = ffprobePath,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
             };
+            probeInfo.ArgumentList.Add("-v");
+            probeInfo.ArgumentList.Add("quiet");
+            probeInfo.ArgumentList.Add("-print_format");
+            probeInfo.ArgumentList.Add("json");
+            probeInfo.ArgumentList.Add("-show_streams");
+            probeInfo.ArgumentList.Add("-select_streams");
+            probeInfo.ArgumentList.Add("a");
+            probeInfo.ArgumentList.Add(mediaPath);
+
+            var process = new Process { StartInfo = probeInfo };
 
             var outputBuilder = new StringBuilder();
             process.OutputDataReceived += (_, e) => { if (e.Data != null) outputBuilder.AppendLine(e.Data); };
@@ -816,19 +833,24 @@ namespace WhisperSubs.Controller
             var ffprobePath = FindFfprobeExecutable();
             if (ffprobePath == null) return -1;
 
-            var arguments = $"-v quiet -print_format json -show_streams -select_streams a \"{mediaPath}\"";
-            var process = new Process
+            var probeInfo = new ProcessStartInfo
             {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = ffprobePath,
-                    Arguments = arguments,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                }
+                FileName = ffprobePath,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
             };
+            probeInfo.ArgumentList.Add("-v");
+            probeInfo.ArgumentList.Add("quiet");
+            probeInfo.ArgumentList.Add("-print_format");
+            probeInfo.ArgumentList.Add("json");
+            probeInfo.ArgumentList.Add("-show_streams");
+            probeInfo.ArgumentList.Add("-select_streams");
+            probeInfo.ArgumentList.Add("a");
+            probeInfo.ArgumentList.Add(mediaPath);
+
+            var process = new Process { StartInfo = probeInfo };
 
             var outputBuilder = new StringBuilder();
             process.OutputDataReceived += (_, e) => { if (e.Data != null) outputBuilder.AppendLine(e.Data); };
@@ -875,32 +897,49 @@ namespace WhisperSubs.Controller
                     "FFmpeg not found. Ensure ffmpeg is installed and available in PATH or at /usr/lib/jellyfin-ffmpeg/ffmpeg");
             }
 
-            var ssArg = startOffsetSeconds > 0 ? $"-ss {startOffsetSeconds:F1} " : "";
-            var mapArg = "";
+            var extractInfo = new ProcessStartInfo
+            {
+                FileName = ffmpegPath,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            if (startOffsetSeconds > 0)
+            {
+                extractInfo.ArgumentList.Add("-ss");
+                extractInfo.ArgumentList.Add(startOffsetSeconds.ToString("F1"));
+            }
+
+            extractInfo.ArgumentList.Add("-i");
+            extractInfo.ArgumentList.Add(videoPath);
+
             if (!string.IsNullOrEmpty(targetLanguage) && !string.Equals(targetLanguage, "auto", StringComparison.OrdinalIgnoreCase))
             {
                 var streamIndex = await FindAudioStreamIndexAsync(videoPath, targetLanguage, cancellationToken);
                 if (streamIndex >= 0)
                 {
-                    mapArg = $"-map 0:a:{streamIndex} ";
+                    extractInfo.ArgumentList.Add("-map");
+                    extractInfo.ArgumentList.Add($"0:a:{streamIndex}");
                     _logger.LogInformation("Selected audio stream {Index} for language {Language}", streamIndex, targetLanguage);
                 }
             }
-            var arguments = $"{ssArg}-i \"{videoPath}\" {mapArg}-vn -acodec pcm_s16le -ac 1 -ar 16000 -y \"{outputAudioPath}\"";
-            _logger.LogInformation("Running FFmpeg: {Path} {Arguments}", ffmpegPath, arguments);
 
-            var process = new Process
-            {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = ffmpegPath,
-                    Arguments = arguments,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                }
-            };
+            extractInfo.ArgumentList.Add("-vn");
+            extractInfo.ArgumentList.Add("-acodec");
+            extractInfo.ArgumentList.Add("pcm_s16le");
+            extractInfo.ArgumentList.Add("-ac");
+            extractInfo.ArgumentList.Add("1");
+            extractInfo.ArgumentList.Add("-ar");
+            extractInfo.ArgumentList.Add("16000");
+            extractInfo.ArgumentList.Add("-y");
+            extractInfo.ArgumentList.Add(outputAudioPath);
+
+            _logger.LogInformation("Running FFmpeg: {Path} {Arguments}", ffmpegPath,
+                string.Join(" ", extractInfo.ArgumentList));
+
+            var process = new Process { StartInfo = extractInfo };
 
             var errorBuilder = new StringBuilder();
             process.ErrorDataReceived += (_, e) =>
@@ -935,19 +974,22 @@ namespace WhisperSubs.Controller
             var ffprobePath = FindFfprobeExecutable();
             if (ffprobePath == null) return 0;
 
-            var arguments = $"-v quiet -print_format json -show_format \"{mediaPath}\"";
-            var process = new Process
+            var durationInfo = new ProcessStartInfo
             {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = ffprobePath,
-                    Arguments = arguments,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                }
+                FileName = ffprobePath,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
             };
+            durationInfo.ArgumentList.Add("-v");
+            durationInfo.ArgumentList.Add("quiet");
+            durationInfo.ArgumentList.Add("-print_format");
+            durationInfo.ArgumentList.Add("json");
+            durationInfo.ArgumentList.Add("-show_format");
+            durationInfo.ArgumentList.Add(mediaPath);
+
+            var process = new Process { StartInfo = durationInfo };
 
             var outputBuilder = new StringBuilder();
             process.OutputDataReceived += (_, e) => { if (e.Data != null) outputBuilder.AppendLine(e.Data); };
@@ -1003,9 +1045,19 @@ namespace WhisperSubs.Controller
         {
             foreach (var candidate in candidates)
             {
+                // For absolute paths, trust File.Exists without probing
+                if (Path.IsPathRooted(candidate))
+                {
+                    if (File.Exists(candidate))
+                    {
+                        return candidate;
+                    }
+                    continue;
+                }
+
                 try
                 {
-                    var process = new Process
+                    using var process = new Process
                     {
                         StartInfo = new ProcessStartInfo
                         {
@@ -1019,7 +1071,12 @@ namespace WhisperSubs.Controller
                     };
 
                     process.Start();
-                    process.WaitForExit(1000);
+
+                    if (!process.WaitForExit(5000))
+                    {
+                        try { process.Kill(); } catch { }
+                        continue;
+                    }
 
                     if (process.ExitCode == 0)
                     {

--- a/Providers/WhisperProvider.cs
+++ b/Providers/WhisperProvider.cs
@@ -16,6 +16,7 @@ namespace WhisperSubs.Providers
         private readonly string _modelPath;
         private readonly string _binaryPath;
         private readonly int _threadCount;
+        private string? _resolvedExecutable;
 
         public string Name => "Whisper";
 
@@ -61,7 +62,8 @@ namespace WhisperSubs.Providers
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
                     UseShellExecute = false,
-                    CreateNoWindow = true
+                    CreateNoWindow = true,
+                    WorkingDirectory = Path.GetDirectoryName(whisperExecutable) ?? ""
                 };
 
                 startInfo.ArgumentList.Add("-m");
@@ -87,8 +89,8 @@ namespace WhisperSubs.Providers
                     startInfo.ArgumentList.Add(langPrompt);
                 }
 
-                _logger.LogInformation("Running: {Executable} {Arguments}", whisperExecutable,
-                    string.Join(" ", startInfo.ArgumentList));
+                _logger.LogInformation("Running: {Executable} {Arguments} (cwd: {WorkingDirectory})",
+                    whisperExecutable, string.Join(" ", startInfo.ArgumentList), startInfo.WorkingDirectory);
 
                 using var process = new Process { StartInfo = startInfo };
 
@@ -136,6 +138,9 @@ namespace WhisperSubs.Providers
 
                     throw;
                 }
+
+                // Flush async stdout/stderr pipe buffers so errorBuilder is complete
+                process.WaitForExit();
 
                 if (process.ExitCode != 0)
                 {
@@ -196,7 +201,8 @@ namespace WhisperSubs.Providers
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
                 UseShellExecute = false,
-                CreateNoWindow = true
+                CreateNoWindow = true,
+                WorkingDirectory = Path.GetDirectoryName(whisperExecutable) ?? ""
             };
 
             startInfo.ArgumentList.Add("-m");
@@ -243,6 +249,9 @@ namespace WhisperSubs.Providers
                 try { process.Kill(entireProcessTree: true); } catch { }
                 throw;
             }
+
+            // Flush async stdout/stderr pipe buffers
+            process.WaitForExit();
 
             var allOutput = outputBuilder.ToString() + "\n" + errorBuilder.ToString();
 
@@ -445,15 +454,38 @@ namespace WhisperSubs.Providers
 
         private string? FindWhisperExecutable()
         {
-            var candidates = !string.IsNullOrEmpty(_binaryPath)
-                ? new[] { _binaryPath, "whisper-cli", "main", "whisper" }
-                : new[] { "whisper-cli", "main", "whisper" };
+            if (_resolvedExecutable != null)
+            {
+                return _resolvedExecutable;
+            }
+
+            // When a binary path is explicitly configured, trust it without probing.
+            // Probing with --help is unreliable: CUDA/Vulkan builds take several seconds
+            // to initialize GPU drivers, exceeding any reasonable timeout and causing
+            // the configured path to be silently skipped.
+            if (!string.IsNullOrEmpty(_binaryPath))
+            {
+                if (File.Exists(_binaryPath))
+                {
+                    _logger.LogInformation("Using configured Whisper executable: {Executable}", _binaryPath);
+                    _resolvedExecutable = _binaryPath;
+                    return _resolvedExecutable;
+                }
+
+                _logger.LogError("Configured Whisper binary not found at: {Path}", _binaryPath);
+                return null;
+            }
+
+            // No configured path — discover from PATH via probing.
+            // "main" is intentionally excluded: it is a common binary name on Windows
+            // (VS build tools, Git, etc.) and could resolve to the wrong executable.
+            var candidates = new[] { "whisper-cli", "whisper" };
 
             foreach (var candidate in candidates)
             {
                 try
                 {
-                    var process = new Process
+                    using var process = new Process
                     {
                         StartInfo = new ProcessStartInfo
                         {
@@ -467,15 +499,25 @@ namespace WhisperSubs.Providers
                     };
 
                     process.Start();
-                    process.WaitForExit(1000);
 
-                    if (process.ExitCode == 0 || process.ExitCode == 1)
+                    if (!process.WaitForExit(5000))
                     {
-                        _logger.LogInformation("Found Whisper executable: {Executable}", candidate);
-                        return candidate;
+                        _logger.LogDebug("Probe timed out for {Candidate}, skipping", candidate);
+                        try { process.Kill(); } catch { }
+                        continue;
+                    }
+
+                    if (process.ExitCode == 0)
+                    {
+                        _logger.LogInformation("Found Whisper executable in PATH: {Executable}", candidate);
+                        _resolvedExecutable = candidate;
+                        return _resolvedExecutable;
                     }
                 }
-                catch { }
+                catch (Exception ex)
+                {
+                    _logger.LogDebug("Probe failed for {Candidate}: {Error}", candidate, ex.Message);
+                }
             }
 
             return null;

--- a/Setup/WhisperSetupService.cs
+++ b/Setup/WhisperSetupService.cs
@@ -425,11 +425,12 @@ namespace WhisperSubs.Setup
 
         private static bool IsWhisperInPath()
         {
-            foreach (var name in new[] { "whisper-cli", "main", "whisper" })
+            // "main" excluded — too generic a name, risks matching wrong binaries on Windows
+            foreach (var name in new[] { "whisper-cli", "whisper" })
             {
                 try
                 {
-                    var p = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+                    using var p = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
                     {
                         FileName = name,
                         Arguments = "--help",
@@ -440,11 +441,15 @@ namespace WhisperSubs.Setup
                     });
                     if (p != null)
                     {
-                        p.WaitForExit(1000);
-                        if (p.ExitCode is 0 or 1) return true;
+                        if (!p.WaitForExit(5000))
+                        {
+                            try { p.Kill(); } catch { }
+                            continue;
+                        }
+                        if (p.ExitCode == 0) return true;
                     }
                 }
-                catch { /* not found */ }
+                catch { /* not found in PATH */ }
             }
             return false;
         }

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.5.0.0</Version>
+    <Version>3.6.0.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
Closes #11

## Summary

Comprehensive fix for Windows transcription failures (exit code 1) addressing 8 root causes:

| # | Severity | Fix |
|---|----------|-----|
| 1 | Critical | `FindWhisperExecutable` trusts configured path via `File.Exists` (no probe launch) |
| 2 | High | All 6 FFmpeg/FFprobe calls migrated from `Arguments` string to `ArgumentList` (injection prevention) |
| 3 | High | `WorkingDirectory` set to binary directory for CUDA/Vulkan DLL discovery |
| 4 | Medium | Added `process.WaitForExit()` after `WaitForExitAsync` for stderr pipe buffer flush |
| 5 | Medium | Kill and dispose orphaned probe processes after 5s timeout |
| 6 | Medium | Same fixes applied consistently in `SubtitleManager.FindExecutable` and `WhisperSetupService.IsWhisperInPath` |
| 7 | Medium | Removed `"main"` from PATH candidates (too generic, risks matching wrong binaries) |
| 8 | Low | Cache resolved executable path to avoid re-probing on every call |

## Files changed

- **`Providers/WhisperProvider.cs`** — Rewrote `FindWhisperExecutable()`, added WorkingDirectory + pipe flush to `TranscribeAsync` and `DetectLanguageAsync`
- **`Controller/SubtitleManager.cs`** — Migrated all FFmpeg calls to `ArgumentList`, rewrote `FindExecutable()` with same improvements
- **`Setup/WhisperSetupService.cs`** — Removed `"main"` candidate, added 5s timeout with kill, `using` for disposal
- **`WhisperSubs.csproj`** — Version bump to 3.6.0.0

## Test plan

- [ ] Windows: Verify transcription works with configured binary path (CUDA, Vulkan, CPU)
- [ ] Windows: Verify FFmpeg/FFprobe calls work with paths containing spaces
- [ ] Linux/macOS: Verify PATH-based discovery still works
- [ ] Verify probe processes don't leak when binary is missing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced external tool detection with improved timeout handling and recovery mechanisms
  * Added caching of executable paths to accelerate startup performance
  * Strengthened process execution reliability with better buffer management and error recovery
  * Refined troubleshooting capabilities through enhanced logging

* **Version**
  * Updated to version 3.6.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->