### PR TITLE
fix: detect missing libvulkan.so.1 before recommending Vulkan variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,15 @@ docker exec jellyfin /opt/whisper/whisper-cli --help
 
 ## GPU Acceleration
 
-whisper.cpp supports GPU offloading via **Vulkan** (Intel, AMD, and some NVIDIA GPUs) and **CUDA** (NVIDIA). GPU acceleration dramatically reduces transcription time, especially with larger models.
+whisper.cpp supports GPU offloading via **Vulkan** (Intel, AMD, and some NVIDIA GPUs), **CUDA** (NVIDIA), and **ROCm** (AMD). GPU acceleration dramatically reduces transcription time, especially with larger models.
+
+> **Docker users:** Passing the GPU device (e.g., `/dev/dri`) to a container is **not enough** -- the container also needs the matching userspace libraries installed. The auto-setup wizard detects both the device and the library and will fall back to CPU if the library is missing.
+>
+> | Backend | Device | Required library | Install command (Debian/Ubuntu) |
+> |---------|--------|------------------|---------------------------------|
+> | **CUDA** | `/dev/nvidia0` | `libcuda.so.1` | `nvidia-container-toolkit` (host) |
+> | **Vulkan** | `/dev/dri` | `libvulkan.so.1` | `apt install libvulkan1 mesa-vulkan-drivers` |
+> | **ROCm** | `/dev/kfd` | `libamdhip64.so` | `apt install rocm-hip-runtime` |
 
 ### Vulkan (Intel / AMD)
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ whisper.cpp supports GPU offloading via **Vulkan** (Intel, AMD, and some NVIDIA 
 > | Backend | Device | Required library | Install command (Debian/Ubuntu) |
 > |---------|--------|------------------|---------------------------------|
 > | **CUDA** | `/dev/nvidia0` | `libcuda.so.1` | `nvidia-container-toolkit` (host) |
-> | **Vulkan** | `/dev/dri` | `libvulkan.so.1` | `apt install libvulkan1 mesa-vulkan-drivers` |
+> | **Vulkan** | `/dev/dri` | `libvulkan.so.1` + ICD JSON | `apt install libvulkan1 mesa-vulkan-drivers` (also needs `/usr/share/vulkan/icd.d/*.json`) |
 > | **ROCm** | `/dev/kfd` | `libamdhip64.so` | `apt install rocm-hip-runtime` |
 
 ### Vulkan (Intel / AMD)

--- a/Setup/WhisperSetupService.cs
+++ b/Setup/WhisperSetupService.cs
@@ -434,21 +434,26 @@ namespace WhisperSubs.Setup
                     }
                 }
 
-                // Auto-apply to plugin config
-                var config = Plugin.Instance.Configuration;
-                config.WhisperBinaryPath = BinaryPath;
-                Plugin.Instance.SaveConfiguration();
-
                 if (validationError == null)
                 {
+                    // Only auto-apply to config when the binary actually works —
+                    // don't overwrite a working config with a known-bad binary.
+                    var config = Plugin.Instance.Configuration;
+                    config.WhisperBinaryPath = BinaryPath;
+                    Plugin.Instance.SaveConfiguration();
+
                     lock (_lock)
                     {
                         _progress = 100;
                         _progressMessage = "whisper-cli downloaded successfully.";
                     }
-                }
 
-                _logger.LogInformation("Binary downloaded to {Path} and config updated", BinaryPath);
+                    _logger.LogInformation("Binary downloaded to {Path} and config updated", BinaryPath);
+                }
+                else
+                {
+                    _logger.LogWarning("Binary downloaded to {Path} but NOT applied to config: {Error}", BinaryPath, validationError);
+                }
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {

--- a/Setup/WhisperSetupService.cs
+++ b/Setup/WhisperSetupService.cs
@@ -276,6 +276,17 @@ namespace WhisperSubs.Setup
                 catch { /* not available */ }
             }
 
+            // CUDA userspace libraries — containers often have the GPU device passed
+            // through but lack the CUDA runtime libraries.
+            var cudaPaths = new[]
+            {
+                "/usr/local/cuda/lib64/libcudart.so",
+                "/usr/lib/x86_64-linux-gnu/libcuda.so.1",
+                "/usr/lib64/libcuda.so.1",
+                "/usr/lib/libcuda.so.1"
+            };
+            info.HasCudaLibrary = Array.Exists(cudaPaths, File.Exists);
+
             // AMD ROCm: check for /dev/kfd (ROCm kernel driver)
             if (File.Exists("/dev/kfd"))
             {
@@ -294,6 +305,16 @@ namespace WhisperSubs.Setup
                 }
                 catch { /* not available */ }
             }
