### PR TITLE
feat: progress banner metadata and phase tracking

### DIFF
--- a/Api/SubtitleController.cs
+++ b/Api/SubtitleController.cs
@@ -200,7 +200,10 @@ namespace WhisperSubs.Api
                 processed = queue.ProcessedCount + queue.TaskProcessed,
                 failed = queue.TaskFailed,
                 taskTotal = queue.IsTaskRunning ? queue.TaskTotal : 0,
-                fileProgress = queue.CurrentFileProgress
+                fileProgress = queue.CurrentFileProgress,
+                phase = queue.CurrentPhase,
+                itemType = queue.TaskCurrentItemType,
+                library = queue.TaskCurrentItemLibrary
             });
         }
 

--- a/Controller/SubtitleManager.cs
+++ b/Controller/SubtitleManager.cs
@@ -108,7 +108,9 @@ namespace WhisperSubs.Controller
 
             try
             {
+                SubtitleQueueService.Instance.ReportPhase("Extracting audio");
                 await ExtractAudioAsync(mediaPath, tempAudioPath, lang, cancellationToken, resumeOffsetSeconds);
+                SubtitleQueueService.Instance.ReportPhase("Transcribing");
                 string srtContent = await provider.TranscribeAsync(tempAudioPath, lang, cancellationToken);
 
                 if (resumeOffsetSeconds > 0 && !string.IsNullOrWhiteSpace(existingSrt))
@@ -220,6 +222,7 @@ namespace WhisperSubs.Controller
                 _logger.LogInformation("Generating forced subtitle for {ItemName} [{Language}]", item.Name, resolvedPrimary);
 
                 // Step 1: Extract full audio
+                SubtitleQueueService.Instance.ReportPhase("Extracting audio");
                 await ExtractAudioAsync(mediaPath, fullAudioPath, resolvedPrimary, cancellationToken);
 
                 // Step 2: Get duration
@@ -235,6 +238,7 @@ namespace WhisperSubs.Controller
                 }
 
                 // Step 3: VAD-based speech segmentation via silencedetect
+                SubtitleQueueService.Instance.ReportPhase("Analyzing audio");
                 var speechSegments = await DetectSpeechSegmentsAsync(fullAudioPath, totalDuration, cancellationToken);
 
                 if (speechSegments.Count == 0)
@@ -248,6 +252,7 @@ namespace WhisperSubs.Controller
                 _logger.LogInformation("Analyzing {Count} audio chunks for foreign language in {ItemName}", chunks.Count, item.Name);
 
                 // Step 5: Language detection per chunk
+                SubtitleQueueService.Instance.ReportPhase("Detecting languages");
                 var foreignChunks = new List<(double Start, double End, string Language)>();
                 int successfulDetections = 0;
 
@@ -307,6 +312,7 @@ namespace WhisperSubs.Controller
                 var mergedSegments = MergeForeignChunks(foreignChunks);
 
                 // Step 7: Transcribe foreign segments
+                SubtitleQueueService.Instance.ReportPhase("Transcribing");
                 var forcedSrt = new StringBuilder();
                 int entryNum = 1;
 
@@ -419,7 +425,9 @@ namespace WhisperSubs.Controller
 
             try
             {
+                SubtitleQueueService.Instance.ReportPhase("Extracting audio");
                 await ExtractAudioAsync(mediaPath, tempAudioPath, lang, cancellationToken);
+                SubtitleQueueService.Instance.ReportPhase("Transcribing");
                 string srtContent = await provider.TranscribeAsync(tempAudioPath, lang, cancellationToken);
                 string lrcContent = ConvertSrtToLrc(srtContent, item.Name);
 

--- a/Controller/SubtitleQueueService.cs
+++ b/Controller/SubtitleQueueService.cs
@@ -94,6 +94,10 @@ namespace WhisperSubs.Controller
             _taskFailed = failed;
             _taskCurrentItemType = itemType;
             _taskCurrentItemLibrary = libraryName;
+            if (string.IsNullOrEmpty(itemName))
+            {
+                _currentPhase = null;
+            }
             Interlocked.CompareExchange(ref _taskIsRunning, 1, 0);
         }
 

