### PR TITLE
fix: variant-aware binary validation error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,27 @@ Then configure the plugin with:
 
 > **Note:** The binary must be compiled for the same architecture as the container (typically x86_64 Linux). Download the `linux-x64` release asset or build inside a matching environment.
 
+#### Container Library Requirements {#container-setup}
+
+The plugin's built-in binary downloader fetches pre-built whisper-cli binaries. These require runtime libraries that are **not included** in the default Jellyfin Docker image:
+
+| Variant | Required packages | Install command |
+|---------|-------------------|-----------------|
+| **CPU** | `libgomp1` | `apt install libgomp1` |
+| **Vulkan** | `libgomp1`, `libvulkan1`, `mesa-vulkan-drivers` | `apt install libgomp1 libvulkan1 mesa-vulkan-drivers` |
+| **CUDA 12** | `libgomp1` + NVIDIA Container Toolkit on host | See [CUDA section](#cuda-nvidia) |
+| **ROCm** | `libgomp1` + ROCm runtime | See [ROCm docs](https://rocm.docs.amd.com/) |
+
+> `libgomp1` (OpenMP threading) is required by **all** variants, including CPU.
+
+To install persistently, add to your container's entrypoint or Dockerfile:
+
+```bash
+apt-get update -qq && apt-get install -y -qq --no-install-recommends libgomp1 && rm -rf /var/lib/apt/lists/*
+```
+
+The plugin's setup page will detect missing libraries and warn you before downloading.
+
 ### Verifying the Installation
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Then configure the plugin with:
 
 > **Note:** The binary must be compiled for the same architecture as the container (typically x86_64 Linux). Download the `linux-x64` release asset or build inside a matching environment.
 
-#### Container Library Requirements {#container-setup}
+#### <a id="container-setup"></a>Container Library Requirements
 
 The plugin's built-in binary downloader fetches pre-built whisper-cli binaries. These require runtime libraries that are **not included** in the default Jellyfin Docker image:
 

--- a/Setup/WhisperSetupService.cs
+++ b/Setup/WhisperSetupService.cs
@@ -336,6 +336,18 @@ namespace WhisperSubs.Setup
             };
             info.HasVulkanLibrary = Array.Exists(vulkanPaths, File.Exists);
 
+            // OpenMP runtime — required by ALL whisper.cpp variants (CPU, Vulkan, CUDA, ROCm)
+            var openmpPaths = new[]
+            {
+                "/lib/x86_64-linux-gnu/libgomp.so.1",
+                "/usr/lib/x86_64-linux-gnu/libgomp.so.1",
+                "/usr/lib/libgomp.so.1",
+                "/lib64/libgomp.so.1",
+                "/usr/lib64/libgomp.so.1",
+                "/lib/aarch64-linux-gnu/libgomp.so.1"
+            };
+            info.HasOpenMP = Array.Exists(openmpPaths, File.Exists);
+
             // Recommend variant based on detection — require both device AND userspace library
             if (info.HasNvidia && info.HasCudaLibrary) info.RecommendedVariant = "cuda12";
             else if (info.HasAmdGpu && info.HasRocmLibrary) info.RecommendedVariant = "rocm";
@@ -511,7 +523,7 @@ namespace WhisperSubs.Setup
                 {
                     // Extract the missing library name from stderr
                     var match = System.Text.RegularExpressions.Regex.Match(
-                        stderr, @"error while loading shared libraries:\s*(\S+)");
+                        stderr, @"error while loading shared libraries:\s*(\S+?):");
                     var lib = match.Success ? match.Groups[1].Value : "a shared library";
                     var installHint = GetInstallHint(lib);
                     var isCpu = string.Equals(variant, "cpu", StringComparison.OrdinalIgnoreCase);
@@ -606,6 +618,7 @@ namespace WhisperSubs.Setup
         public bool HasRocmLibrary { get; set; }
         public bool HasRenderDevice { get; set; }
         public bool HasVulkanLibrary { get; set; }
+        public bool HasOpenMP { get; set; }
         public string RecommendedVariant { get; set; } = "cpu";
     }
 

--- a/Setup/WhisperSetupService.cs
+++ b/Setup/WhisperSetupService.cs
@@ -422,7 +422,7 @@ namespace WhisperSubs.Setup
                 _logger.LogInformation("Binary {Variant} SHA256: {Hash}", variant, sha256);
 
                 // Validate the binary can actually run (catches missing shared libraries)