+
+            // ROCm userspace library
+            var rocmPaths = new[]
+            {
+                "/opt/rocm/lib/libamdhip64.so",
+                "/usr/lib/x86_64-linux-gnu/libamdhip64.so",
+                "/usr/lib64/libamdhip64.so",
+                "/usr/lib/libamdhip64.so"
+            };
+            info.HasRocmLibrary = Array.Exists(rocmPaths, File.Exists);
 
             // Intel / Vulkan: check for /dev/dri/renderD128
             if (File.Exists("/dev/dri/renderD128"))
@@ -315,9 +336,9 @@ namespace WhisperSubs.Setup
             };
             info.HasVulkanLibrary = Array.Exists(vulkanPaths, File.Exists);
 
-            // Recommend variant based on detection
-            if (info.HasNvidia) info.RecommendedVariant = "cuda12";
-            else if (info.HasAmdGpu) info.RecommendedVariant = "rocm";
+            // Recommend variant based on detection — require both device AND userspace library
+            if (info.HasNvidia && info.HasCudaLibrary) info.RecommendedVariant = "cuda12";
+            else if (info.HasAmdGpu && info.HasRocmLibrary) info.RecommendedVariant = "rocm";
             else if (info.HasRenderDevice && info.HasVulkanLibrary) info.RecommendedVariant = "vulkan";
             else info.RecommendedVariant = "cpu";
 
@@ -468,14 +489,17 @@ namespace WhisperSubs.Setup
                 };
 
                 process.Start();
-                process.StandardOutput.ReadToEnd();
-                var stderr = process.StandardError.ReadToEnd();
+                var stdoutTask = process.StandardOutput.ReadToEndAsync();
+                var stderrTask = process.StandardError.ReadToEndAsync();
 
                 if (!process.WaitForExit(10000))
                 {
-                    try { process.Kill(); } catch { }
+                    try { process.Kill(entireProcessTree: true); } catch { }
                     return null; // Timeout is OK — GPU init can be slow, binary exists and launched
                 }
+
+                var stderr = stderrTask.GetAwaiter().GetResult();
+                _ = stdoutTask.GetAwaiter().GetResult();
 
                 // Exit code 127 = missing shared library (Linux dynamic linker error)
                 if (process.ExitCode == 127)
@@ -555,7 +579,9 @@ namespace WhisperSubs.Setup
     public class GpuInfo
     {
         public bool HasNvidia { get; set; }
+        public bool HasCudaLibrary { get; set; }
         public bool HasAmdGpu { get; set; }
+        public bool HasRocmLibrary { get; set; }
         public bool HasRenderDevice { get; set; }
         public bool HasVulkanLibrary { get; set; }
         public string RecommendedVariant { get; set; } = "cpu";

--- a/Setup/WhisperSetupService.cs
+++ b/Setup/WhisperSetupService.cs
@@ -301,10 +301,24 @@ namespace WhisperSubs.Setup
                 info.HasRenderDevice = true;
             }
 
+            // Vulkan userspace library — required at runtime by the vulkan binary.
+            // The render device alone is not sufficient; containers often have /dev/dri
+            // passed through but lack the libvulkan.so.1 userspace library.
+            var vulkanPaths = new[]
+            {
+                "/lib/x86_64-linux-gnu/libvulkan.so.1",
+                "/usr/lib/x86_64-linux-gnu/libvulkan.so.1",
+                "/usr/lib/libvulkan.so.1",
+                "/lib64/libvulkan.so.1",
+                "/usr/lib64/libvulkan.so.1",
+                "/lib/aarch64-linux-gnu/libvulkan.so.1"
+            };
+            info.HasVulkanLibrary = Array.Exists(vulkanPaths, File.Exists);
+
             // Recommend variant based on detection
             if (info.HasNvidia) info.RecommendedVariant = "cuda12";
             else if (info.HasAmdGpu) info.RecommendedVariant = "rocm";