--- a/Controller/SubtitleQueueService.cs
+++ b/Controller/SubtitleQueueService.cs
@@ -72,25 +72,44 @@ namespace WhisperSubs.Controller
 
         /// <summary>Whether the scheduled auto-generation task is running.</summary>
         public bool IsTaskRunning => _taskIsRunning == 1;
+        private string? _taskCurrentItemType;
+        private string? _taskCurrentItemLibrary;
+        private string? _currentPhase;
+
         public string? TaskCurrentItemName => _taskCurrentItemName;
+        public string? TaskCurrentItemType => _taskCurrentItemType;
+        public string? TaskCurrentItemLibrary => _taskCurrentItemLibrary;
+        public string? CurrentPhase => _currentPhase;
         public int TaskTotal => _taskTotal;
         public int TaskProcessed => _taskProcessed;
         public int TaskFailed => _taskFailed;
 
         /// <summary>Reports progress from the scheduled task so the Queue endpoint can expose it.</summary>
-        public void ReportTaskProgress(string? itemName, int processed, int total, int failed)
+        public void ReportTaskProgress(string? itemName, int processed, int total, int failed,
+            string? itemType = null, string? libraryName = null)
         {
             _taskCurrentItemName = itemName;
             _taskProcessed = processed;
             _taskTotal = total;
             _taskFailed = failed;
+            _taskCurrentItemType = itemType;
+            _taskCurrentItemLibrary = libraryName;
             Interlocked.CompareExchange(ref _taskIsRunning, 1, 0);
+        }
+
+        /// <summary>Reports the current processing phase (e.g. "Extracting audio", "Transcribing").</summary>
+        public void ReportPhase(string phase)
+        {
+            _currentPhase = phase;
         }
 
         /// <summary>Marks the scheduled task as complete.</summary>
         public void ReportTaskComplete()
         {
             _taskCurrentItemName = null;
+            _taskCurrentItemType = null;
+            _taskCurrentItemLibrary = null;
+            _currentPhase = null;
             Interlocked.Exchange(ref _taskIsRunning, 0);
         }
 

--- a/ScheduledTasks/SubtitleGenerationTask.cs
+++ b/ScheduledTasks/SubtitleGenerationTask.cs
@@ -110,9 +110,12 @@ namespace WhisperSubs.ScheduledTasks
                 includeKinds.Add(BaseItemKind.Audio);
             }
 
-            var allItems = new List<BaseItem>();
+            var allItems = new List<(BaseItem Item, string LibraryName)>();
             foreach (var libraryId in enabledLibraryIds)
             {
+                var library = _libraryManager.GetItemById(libraryId);
+                var libraryName = library?.Name ?? "Unknown";
+
                 var items = _libraryManager.GetItemList(new InternalItemsQuery
                 {
                     ParentId = libraryId,
@@ -125,11 +128,11 @@ namespace WhisperSubs.ScheduledTasks
                     if (queryItem is Video video)
                     {
                         if (!needsForced && video.HasSubtitles) continue;
-                        allItems.Add(video);
+                        allItems.Add((video, libraryName));
                     }
                     else if (queryItem is MediaBrowser.Controller.Entities.Audio.Audio)
                     {
-                        allItems.Add(queryItem);
+                        allItems.Add((queryItem, libraryName));
                     }
                 }
             }
@@ -158,7 +161,8 @@ namespace WhisperSubs.ScheduledTasks
                     await queue.DrainPriorityAsync(manager, provider, _logger, cancellationToken);
                 }
 
-                var item = allItems[i];
+                var (item, libName) = allItems[i];
+                var itemType = item.GetType().Name;
 
                 // For Audio items (lyrics), skip if .lrc already exists
                 if (item is MediaBrowser.Controller.Entities.Audio.Audio)
@@ -241,7 +245,7 @@ namespace WhisperSubs.ScheduledTasks
                     _logger.LogInformation("[{Current}/{Total}] Processing {ItemName}",
                         completed + 1, allItems.Count, item.Name);
                     queue.ResetFileProgress();