-                var validationError = ValidateBinary(BinaryPath);
+                var validationError = ValidateBinary(BinaryPath, variant);
                 if (validationError != null)
                 {
                     _logger.LogWarning("Binary validation warning: {Error}", validationError);
@@ -476,7 +476,7 @@ namespace WhisperSubs.Setup
         /// Returns null on success, or a user-friendly error message on failure
         /// (e.g. missing shared libraries like libvulkan.so.1).
         /// </summary>
-        private string? ValidateBinary(string binaryPath)
+        private string? ValidateBinary(string binaryPath, string variant)
         {
             try
             {
@@ -513,7 +513,12 @@ namespace WhisperSubs.Setup
                     var match = System.Text.RegularExpressions.Regex.Match(
                         stderr, @"error while loading shared libraries:\s*(\S+)");
                     var lib = match.Success ? match.Groups[1].Value : "a shared library";
-                    return $"Missing {lib}. Try the CPU variant, or install the library in your container (e.g. 'apt install libvulkan1' for Vulkan).";
+                    var installHint = GetInstallHint(lib);
+                    var isCpu = string.Equals(variant, "cpu", StringComparison.OrdinalIgnoreCase);
+                    var suggestion = isCpu
+                        ? $"Install it in your container ({installHint})."
+                        : $"Try the CPU variant, or install the library in your container ({installHint}).";
+                    return $"Missing {lib}. {suggestion}";
                 }
 
                 return null; // Any other exit code is fine (--help may return non-zero on some builds)
@@ -524,6 +529,18 @@ namespace WhisperSubs.Setup
                 return null; // Can't probe — don't block the download
             }
         }