-            else if (info.HasRenderDevice) info.RecommendedVariant = "vulkan";
+            else if (info.HasRenderDevice && info.HasVulkanLibrary) info.RecommendedVariant = "vulkan";
             else info.RecommendedVariant = "cpu";
 
             return info;
@@ -386,15 +400,31 @@ namespace WhisperSubs.Setup
                 var sha256 = ComputeSha256(BinaryPath);
                 _logger.LogInformation("Binary {Variant} SHA256: {Hash}", variant, sha256);
 
+                // Validate the binary can actually run (catches missing shared libraries)
+                var validationError = ValidateBinary(BinaryPath);
+                if (validationError != null)
+                {
+                    _logger.LogWarning("Binary validation warning: {Error}", validationError);
+                    lock (_lock)
+                    {
+                        _progress = 100;
+                        _progressMessage = $"whisper-cli downloaded but may not work: {validationError}";
+                        _error = validationError;
+                    }
+                }
+
                 // Auto-apply to plugin config
                 var config = Plugin.Instance.Configuration;
                 config.WhisperBinaryPath = BinaryPath;
                 Plugin.Instance.SaveConfiguration();
 
-                lock (_lock)
+                if (validationError == null)
                 {
-                    _progress = 100;
-                    _progressMessage = "whisper-cli downloaded successfully.";
+                    lock (_lock)
+                    {
+                        _progress = 100;
+                        _progressMessage = "whisper-cli downloaded successfully.";
+                    }
                 }
 
                 _logger.LogInformation("Binary downloaded to {Path} and config updated", BinaryPath);
@@ -412,6 +442,57 @@ namespace WhisperSubs.Setup
             finally
             {
                 lock (_lock) { _isRunning = false; }
+            }
+        }
+
+        /// <summary>
+        /// Probes the downloaded binary to check it can actually launch.
+        /// Returns null on success, or a user-friendly error message on failure
+        /// (e.g. missing shared libraries like libvulkan.so.1).
+        /// </summary>
+        private string? ValidateBinary(string binaryPath)
+        {
+            try
+            {
+                using var process = new System.Diagnostics.Process
+                {
+                    StartInfo = new System.Diagnostics.ProcessStartInfo
+                    {
+                        FileName = binaryPath,
+                        Arguments = "--help",
+                        RedirectStandardOutput = true,
+                        RedirectStandardError = true,
+                        UseShellExecute = false,
+                        CreateNoWindow = true
+                    }
+                };
+
+                process.Start();
+                process.StandardOutput.ReadToEnd();
+                var stderr = process.StandardError.ReadToEnd();
+
+                if (!process.WaitForExit(10000))
+                {
+                    try { process.Kill(); } catch { }
+                    return null; // Timeout is OK — GPU init can be slow, binary exists and launched
+                }
+
+                // Exit code 127 = missing shared library (Linux dynamic linker error)
+                if (process.ExitCode == 127)
+                {
+                    // Extract the missing library name from stderr
+                    var match = System.Text.RegularExpressions.Regex.Match(
+                        stderr, @"error while loading shared libraries:\s*(\S+)");
+                    var lib = match.Success ? match.Groups[1].Value : "a shared library";
+                    return $"Missing {lib}. Try the CPU variant, or install the library in your container (e.g. 'apt install libvulkan1' for Vulkan).";
+                }
+
+                return null; // Any other exit code is fine (--help may return non-zero on some builds)
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug("Binary validation probe failed: {Error}", ex.Message);
+                return null; // Can't probe — don't block the download
             }
         }
 
@@ -476,6 +557,7 @@ namespace WhisperSubs.Setup
         public bool HasNvidia { get; set; }
         public bool HasAmdGpu { get; set; }
         public bool HasRenderDevice { get; set; }