-                    queue.ReportTaskProgress(item.Name, completed, allItems.Count, failed);
+                    queue.ReportTaskProgress(item.Name, completed, allItems.Count, failed, itemType, libName);
 
                     await SubtitleQueueService.TranscriptionLock.WaitAsync(cancellationToken);
                     try

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -946,16 +946,33 @@
                             // Progress bar — shows per-file whisper progress (0-100%)
                             var filePct = q.fileProgress || 0;
                             bar.style.width = filePct + '%';
-                            pct.textContent = filePct > 0 ? filePct + '%' : '';
+                            pct.textContent = filePct + '%';
 
-                            // Title
-                            title.textContent = q.currentItem ? 'Generating Subtitles' : 'Waiting\u2026';
+                            // Title — show phase if available
+                            if (q.phase) {
+                                title.textContent = q.phase;
+                            } else if (q.currentItem) {
+                                title.textContent = 'Generating Subtitles';
+                            } else {
+                                title.textContent = 'Waiting\u2026';
+                            }
 
-                            // Current item
+                            // Current item — with type badge and library
                             var total = q.taskTotal || (q.processed + q.remaining);
                             if (q.currentItem) {
-                                current.innerHTML = '<strong>' +
-                                    WhisperSubsConfig.escapeHtml(q.currentItem) + '</strong>';
+                                var itemLabel = '';
+                                if (q.itemType) {
+                                    var typeLabel = q.itemType === 'Episode' ? 'Episode'
+                                        : q.itemType === 'Audio' ? 'Audio' : 'Movie';
+                                    itemLabel += '<span style="opacity:0.7; font-size:0.9em;">' +
+                                        WhisperSubsConfig.escapeHtml(typeLabel) + ' \u00b7 </span>';
+                                }
+                                itemLabel += '<strong>' + WhisperSubsConfig.escapeHtml(q.currentItem) + '</strong>';
+                                if (q.library) {
+                                    itemLabel += '<span style="opacity:0.5; font-size:0.85em;"> \u2014 ' +
+                                        WhisperSubsConfig.escapeHtml(q.library) + '</span>';
+                                }
+                                current.innerHTML = itemLabel;
                             } else {
                                 current.textContent = '';
                             }

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.8.4.0</Version>
+    <Version>3.8.5.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
## Summary
- Add **item type** (Movie/Episode/Audio) and **source library** name to queue status endpoint and progress banner
- Add **processing phase** display (Extracting audio, Analyzing audio, Detecting languages, Transcribing) — reported from SubtitleManager pipeline stages
- Fix **0% always showing** in progress bar (was hidden when fileProgress was 0)
- Version bump to 3.8.5.0

## Changes
- `SubtitleManager.cs`: `ReportPhase()` calls before each pipeline stage (FFmpeg extraction, VAD, language detection, transcription) for both full, forced, and lyrics generation
- `SubtitleController.cs`: Queue endpoint now returns `phase`, `itemType`, `library` fields
- `SubtitleQueueService.cs`: Already had the backing fields from previous PR
- `ScheduledTasks/SubtitleGenerationTask.cs`: Already passing itemType and libraryName from previous PR
- `configPage.html`: Banner JS shows type badge, library name, phase as title, and always displays percentage text

## Test plan
- [ ] Verify banner shows "Extracting audio" phase during FFmpeg step
- [ ] Verify banner shows "Transcribing" during whisper step
- [ ] Verify item type badge appears (e.g. "Movie · ItemName")
- [ ] Verify library name appears after item name
- [ ] Verify 0% is displayed when progress is zero
- [ ] Verify forced subtitle pipeline shows "Analyzing audio" and "Detecting languages" phases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Queue status now shows current processing phase, content type (Episode/Audio/etc.), and originating library.
  * Progress banner and current-item details display phase and content metadata, including a type badge and library label when available.
  * File progress percentage is always shown, including at 0%.

* **Chores**
  * Version bumped to 3.8.5.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->