### PR TITLE
fix: process hygiene — drain pipes, kill on cancel, CI tests+Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 
@@ -20,3 +23,6 @@ jobs:
 
       - name: Build
         run: dotnet build --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test --configuration Release --no-build --verbosity normal

--- a/Controller/SubtitleManager.cs
+++ b/Controller/SubtitleManager.cs
@@ -524,7 +524,7 @@ namespace WhisperSubs.Controller
             startInfo.ArgumentList.Add("-f");
             startInfo.ArgumentList.Add("null");
             startInfo.ArgumentList.Add("-");
-            var process = new Process { StartInfo = startInfo };
+            using var process = new Process { StartInfo = startInfo };
 
             var errorBuilder = new StringBuilder();
             process.ErrorDataReceived += (_, e) => { if (e.Data != null) errorBuilder.AppendLine(e.Data); };
@@ -532,7 +532,19 @@ namespace WhisperSubs.Controller
             process.Start();
             process.BeginOutputReadLine();
             process.BeginErrorReadLine();
-            await process.WaitForExitAsync(cancellationToken);
+
+            try
+            {
+                await process.WaitForExitAsync(cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                try { process.Kill(entireProcessTree: true); } catch { }
+                throw;
+            }
+
+            // Flush async pipe buffers
+            process.WaitForExit();
 
             var output = errorBuilder.ToString();
 
@@ -710,11 +722,22 @@ namespace WhisperSubs.Controller
             startInfo.ArgumentList.Add("-y");
             startInfo.ArgumentList.Add(outputPath);
 
-            var process = new Process { StartInfo = startInfo };
+            using var process = new Process { StartInfo = startInfo };
 
             process.Start();
             process.BeginErrorReadLine();
-            await process.WaitForExitAsync(cancellationToken);
+
+            try
+            {
+                await process.WaitForExitAsync(cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                try { process.Kill(entireProcessTree: true); } catch { }
+                throw;
+            }
+
+            process.WaitForExit();
 
             if (process.ExitCode != 0 || !File.Exists(outputPath))
             {
@@ -780,14 +803,25 @@ namespace WhisperSubs.Controller
             probeInfo.ArgumentList.Add("a");
             probeInfo.ArgumentList.Add(mediaPath);
 
-            var process = new Process { StartInfo = probeInfo };
+            using var process = new Process { StartInfo = probeInfo };
 
             var outputBuilder = new StringBuilder();
             process.OutputDataReceived += (_, e) => { if (e.Data != null) outputBuilder.AppendLine(e.Data); };
 
             process.Start();
             process.BeginOutputReadLine();
-            await process.WaitForExitAsync(cancellationToken);
+
+            try
+            {
+                await process.WaitForExitAsync(cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                try { process.Kill(entireProcessTree: true); } catch { }
+                throw;
+            }
+
+            process.WaitForExit();
 
             if (process.ExitCode != 0)
             {
@@ -850,14 +884,25 @@ namespace WhisperSubs.Controller
             probeInfo.ArgumentList.Add("a");
             probeInfo.ArgumentList.Add(mediaPath);
 
-            var process = new Process { StartInfo = probeInfo };
+            using var process = new Process { StartInfo = probeInfo };
 
             var outputBuilder = new StringBuilder();
             process.OutputDataReceived += (_, e) => { if (e.Data != null) outputBuilder.AppendLine(e.Data); };
 
             process.Start();
             process.BeginOutputReadLine();
-            await process.WaitForExitAsync(cancellationToken);
+
+            try
+            {
+                await process.WaitForExitAsync(cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                try { process.Kill(entireProcessTree: true); } catch { }
+                throw;
+            }
+
+            process.WaitForExit();
 
             if (process.ExitCode != 0) return -1;
 
@@ -939,7 +984,7 @@ namespace WhisperSubs.Controller
             _logger.LogInformation("Running FFmpeg: {Path} {Arguments}", ffmpegPath,
                 string.Join(" ", extractInfo.ArgumentList));
 
-            var process = new Process { StartInfo = extractInfo };
+            using var process = new Process { StartInfo = extractInfo };
 
             var errorBuilder = new StringBuilder();
             process.ErrorDataReceived += (_, e) =>
@@ -953,7 +998,18 @@ namespace WhisperSubs.Controller
 
             process.Start();
             process.BeginErrorReadLine();
-            await process.WaitForExitAsync(cancellationToken);
+
+            try
+            {
+                await process.WaitForExitAsync(cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                try { process.Kill(entireProcessTree: true); } catch { }
+                throw;
+            }
+
+            process.WaitForExit();
 
             if (process.ExitCode != 0)
             {
@@ -989,14 +1045,25 @@ namespace WhisperSubs.Controller
             durationInfo.ArgumentList.Add("-show_format");
             durationInfo.ArgumentList.Add(mediaPath);
 
-            var process = new Process { StartInfo = durationInfo };
+            using var process = new Process { StartInfo = durationInfo };
 
             var outputBuilder = new StringBuilder();
             process.OutputDataReceived += (_, e) => { if (e.Data != null) outputBuilder.AppendLine(e.Data); };
 
             process.Start();
             process.BeginOutputReadLine();
-            await process.WaitForExitAsync(cancellationToken);
+
+            try
+            {
+                await process.WaitForExitAsync(cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                try { process.Kill(entireProcessTree: true); } catch { }
+                throw;
+            }
+
+            process.WaitForExit();
 
             if (process.ExitCode != 0) return 0;
 
@@ -1071,6 +1138,10 @@ namespace WhisperSubs.Controller
                     };
 
                     process.Start();
+
+                    // Drain redirected streams to avoid deadlock
+                    process.StandardOutput.ReadToEnd();
+                    process.StandardError.ReadToEnd();
 
                     if (!process.WaitForExit(5000))
                     {

--- a/Providers/WhisperProvider.cs
+++ b/Providers/WhisperProvider.cs
@@ -51,7 +51,7 @@ namespace WhisperSubs.Providers
                 if (whisperExecutable == null)
                 {
                     throw new InvalidOperationException(
-                        "Whisper executable not found. Please install whisper.cpp and ensure 'whisper-cli' or 'main' is in PATH.");
+                        "Whisper executable not found. Please install whisper.cpp and ensure 'whisper-cli' is in PATH, or set the binary path in plugin settings.");
                 }
 
                 var langPrompt = GetLanguagePrompt(language);
@@ -192,7 +192,7 @@ namespace WhisperSubs.Providers
             if (whisperExecutable == null)
             {
                 throw new InvalidOperationException(
-                    "Whisper executable not found. Please install whisper.cpp and ensure 'whisper-cli' or 'main' is in PATH.");
+                    "Whisper executable not found. Please install whisper.cpp and ensure 'whisper-cli' is in PATH, or set the binary path in plugin settings.");
             }
 
             var startInfo = new ProcessStartInfo
@@ -499,6 +499,11 @@ namespace WhisperSubs.Providers
                     };
 
                     process.Start();
+
+                    // Drain redirected streams to avoid deadlock — the process may
+                    // block if its stdout/stderr buffer fills before WaitForExit returns.
+                    process.StandardOutput.ReadToEnd();
+                    process.StandardError.ReadToEnd();
 
                     if (!process.WaitForExit(5000))
                     {

--- a/Setup/WhisperSetupService.cs
+++ b/Setup/WhisperSetupService.cs
@@ -441,6 +441,10 @@ namespace WhisperSubs.Setup
                     });
                     if (p != null)
                     {
+                        // Drain redirected streams to avoid deadlock
+                        p.StandardOutput.ReadToEnd();
+                        p.StandardError.ReadToEnd();
+
                         if (!p.WaitForExit(5000))
                         {
                             try { p.Kill(); } catch { }

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.6.0.0</Version>
+    <Version>3.7.0.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
## Summary

Follow-up to PR #13 addressing remaining process-management findings from the code review:

- **Pipe deadlock prevention (High):** All probe processes (`FindWhisperExecutable`, `FindExecutable`, `IsWhisperInPath`) now drain `stdout`/`stderr` before calling `WaitForExit`, preventing buffer-full deadlocks
- **Cancellation cleanup (High):** All 6 ffmpeg/ffprobe methods in `SubtitleManager` now catch `OperationCanceledException` and kill the entire process tree, preventing orphaned child processes on task cancellation or Jellyfin shutdown
- **Pipe flush (Medium):** Added `process.WaitForExit()` after `WaitForExitAsync` in all `SubtitleManager` methods to ensure async pipe buffers are fully drained before reading output
- **Deterministic disposal:** Added `using` to all `Process` instances in `SubtitleManager`
- **Error text (Low):** Removed stale reference to `main` binary in user-facing error messages
- **CI (Medium):** Added `dotnet test` step and Windows build matrix to catch platform-specific regressions

## Files changed

- `Providers/WhisperProvider.cs` — pipe drain in probe, error message fix
- `Controller/SubtitleManager.cs` — `using` + cancellation kill + pipe flush on all 6 ffmpeg/ffprobe methods, pipe drain in `FindExecutable`
- `Setup/WhisperSetupService.cs` — pipe drain in `IsWhisperInPath`
- `WhisperSubs.csproj` — version bump 3.6.0.0 → 3.7.0.0
- `.github/workflows/ci.yml` — test step + Windows matrix

## Test plan

- [ ] CI passes on both Linux and Windows
- [ ] Cancel a running subtitle task — verify no orphaned ffmpeg/ffprobe processes remain
- [ ] Verify subtitle generation still works end-to-end after changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process stability and reliability across different systems
  * Enhanced error guidance for Whisper executable configuration in plugin settings
  * Fixed potential deadlock issues with stream handling

* **Chores**
  * Version bumped to 3.7.0
  * Expanded CI testing coverage to Windows and Linux platforms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->