+        public bool HasVulkanLibrary { get; set; }
         public string RecommendedVariant { get; set; } = "cpu";
     }
 

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -290,12 +290,18 @@
 
                             var hint = document.querySelector('#gpuDetectionHint');
                             if (s.Gpu) {
-                                if (s.Gpu.HasNvidia) {
+                                if (s.Gpu.HasNvidia && s.Gpu.HasCudaLibrary) {
                                     hint.textContent = 'NVIDIA GPU detected — CUDA 12 variant recommended for fastest transcription.';
                                     hint.style.color = '#52B54B';
-                                } else if (s.Gpu.HasAmdGpu) {
+                                } else if (s.Gpu.HasNvidia && !s.Gpu.HasCudaLibrary) {
+                                    hint.textContent = 'NVIDIA GPU detected but CUDA libraries are missing in this container. CPU variant selected. To use CUDA, install nvidia-cuda-toolkit or pass the NVIDIA runtime to your container.';
+                                    hint.style.color = '#CC7B19';
+                                } else if (s.Gpu.HasAmdGpu && s.Gpu.HasRocmLibrary) {
                                     hint.textContent = 'AMD GPU detected — ROCm variant recommended for GPU-accelerated transcription.';
                                     hint.style.color = '#52B54B';
+                                } else if (s.Gpu.HasAmdGpu && !s.Gpu.HasRocmLibrary) {
+                                    hint.textContent = 'AMD GPU detected but ROCm libraries are missing in this container. CPU variant selected. To use ROCm, install the ROCm runtime in your Docker image.';
+                                    hint.style.color = '#CC7B19';
                                 } else if (s.Gpu.HasRenderDevice && s.Gpu.HasVulkanLibrary) {
                                     hint.textContent = 'GPU render device detected — Vulkan variant recommended.';
                                     hint.style.color = '#52B54B';

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -296,9 +296,12 @@
                                 } else if (s.Gpu.HasAmdGpu) {
                                     hint.textContent = 'AMD GPU detected — ROCm variant recommended for GPU-accelerated transcription.';
                                     hint.style.color = '#52B54B';
-                                } else if (s.Gpu.HasRenderDevice) {
+                                } else if (s.Gpu.HasRenderDevice && s.Gpu.HasVulkanLibrary) {
                                     hint.textContent = 'GPU render device detected — Vulkan variant recommended.';
                                     hint.style.color = '#52B54B';
+                                } else if (s.Gpu.HasRenderDevice && !s.Gpu.HasVulkanLibrary) {
+                                    hint.textContent = 'GPU detected but Vulkan library (libvulkan.so.1) is missing in this container. CPU variant selected. To use Vulkan, install libvulkan1 in your Docker image.';
+                                    hint.style.color = '#CC7B19';
                                 } else {
                                     hint.textContent = 'No GPU detected. CPU variant selected (works on any system).';
                                     hint.style.color = '';

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.7.0.0</Version>
+    <Version>3.7.1.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
## Summary

Fixes a bug where auto-setup recommended the Vulkan binary variant on systems that have `/dev/dri/renderD128` passed through but lack the `libvulkan.so.1` userspace library (e.g. `linuxserver/jellyfin` image). The downloaded binary then fails at runtime with exit code 127.

Reported by user Iphitto on Reddit — they had an iGPU detected, Quick Setup downloaded the Vulkan binary, but transcription failed:
```
libvulkan.so.1: cannot open shared object file: No such file or directory
```

**Root cause:** `DetectGpu()` only checked for the kernel device file, not the userspace Vulkan library.

## Changes

- **`DetectGpu()`**: Check common `libvulkan.so.1` paths; only recommend `vulkan` when both render device AND library are present, otherwise fall back to `cpu`
- **`GpuInfo`**: Added `HasVulkanLibrary` property exposed to UI
- **UI hint**: When render device exists but Vulkan library is missing, shows warning with remediation steps (`apt install libvulkan1`)
- **Post-download validation**: After downloading any binary, probes it with `--help`; if exit code 127 (missing shared library), extracts the library name from stderr and surfaces an actionable error message
- Version bump 3.7.0.0 → 3.7.1.0

## Test plan

- [ ] Container WITH libvulkan.so.1 + /dev/dri: recommends Vulkan, binary works
- [ ] Container with /dev/dri but NO libvulkan.so.1: recommends CPU, UI shows warning
- [ ] Container with no GPU: recommends CPU as before
- [ ] Post-download validation catches missing shared library and shows error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GPU detection now requires both device and matching userspace libraries (CUDA, ROCm, Vulkan) before recommending a GPU runtime.
  * Binary downloads include a post-download validation step that detects missing shared-library failures and prevents auto-applying non-working binaries.

* **Bug Fixes**
  * Clearer UI warnings and safer fallback to CPU when required userspace GPU libraries are absent.

* **Documentation**
  * Added ROCm guidance and container/library setup notes.

* **Chores**
  * Project version bump.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->