+
+        /// <summary>
+        /// Returns an apt-install hint for a missing shared library.
+        /// </summary>
+        private static string GetInstallHint(string libraryName) => libraryName switch
+        {
+            "libgomp.so.1" => "e.g. 'apt install libgomp1'",
+            "libvulkan.so.1" => "e.g. 'apt install libvulkan1'",
+            "libcuda.so.1" or "libcudart.so.12" => "e.g. install the NVIDIA CUDA toolkit",
+            "libamdhip64.so" => "e.g. install the AMD ROCm runtime",
+            _ => $"e.g. 'apt install' the package providing {libraryName}"
+        };
 
         private static string ComputeSha256(string filePath)
         {

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -623,37 +623,48 @@
                     var variant = document.querySelector('#engineBinaryVariant').value || 'cpu';
                     if (!gpuInfo) { hint.textContent = ''; return; }
 
-                    var missing = [];
-                    if (!gpuInfo.HasOpenMP) missing.push('libgomp1');
-
-                    if (variant === 'vulkan' && !gpuInfo.HasVulkanLibrary) missing.push('libvulkan1');
-                    if (variant === 'cuda12' && !gpuInfo.HasCudaLibrary) missing.push('nvidia-cuda-toolkit');
-                    if (variant === 'rocm' && !gpuInfo.HasRocmLibrary) missing.push('ROCm runtime');
-
-                    if (missing.length > 0) {
-                        hint.innerHTML = '\u26a0\ufe0f Missing libraries: <strong>' + missing.join(', ') +
-                            '</strong>. Install them in your container first (e.g. <code>apt install ' +
-                            missing.filter(function(m) { return m !== 'nvidia-cuda-toolkit' && m !== 'ROCm runtime'; }).join(' ') +
-                            '</code>).' +
-                            ' <a href="https://github.com/GeiserX/whisper-subs#container-setup" target="_blank" style="color:#52B54B;">Setup guide</a>';
-                        hint.style.color = '#CC7B19';
-                    } else if (variant === 'cuda12' && gpuInfo.HasNvidia) {
-                        hint.textContent = 'NVIDIA GPU detected \u2014 CUDA 12 variant recommended.';
-                        hint.style.color = '#52B54B';
-                    } else if (variant === 'rocm' && gpuInfo.HasAmdGpu) {
-                        hint.textContent = 'AMD GPU detected \u2014 ROCm variant recommended.';
-                        hint.style.color = '#52B54B';
-                    } else if (variant === 'vulkan' && gpuInfo.HasRenderDevice) {
-                        hint.textContent = 'GPU detected \u2014 Vulkan variant ready.';
-                        hint.style.color = '#52B54B';
-                    } else if (variant === 'cpu') {
-                        hint.textContent = gpuInfo.HasNvidia || gpuInfo.HasAmdGpu || gpuInfo.HasRenderDevice
-                            ? 'GPU detected \u2014 consider a GPU variant for faster transcription.'
-                            : 'No GPU detected. CPU variant ready.';
-                        hint.style.color = gpuInfo.HasNvidia || gpuInfo.HasAmdGpu || gpuInfo.HasRenderDevice ? '#CC7B19' : '#52B54B';
+                    if (variant === 'cuda12') {
+                        if (gpuInfo.HasNvidia && gpuInfo.HasCudaLibrary) {
+                            hint.textContent = 'NVIDIA GPU detected \u2014 CUDA 12 variant recommended.';
+                            hint.style.color = '#52B54B';
+                        } else if (gpuInfo.HasNvidia) {
+                            hint.textContent = 'NVIDIA GPU detected but CUDA libraries not found. Install nvidia-cuda-toolkit or use CPU variant.';
+                            hint.style.color = '#CC7B19';
+                        } else {
+                            hint.textContent = 'No NVIDIA GPU detected. This variant requires an NVIDIA GPU with CUDA support.';
+                            hint.style.color = '#CC7B19';
+                        }
+                    } else if (variant === 'rocm') {
+                        if (gpuInfo.HasAmdGpu && gpuInfo.HasRocmLibrary) {
+                            hint.textContent = 'AMD GPU detected \u2014 ROCm variant recommended.';
+                            hint.style.color = '#52B54B';
+                        } else if (gpuInfo.HasAmdGpu) {
+                            hint.textContent = 'AMD GPU detected but ROCm libraries not found.';
+                            hint.style.color = '#CC7B19';
+                        } else {
+                            hint.textContent = 'No AMD GPU detected. This variant requires an AMD GPU with ROCm support.';
+                            hint.style.color = '#CC7B19';
+                        }
+                    } else if (variant === 'vulkan') {
+                        if (gpuInfo.HasRenderDevice && gpuInfo.HasVulkanLibrary) {
+                            hint.textContent = 'GPU detected \u2014 Vulkan variant ready.';
+                            hint.style.color = '#52B54B';
+                        } else if (gpuInfo.HasRenderDevice) {
+                            hint.textContent = 'GPU detected but Vulkan library not found. May need libvulkan1 installed.';
+                            hint.style.color = '#CC7B19';
+                        } else {
+                            hint.textContent = 'No GPU render device detected. This variant requires a GPU with Vulkan support.';
+                            hint.style.color = '#CC7B19';
+                        }
                     } else {
-                        hint.textContent = '';
-                        hint.style.color = '';
+                        // CPU
+                        if (gpuInfo.HasNvidia || gpuInfo.HasAmdGpu || gpuInfo.HasRenderDevice) {
+                            hint.textContent = 'GPU detected \u2014 consider a GPU variant for faster transcription.';
+                            hint.style.color = '#CC7B19';
+                        } else {
+                            hint.textContent = 'No GPU detected. CPU variant selected.';
+                            hint.style.color = '';
+                        }
                     }
                 },
 

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -325,31 +325,13 @@
                             if (gpuInfo && gpuInfo.RecommendedVariant) {
                                 select.value = gpuInfo.RecommendedVariant;
                             }
-                            var hint = document.querySelector('#engineGpuHint');
-                            if (gpuInfo) {
-                                if (gpuInfo.HasNvidia && gpuInfo.HasCudaLibrary) {
-                                    hint.textContent = 'NVIDIA GPU detected \u2014 CUDA 12 variant recommended.';
-                                    hint.style.color = '#52B54B';
-                                } else if (gpuInfo.HasNvidia && !gpuInfo.HasCudaLibrary) {
-                                    hint.textContent = 'NVIDIA GPU detected but CUDA libraries missing. Install nvidia-cuda-toolkit or use CPU variant.';
-                                    hint.style.color = '#CC7B19';
-                                } else if (gpuInfo.HasAmdGpu && gpuInfo.HasRocmLibrary) {
-                                    hint.textContent = 'AMD GPU detected \u2014 ROCm variant recommended.';
-                                    hint.style.color = '#52B54B';
-                                } else if (gpuInfo.HasAmdGpu && !gpuInfo.HasRocmLibrary) {
-                                    hint.textContent = 'AMD GPU detected but ROCm libraries missing.';
-                                    hint.style.color = '#CC7B19';
-                                } else if (gpuInfo.HasRenderDevice && gpuInfo.HasVulkanLibrary) {
-                                    hint.textContent = 'GPU detected \u2014 Vulkan variant recommended.';
-                                    hint.style.color = '#52B54B';
-                                } else if (gpuInfo.HasRenderDevice && !gpuInfo.HasVulkanLibrary) {
-                                    hint.textContent = 'GPU detected but Vulkan library missing.';
-                                    hint.style.color = '#CC7B19';
-                                } else {
-                                    hint.textContent = 'No GPU detected. CPU variant selected.';
-                                    hint.style.color = '';
-                                }
-                            }
+                            // Store gpuInfo for variant change handler
+                            WhisperSubsConfig._gpuInfo = gpuInfo;
+                            // Update hint for initially selected variant
+                            WhisperSubsConfig.updateVariantHint();
+                            // Listen for variant changes
+                            select.removeEventListener('change', WhisperSubsConfig.updateVariantHint);
+                            select.addEventListener('change', WhisperSubsConfig.updateVariantHint);
                         })
                         .catch(function (err) {
                             console.error('WhisperSubs: error loading binary variants', err);
@@ -631,6 +613,48 @@
                     if (binBtn) { binBtn.disabled = false; binBtn.innerHTML = '<span>Download</span>'; }
                     if (modBtn) { modBtn.disabled = false; modBtn.innerHTML = '<span>Download</span>'; }
                     WhisperSubsConfig.updateModelDownloadState();
+                },
+
+                _gpuInfo: null,
+
+                updateVariantHint: function () {
+                    var gpuInfo = WhisperSubsConfig._gpuInfo;
+                    var hint = document.querySelector('#engineGpuHint');
+                    var variant = document.querySelector('#engineBinaryVariant').value || 'cpu';
+                    if (!gpuInfo) { hint.textContent = ''; return; }
+
+                    var missing = [];
+                    if (!gpuInfo.HasOpenMP) missing.push('libgomp1');
+
+                    if (variant === 'vulkan' && !gpuInfo.HasVulkanLibrary) missing.push('libvulkan1');
+                    if (variant === 'cuda12' && !gpuInfo.HasCudaLibrary) missing.push('nvidia-cuda-toolkit');
+                    if (variant === 'rocm' && !gpuInfo.HasRocmLibrary) missing.push('ROCm runtime');
+
+                    if (missing.length > 0) {
+                        hint.innerHTML = '\u26a0\ufe0f Missing libraries: <strong>' + missing.join(', ') +
+                            '</strong>. Install them in your container first (e.g. <code>apt install ' +
+                            missing.filter(function(m) { return m !== 'nvidia-cuda-toolkit' && m !== 'ROCm runtime'; }).join(' ') +
+                            '</code>).' +
+                            ' <a href="https://github.com/GeiserX/whisper-subs#container-setup" target="_blank" style="color:#52B54B;">Setup guide</a>';
+                        hint.style.color = '#CC7B19';
+                    } else if (variant === 'cuda12' && gpuInfo.HasNvidia) {
+                        hint.textContent = 'NVIDIA GPU detected \u2014 CUDA 12 variant recommended.';
+                        hint.style.color = '#52B54B';
+                    } else if (variant === 'rocm' && gpuInfo.HasAmdGpu) {
+                        hint.textContent = 'AMD GPU detected \u2014 ROCm variant recommended.';
+                        hint.style.color = '#52B54B';
+                    } else if (variant === 'vulkan' && gpuInfo.HasRenderDevice) {
+                        hint.textContent = 'GPU detected \u2014 Vulkan variant ready.';
+                        hint.style.color = '#52B54B';
+                    } else if (variant === 'cpu') {
+                        hint.textContent = gpuInfo.HasNvidia || gpuInfo.HasAmdGpu || gpuInfo.HasRenderDevice
+                            ? 'GPU detected \u2014 consider a GPU variant for faster transcription.'
+                            : 'No GPU detected. CPU variant ready.';
+                        hint.style.color = gpuInfo.HasNvidia || gpuInfo.HasAmdGpu || gpuInfo.HasRenderDevice ? '#CC7B19' : '#52B54B';
+                    } else {
+                        hint.textContent = '';
+                        hint.style.color = '';
+                    }
                 },
 
                 // Full language list — matches DefaultLanguage selector exactly

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -12,8 +12,8 @@
                 <!-- Whisper Engine Management -->
                 <div style="display:flex; align-items:baseline; gap:0.8em;">
                     <h2 style="margin:0;">Whisper Engine</h2>
-                    <a href="https://github.com/GeiserX/whisper-subs#container-library-requirements" target="_blank"
-                       style="font-size:0.85em; opacity:0.7; text-decoration:none;">Setup guide &rarr;</a>
+                    <a href="https://geiserx.github.io/whisper-subs/docs/setup/" target="_blank"
+                       style="font-size:0.85em; color:#52B54B; text-decoration:none;">Setup guide &rarr;</a>
                 </div>
 
                 <div id="engineBinaryPanel" style="background:rgba(0,0,0,0.15); border-radius:6px; padding:1em; margin-bottom:1em;">

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -10,7 +10,11 @@
                 <h1>WhisperSubs</h1>
 
                 <!-- Whisper Engine Management -->
-                <h2>Whisper Engine</h2>
+                <div style="display:flex; align-items:baseline; gap:0.8em;">
+                    <h2 style="margin:0;">Whisper Engine</h2>
+                    <a href="https://github.com/GeiserX/whisper-subs#container-library-requirements" target="_blank"
+                       style="font-size:0.85em; opacity:0.7; text-decoration:none;">Setup guide &rarr;</a>
+                </div>
 
                 <div id="engineBinaryPanel" style="background:rgba(0,0,0,0.15); border-radius:6px; padding:1em; margin-bottom:1em;">
                     <div style="display:flex; align-items:center; gap:0.5em; margin-bottom:0.5em;">

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -12,7 +12,7 @@
                 <!-- Whisper Engine Management -->
                 <div style="display:flex; align-items:baseline; gap:0.8em;">
                     <h2 style="margin:0;">Whisper Engine</h2>
-                    <a href="https://geiserx.github.io/whisper-subs/docs/setup/" target="_blank"
+                    <a href="https://geiserx.github.io/whisper-subs/docs/setup/" target="_blank" rel="noopener noreferrer"
                        style="font-size:0.85em; color:#52B54B; text-decoration:none;">Setup guide &rarr;</a>
                 </div>
 
@@ -625,7 +625,7 @@
                     var gpuInfo = WhisperSubsConfig._gpuInfo;
                     var hint = document.querySelector('#engineGpuHint');
                     var variant = document.querySelector('#engineBinaryVariant').value || 'cpu';
-                    if (!gpuInfo) { hint.textContent = ''; return; }
+                    if (!gpuInfo) { hint.textContent = ''; hint.style.color = ''; return; }
 
                     if (variant === 'cuda12') {
                         if (gpuInfo.HasNvidia && gpuInfo.HasCudaLibrary) {

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.9.0.0</Version>
+    <Version>3.9.1.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>

--- a/docs/setup/index.html
+++ b/docs/setup/index.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>WhisperSubs - Container Setup Guide</title>
+    <style>
+        :root { --bg: #101014; --card: #1a1a22; --border: #2a2a35; --text: #e0e0e8; --muted: #8888a0; --green: #52B54B; --orange: #CC7B19; --purple: #6B4C9A; }
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: var(--bg); color: var(--text); line-height: 1.7; }
+        .container { max-width: 820px; margin: 0 auto; padding: 2em 1.5em 4em; }
+        a { color: var(--green); text-decoration: none; }
+        a:hover { text-decoration: underline; }
+        h1 { font-size: 2em; margin-bottom: 0.2em; }
+        h1 span { color: var(--purple); }
+        .subtitle { color: var(--muted); font-size: 1.05em; margin-bottom: 2em; }
+        h2 { font-size: 1.3em; margin: 2em 0 0.8em; padding-bottom: 0.3em; border-bottom: 1px solid var(--border); }
+        h3 { font-size: 1.1em; margin: 1.5em 0 0.5em; }
+        p, li { color: var(--text); margin-bottom: 0.6em; }
+        ul { padding-left: 1.5em; }
+        table { width: 100%; border-collapse: collapse; margin: 1em 0; }
+        th, td { padding: 0.6em 0.8em; text-align: left; border-bottom: 1px solid var(--border); }
+        th { color: var(--muted); font-size: 0.85em; text-transform: uppercase; letter-spacing: 0.05em; }
+        code { background: rgba(255,255,255,0.06); padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Monaco, Consolas, monospace; }
+        pre { background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 1em 1.2em; overflow-x: auto; margin: 1em 0; }
+        pre code { background: none; padding: 0; font-size: 0.88em; }
+        .card { background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 1.2em; margin: 1em 0; }
+        .card-green { border-left: 3px solid var(--green); }
+        .card-orange { border-left: 3px solid var(--orange); }
+        .badge { display: inline-block; padding: 0.15em 0.5em; border-radius: 4px; font-size: 0.8em; font-weight: 600; }
+        .badge-green { background: rgba(82,181,75,0.15); color: var(--green); }
+        .badge-orange { background: rgba(204,123,25,0.15); color: var(--orange); }
+        .badge-purple { background: rgba(107,76,154,0.15); color: #a88bcc; }
+        .nav { display: flex; gap: 1em; margin-bottom: 2em; flex-wrap: wrap; }
+        .nav a { color: var(--muted); font-size: 0.9em; padding: 0.3em 0.7em; border: 1px solid var(--border); border-radius: 6px; transition: all 0.2s; }
+        .nav a:hover { color: var(--green); border-color: var(--green); text-decoration: none; }
+        .back { color: var(--muted); font-size: 0.9em; margin-bottom: 1.5em; display: inline-block; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <a href="https://github.com/GeiserX/whisper-subs" class="back">&larr; Back to repository</a>
+
+        <h1><span>WhisperSubs</span> Setup Guide</h1>
+        <p class="subtitle">Container library requirements for the built-in binary downloader</p>
+
+        <div class="nav">
+            <a href="#quick-start">Quick Start</a>
+            <a href="#variants">Variant Requirements</a>
+            <a href="#docker-setup">Docker Setup</a>
+            <a href="#troubleshooting">Troubleshooting</a>
+        </div>
+
+        <h2 id="quick-start">Quick Start</h2>
+        <p>WhisperSubs can download whisper-cli binaries directly from the plugin settings page. These pre-built binaries require runtime libraries that may not be included in your Jellyfin container.</p>
+
+        <div class="card card-green">
+            <strong>Running on bare metal?</strong> If Jellyfin runs directly on your system (not in Docker), the required libraries are usually already present. Just select your variant and download &mdash; the plugin will tell you if anything is missing.
+        </div>
+
+        <h2 id="variants">Variant Requirements</h2>
+        <p>Every variant requires <code>libgomp1</code> (the OpenMP threading library). GPU variants need additional libraries.</p>
+
+        <table>
+            <thead>
+                <tr>
+                    <th>Variant</th>
+                    <th>Required Packages</th>
+                    <th>Install Command</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td><span class="badge badge-green">CPU</span></td>
+                    <td><code>libgomp1</code></td>
+                    <td><code>apt install libgomp1</code></td>
+                </tr>
+                <tr>
+                    <td><span class="badge badge-purple">Vulkan</span></td>
+                    <td><code>libgomp1</code> <code>libvulkan1</code> <code>mesa-vulkan-drivers</code></td>
+                    <td><code>apt install libgomp1 libvulkan1 mesa-vulkan-drivers</code></td>
+                </tr>
+                <tr>
+                    <td><span class="badge badge-purple">CUDA 12</span></td>
+                    <td><code>libgomp1</code> + NVIDIA Container Toolkit on host</td>
+                    <td><a href="https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html">NVIDIA docs</a></td>
+                </tr>
+                <tr>
+                    <td><span class="badge badge-purple">ROCm</span></td>
+                    <td><code>libgomp1</code> + ROCm runtime</td>
+                    <td><a href="https://rocm.docs.amd.com/">ROCm docs</a></td>
+                </tr>
+            </tbody>
+        </table>
+
+        <h2 id="docker-setup">Docker Setup</h2>
+
+        <h3>CPU Variant (simplest)</h3>
+        <p>Add to your container entrypoint or run once inside the container:</p>
+        <pre><code>apt-get update -qq && apt-get install -y -qq --no-install-recommends libgomp1 && rm -rf /var/lib/apt/lists/*</code></pre>
+
+        <h3>Vulkan Variant (Intel / AMD GPU)</h3>
+        <p>Pass the GPU device and install Vulkan libraries:</p>
+        <pre><code># docker-compose.yml
+services:
+  jellyfin:
+    image: jellyfin/jellyfin
+    devices:
+      - /dev/dri:/dev/dri</code></pre>
+        <p>Then inside the container:</p>
+        <pre><code>apt-get update -qq && \
+apt-get install -y -qq --no-install-recommends \
+  libgomp1 libvulkan1 mesa-vulkan-drivers && \
+rm -rf /var/lib/apt/lists/*</code></pre>
+
+        <h3>Persistent Install via Entrypoint</h3>
+        <p>Libraries installed with <code>apt</code> inside a running container are lost on restart. To make them persistent, override the entrypoint:</p>
+        <pre><code># docker-compose.yml
+services:
+  jellyfin:
+    image: jellyfin/jellyfin
+    entrypoint:
+      - /bin/bash
+      - -c
+      - |
+        dpkg -s libgomp1 > /dev/null 2>&1 || \
+          (apt-get update -qq && \
+           apt-get install -y -qq --no-install-recommends \
+             libgomp1 > /dev/null 2>&1 && \
+           rm -rf /var/lib/apt/lists/*)
+        exec /jellyfin/jellyfin
+    devices:
+      - /dev/dri:/dev/dri   # only if using GPU variants</code></pre>
+
+        <div class="card card-orange">
+            <strong>Unraid users:</strong> You can add the <code>apt install</code> command to the container's <strong>Post Arguments</strong> or use the <strong>User Scripts</strong> plugin to run it on container start.
+        </div>
+
+        <h2 id="troubleshooting">Troubleshooting</h2>
+
+        <h3>"Missing libgomp.so.1"</h3>
+        <p>All whisper-cli variants use OpenMP for threading. Install it with:</p>
+        <pre><code>apt install libgomp1</code></pre>
+
+        <h3>"Missing libvulkan.so.1"</h3>
+        <p>The Vulkan variant needs the Vulkan loader. Jellyfin's bundled FFmpeg includes its own copy, but whisper-cli needs the system one:</p>
+        <pre><code>apt install libvulkan1 mesa-vulkan-drivers</code></pre>
+
+        <h3>Binary downloads return 404</h3>
+        <p>The download URL uses the plugin version to find the matching GitHub release. Make sure the plugin version matches an existing <a href="https://github.com/GeiserX/whisper-subs/releases">release</a>.</p>
+
+        <h3>Verify GPU inside Docker</h3>
+        <pre><code># Check Vulkan
+docker exec jellyfin apt-get update -qq && \
+  docker exec jellyfin apt-get install -y -qq vulkan-tools && \
+  docker exec jellyfin vulkaninfo --summary
+
+# Check NVIDIA
+docker exec jellyfin nvidia-smi</code></pre>
+
+        <hr style="border:none; border-top:1px solid var(--border); margin:3em 0 1.5em;">
+        <p style="color:var(--muted); font-size:0.85em;">
+            <a href="https://github.com/GeiserX/whisper-subs">WhisperSubs</a> &mdash;
+            Automated subtitle generation for Jellyfin using local AI models.
+        </p>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Binary validation error message is now variant-aware — when a CPU binary fails (e.g. missing `libgomp.so.1`), it no longer suggests "Try the CPU variant" since that's what already failed
- Known libraries get specific install hints (`libgomp1`, `libvulkan1`, CUDA toolkit, ROCm runtime)
- GPU variant failures still suggest CPU as a fallback alongside the install command
- Version bump to 3.9.1.0

## Test plan
- [ ] Download Vulkan binary on a system without `libvulkan.so.1` → should suggest "Try the CPU variant, or install the library (e.g. 'apt install libvulkan1')"
- [ ] Download CPU binary on a system without `libgomp.so.1` → should suggest "Install it in your container (e.g. 'apt install libgomp1')" (no "Try CPU" suggestion)
- [ ] Download CPU binary on a system with all deps → should succeed normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Container Library Requirements section detailing required runtime libraries per variant and an apt-get install example; notes that libgomp1 is required for all variants and the setup page will warn if libraries are missing before download.

* **New Features**
  * Enhanced system library detection to include OpenMP/runtime checks.
  * Configuration page now updates guidance when you change the selected GPU variant.

* **Bug Fixes**
  * More accurate detection and clearer, variant-aware installation hints for missing libraries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->