### PR TITLE
feat: Generate Subtitles button on library detail pages

### DIFF
--- a/Api/SubtitleController.cs
+++ b/Api/SubtitleController.cs
@@ -184,6 +184,82 @@ namespace WhisperSubs.Api
         }
 
         /// <summary>
+        /// Enqueues subtitle generation for all child items of a container (Series, Season, MusicAlbum).
+        /// For leaf items (Movie, Episode, Audio), behaves like the single-item endpoint.
+        /// </summary>
+        [HttpPost("Items/{itemId}/GenerateAll")]
+        public ActionResult GenerateAllSubtitles(
+            [FromRoute] string itemId,
+            [FromQuery] string? language = null)
+        {
+            try
+            {
+                var parent = _libraryManager.GetItemById(Guid.Parse(itemId));
+                if (parent == null)
+                {
+                    return NotFound(new { error = "Item not found" });
+                }
+
+                var config = Plugin.Instance.Configuration;
+                var targetLanguage = language ?? config.DefaultLanguage;
+
+                // Resolve leaf items (Video / Audio) from the container
+                var typeStr = config.EnableLyricsGeneration ? "Movie,Episode,Audio" : "Movie,Episode";
+                var includeTypes = GetBaseItemKinds(typeStr);
+                var children = _libraryManager.GetItemList(new InternalItemsQuery
+                {
+                    ParentId = parent.Id,
+                    IncludeItemTypes = includeTypes,
+                    Recursive = true
+                });
+
+                // If this IS a leaf item itself, include it directly
+                if (children.Count == 0 && (parent is Video || (parent is MediaBrowser.Controller.Entities.Audio.Audio && config.EnableLyricsGeneration)))
+                {
+                    children = new List<BaseItem> { parent };
+                }
+
+                if (children.Count == 0)
+                {
+                    return BadRequest(new { error = "No supported media items found under this item." });
+                }
+
+                var queue = SubtitleQueueService.Instance;
+                foreach (var child in children)
+                {
+                    queue.Enqueue(child, targetLanguage);
+                }
+
+                _logger.LogInformation(
+                    "Queued {Count} items for subtitle generation under {ParentName} [{Language}]",
+                    children.Count, parent.Name, targetLanguage);
+
+                // Ensure the background drain worker is running
+                var manager = GetSubtitleManager();
+                var provider = new WhisperProvider(
+                    _loggerFactory.CreateLogger<WhisperProvider>(),
+                    config.WhisperModelPath,
+                    config.WhisperBinaryPath,
+                    config.WhisperThreadCount);
+                queue.EnsureDraining(manager, provider, _logger, CancellationToken.None);
+
+                return Accepted(new
+                {
+                    message = $"Queued {children.Count} item(s) for subtitle generation",
+                    parent = parent.Name,
+                    count = children.Count,
+                    language = targetLanguage,
+                    queueSize = queue.PriorityCount
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error queuing batch generation for item {ItemId}", itemId);
+                return StatusCode(500, new { error = ex.Message });
+            }
+        }
+
+        /// <summary>
         /// Gets the current queue status.
         /// </summary>
         [HttpGet("Queue")]

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -1,17 +1,22 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.RegularExpressions;
 using WhisperSubs.Configuration;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Plugins;
 using MediaBrowser.Model.Plugins;
 using MediaBrowser.Model.Serialization;
+using Microsoft.Extensions.Logging;
 
 namespace WhisperSubs
 {
     public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     {
         private readonly IApplicationPaths _appPaths;
+        private readonly ILogger<Plugin> _logger;
+
+        private const string ScriptTag = "<script src=\"configurationpage?name=whisperSubs.js\"></script>";
 
         public override string Name => "WhisperSubs";
         public override Guid Id => Guid.Parse("97124bd9-c8cd-4a53-a213-e593aa3fef52"); // Using a static GUID
@@ -19,15 +24,20 @@ namespace WhisperSubs
         // Store data outside /plugins/ to avoid Jellyfin treating the data dir as a plugin folder
         public new string DataFolderPath => Path.Combine(_appPaths.DataPath, "WhisperSubs");
 
-        public Plugin(IApplicationPaths applicationPaths, IXmlSerializer xmlSerializer)
+        public Plugin(
+            IApplicationPaths applicationPaths,
+            IXmlSerializer xmlSerializer,
+            ILogger<Plugin> logger)
             : base(applicationPaths, xmlSerializer)
         {
             _appPaths = applicationPaths;
+            _logger = logger;
             Instance = this;
+
+            InjectClientScript();
         }
 
-        
-        public static Plugin Instance { get; private set; } = null!;    
+        public static Plugin Instance { get; private set; } = null!;
 
         public IEnumerable<PluginPageInfo> GetPages()
         {
@@ -38,8 +48,53 @@ namespace WhisperSubs
                     Name = this.Name,
                     EmbeddedResourcePath = GetType().Namespace + ".Web.configPage.html",
                     EnableInMainMenu = true
+                },
+                new PluginPageInfo
+                {
+                    Name = "whisperSubs.js",
+                    EmbeddedResourcePath = GetType().Namespace + ".Web.whisperSubs.js"
                 }
             };
+        }
+
+        /// <summary>
+        /// Injects a script tag into Jellyfin's index.html so our JS runs on every page.
+        /// Follows the same pattern used by intro-skipper and JellyScrub plugins.
+        /// </summary>
+        private void InjectClientScript()
+        {
+            try
+            {
+                var indexPath = Path.Combine(_appPaths.WebPath, "index.html");
+                if (!File.Exists(indexPath))
+                {
+                    _logger.LogDebug("WhisperSubs: index.html not found at {Path}, skipping script injection", indexPath);
+                    return;
+                }
+
+                var contents = File.ReadAllText(indexPath);
+                if (contents.Contains(ScriptTag, StringComparison.OrdinalIgnoreCase))
+                {
+                    _logger.LogDebug("WhisperSubs: script tag already present in index.html");
+                    return;
+                }
+
+                // Insert before </head>
+                var headEnd = new Regex("</head>", RegexOptions.IgnoreCase);
+                if (!headEnd.IsMatch(contents))
+                {
+                    _logger.LogWarning("WhisperSubs: could not find </head> in index.html, skipping script injection");
+                    return;
+                }
+
+                contents = headEnd.Replace(contents, ScriptTag + "\n</head>", 1);
+                File.WriteAllText(indexPath, contents);
+                _logger.LogInformation("WhisperSubs: injected client script into index.html");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "WhisperSubs: failed to inject client script into index.html");
+            }
         }
     }
 }

--- a/Providers/WhisperProvider.cs
+++ b/Providers/WhisperProvider.cs
@@ -487,7 +487,20 @@ namespace WhisperSubs.Providers
                 return null;
             }
 
-            // No configured path — discover from PATH via probing.
+            // No configured path — check the default auto-download location first.
+            var dataDir = Plugin.Instance?.DataFolderPath;
+            if (!string.IsNullOrEmpty(dataDir))
+            {
+                var autoDownloaded = Path.Combine(dataDir, "whisper", "whisper-cli");
+                if (File.Exists(autoDownloaded))
+                {
+                    _logger.LogInformation("Found auto-downloaded Whisper executable: {Executable}", autoDownloaded);
+                    _resolvedExecutable = autoDownloaded;
+                    return _resolvedExecutable;
+                }
+            }
+
+            // Fallback: discover from PATH via probing.
             // "main" is intentionally excluded: it is a common binary name on Windows
             // (VS build tools, Git, etc.) and could resolve to the wrong executable.
             var candidates = new[] { "whisper-cli", "whisper" };

--- a/Web/whisperSubs.js
+++ b/Web/whisperSubs.js
@@ -1,180 +1,154 @@
-// WhisperSubs -- library detail page integration
-// Injects "Generate Subtitles" buttons on item detail pages (admin only).
+// WhisperSubs -- context menu integration
+// Adds "Generate Subtitles" to the three-dot menu on item detail pages and cards (admin only).
 // Loaded via script injection into Jellyfin's index.html.
 (function () {
     'use strict';
 
-    var PLUGIN_ID = '97124bd9-c8cd-4a53-a213-e593aa3fef52';
-    var BUTTON_CLASS = 'btnWhisperSubs';
-
-    // Item types that support batch generation (enqueue all children)
-    var BATCH_TYPES = ['Series', 'Season', 'MusicAlbum', 'BoxSet', 'Playlist'];
-    // Item types that support single-item generation
-    var LEAF_TYPES = ['Movie', 'Episode', 'Audio'];
-
-    var isAdmin = null; // cached after first check
+    var isAdmin = null;
+    var pendingItemId = null;
+    var menuObserver = null;
 
     function checkAdmin() {
-        if (isAdmin !== null) {
-            return Promise.resolve(isAdmin);
-        }
+        if (isAdmin !== null) return Promise.resolve(isAdmin);
         return ApiClient.getCurrentUser().then(function (user) {
             isAdmin = user && user.Policy && user.Policy.IsAdministrator;
             return isAdmin;
-        }).catch(function () {
-            return false;
-        });
+        }).catch(function () { return false; });
     }
 
     function showToast(message) {
-        if (typeof Dashboard !== 'undefined' && Dashboard.alert) {
-            Dashboard.alert(message);
-        } else {
-            // Fallback: use Jellyfin's require-based toast if available
-            try {
-                require(['toast'], function (toast) { toast(message); });
-            } catch (e) {
-                console.log('[WhisperSubs] ' + message);
-            }
+        try { require(['toast'], function (toast) { toast(message); }); }
+        catch (e) { console.log('[WhisperSubs] ' + message); }
+    }
+
+    function closeDialog(el) {
+        var dialog = el.closest('dialog');
+        if (dialog && dialog.close) {
+            dialog.close();
+            return;
+        }
+        var btn = el.closest('.actionSheet');
+        if (btn) {
+            var cancel = btn.querySelector('.btnCloseActionSheet');
+            if (cancel) cancel.click();
         }
     }
 
-    function generateSingle(itemId) {
-        var url = ApiClient.getUrl('Plugins/WhisperSubs/Items/' + itemId + '/Generate', { language: 'auto' });
-        return ApiClient.ajax({ type: 'POST', url: url });
-    }
-
-    function generateAll(itemId) {
+    function generateSubtitles(itemId) {
         var url = ApiClient.getUrl('Plugins/WhisperSubs/Items/' + itemId + '/GenerateAll', { language: 'auto' });
         return ApiClient.ajax({ type: 'POST', url: url });
     }
 
-    function onButtonClick(itemId, itemType, itemName, button) {
-        button.disabled = true;
-        var icon = button.querySelector('.detailButton-icon');
-        if (icon) icon.textContent = 'hourglass_empty';
+    function createMenuItem(itemId) {
+        // Match Jellyfin's exact action sheet button structure
+        var btn = document.createElement('button');
+        btn.setAttribute('is', 'emby-button');
+        btn.type = 'button';
+        btn.className = 'listItem listItem-button actionSheetMenuItem btnWhisperSubs';
+        btn.setAttribute('data-id', 'whispersubs');
 
-        var isBatch = BATCH_TYPES.indexOf(itemType) !== -1;
-        var promise = isBatch ? generateAll(itemId) : generateSingle(itemId);
-
-        promise.then(function (response) {
-            var data = typeof response === 'string' ? JSON.parse(response) : response;
-            var msg = isBatch
-                ? 'WhisperSubs: Queued ' + (data.count || 'all') + ' item(s) for "' + itemName + '"'
-                : 'WhisperSubs: Queued "' + itemName + '" for subtitle generation';
-            showToast(msg);
-            if (icon) icon.textContent = 'check';
-            setTimeout(function () {
-                if (icon) icon.textContent = 'subtitles';
-                button.disabled = false;
-            }, 3000);
-        }).catch(function (err) {
-            console.error('[WhisperSubs] Generation failed:', err);
-            showToast('WhisperSubs: Failed to queue generation');
-            if (icon) icon.textContent = 'subtitles';
-            button.disabled = false;
-        });
-    }
-
-    function createButton(itemId, itemType, itemName) {
-        var isBatch = BATCH_TYPES.indexOf(itemType) !== -1;
-        var label = isBatch ? 'Generate All Subtitles' : 'Generate Subtitles';
-
-        var button = document.createElement('button');
-        button.setAttribute('is', 'emby-button');
-        button.type = 'button';
-        button.className = 'button-flat ' + BUTTON_CLASS + ' detailButton emby-button';
-        button.title = label;
-
-        // Match Jellyfin's detail button structure
-        button.innerHTML =
-            '<div class="detailButton-content">' +
-                '<span class="material-icons detailButton-icon subtitles" aria-hidden="true"></span>' +
-                '<span class="detailButton-text">' + label + '</span>' +
+        btn.innerHTML =
+            '<span class="actionsheetMenuItemIcon listItemIcon listItemIcon-transparent material-icons subtitles" aria-hidden="true"></span>' +
+            '<div class="listItemBody actionsheetListItemBody">' +
+                '<div class="listItemBodyText actionSheetItemText">Generate Subtitles</div>' +
             '</div>';
 
-        button.addEventListener('click', function () {
-            onButtonClick(itemId, itemType, itemName, button);
-        });
-
-        return button;
-    }
-
-    function injectButton(itemId, itemType, itemName) {
-        // Find the detail buttons container
-        var container = document.querySelector('.mainDetailButtons');
-        if (!container) return;
-
-        // Don't inject twice
-        if (container.querySelector('.' + BUTTON_CLASS)) return;
-
-        var button = createButton(itemId, itemType, itemName);
-
-        // Insert before the "more commands" (three-dot) button if present
-        var moreBtn = container.querySelector('.btnMoreCommands');
-        if (moreBtn) {
-            container.insertBefore(button, moreBtn);
-        } else {
-            container.appendChild(button);
-        }
-    }
-
-    function waitForElement(selector, timeout) {
-        timeout = timeout || 5000;
-        return new Promise(function (resolve) {
-            var el = document.querySelector(selector);
-            if (el) return resolve(el);
-
-            var observer = new MutationObserver(function () {
-                var found = document.querySelector(selector);
-                if (found) {
-                    observer.disconnect();
-                    resolve(found);
-                }
+        btn.addEventListener('click', function () {
+            closeDialog(btn);
+            showToast('WhisperSubs: Queuing...');
+            generateSubtitles(itemId).then(function (response) {
+                var data = typeof response === 'string' ? JSON.parse(response) : response;
+                var count = data.count || 1;
+                showToast('WhisperSubs: Queued ' + count + ' item(s) for subtitle generation');
+            }).catch(function () {
+                showToast('WhisperSubs: Failed to queue generation');
             });
-            observer.observe(document.body, { childList: true, subtree: true });
-            setTimeout(function () {
-                observer.disconnect();
-                resolve(null);
-            }, timeout);
         });
+
+        return btn;
     }
 
-    function onViewShow() {
-        var hash = window.location.hash || '';
-        // Item detail pages: #!/details?id=xxx or #/details?id=xxx
-        if (hash.indexOf('details') === -1) return;
-
-        var qmark = hash.indexOf('?');
-        if (qmark === -1) return;
-
-        var params = new URLSearchParams(hash.substring(qmark + 1));
-        var itemId = params.get('id');
-        if (!itemId) return;
+    function injectIntoActionSheet(sheet) {
+        if (!pendingItemId) return;
+        if (sheet.querySelector('.btnWhisperSubs')) return;
 
         checkAdmin().then(function (admin) {
             if (!admin) return;
 
-            // Fetch item info to know the type
-            ApiClient.getItem(ApiClient.getCurrentUserId(), itemId).then(function (item) {
-                if (!item || !item.Type) return;
+            var scroller = sheet.querySelector('.actionSheetScroller') || sheet;
+            var cancelDiv = scroller.querySelector('.buttons');
+            var menuItem = createMenuItem(pendingItemId);
 
-                var supported = BATCH_TYPES.indexOf(item.Type) !== -1 || LEAF_TYPES.indexOf(item.Type) !== -1;
-                if (!supported) return;
-
-                waitForElement('.mainDetailButtons').then(function (container) {
-                    if (container) {
-                        injectButton(itemId, item.Type, item.Name);
-                    }
-                });
-            }).catch(function (err) {
-                console.debug('[WhisperSubs] Could not fetch item:', err);
-            });
+            if (cancelDiv) {
+                scroller.insertBefore(menuItem, cancelDiv);
+            } else {
+                scroller.appendChild(menuItem);
+            }
         });
     }
 
-    // Register the viewshow listener
-    document.addEventListener('viewshow', onViewShow);
+    function watchForActionSheet() {
+        // Disconnect any previous observer
+        if (menuObserver) menuObserver.disconnect();
 
-    console.debug('[WhisperSubs] Library integration loaded');
+        menuObserver = new MutationObserver(function (mutations) {
+            for (var i = 0; i < mutations.length; i++) {
+                var added = mutations[i].addedNodes;
+                for (var j = 0; j < added.length; j++) {
+                    var node = added[j];
+                    if (node.nodeType !== 1) continue;
+
+                    var sheet = null;
+                    if (node.classList && node.classList.contains('actionSheet')) {
+                        sheet = node;
+                    } else if (node.querySelector) {
+                        sheet = node.querySelector('.actionSheet');
+                    }
+
+                    if (sheet) {
+                        menuObserver.disconnect();
+                        menuObserver = null;
+                        injectIntoActionSheet(sheet);
+                        return;
+                    }
+                }
+            }
+        });
+
+        menuObserver.observe(document.body, { childList: true, subtree: true });
+
+        // Auto-disconnect after 3 seconds
+        setTimeout(function () {
+            if (menuObserver) {
+                menuObserver.disconnect();
+                menuObserver = null;
+            }
+        }, 3000);
+    }
+
+    // Capture clicks on three-dot menu triggers everywhere
+    document.addEventListener('click', function (e) {
+        var trigger = e.target.closest('.btnMoreCommands, [data-action="menu"]');
+        if (!trigger) return;
+
+        // Try to get item ID from the nearest card/item element
+        var card = trigger.closest('[data-id]');
+        if (card) {
+            pendingItemId = card.getAttribute('data-id');
+        } else {
+            // Detail page fallback: extract from URL hash
+            var hash = window.location.hash || '';
+            var q = hash.indexOf('?');
+            if (q !== -1) {
+                var params = new URLSearchParams(hash.substring(q + 1));
+                pendingItemId = params.get('id');
+            }
+        }
+
+        if (pendingItemId) {
+            watchForActionSheet();
+        }
+    }, true); // capture phase to run before Jellyfin's handler
+
+    console.debug('[WhisperSubs] Context menu integration loaded');
 })();

--- a/Web/whisperSubs.js
+++ b/Web/whisperSubs.js
@@ -1,0 +1,180 @@
+// WhisperSubs -- library detail page integration
+// Injects "Generate Subtitles" buttons on item detail pages (admin only).
+// Loaded via script injection into Jellyfin's index.html.
+(function () {
+    'use strict';
+
+    var PLUGIN_ID = '97124bd9-c8cd-4a53-a213-e593aa3fef52';
+    var BUTTON_CLASS = 'btnWhisperSubs';
+
+    // Item types that support batch generation (enqueue all children)
+    var BATCH_TYPES = ['Series', 'Season', 'MusicAlbum', 'BoxSet', 'Playlist'];
+    // Item types that support single-item generation
+    var LEAF_TYPES = ['Movie', 'Episode', 'Audio'];
+
+    var isAdmin = null; // cached after first check
+
+    function checkAdmin() {
+        if (isAdmin !== null) {
+            return Promise.resolve(isAdmin);
+        }
+        return ApiClient.getCurrentUser().then(function (user) {
+            isAdmin = user && user.Policy && user.Policy.IsAdministrator;
+            return isAdmin;
+        }).catch(function () {
+            return false;
+        });
+    }
+
+    function showToast(message) {
+        if (typeof Dashboard !== 'undefined' && Dashboard.alert) {
+            Dashboard.alert(message);
+        } else {
+            // Fallback: use Jellyfin's require-based toast if available
+            try {
+                require(['toast'], function (toast) { toast(message); });
+            } catch (e) {
+                console.log('[WhisperSubs] ' + message);
+            }
+        }
+    }
+
+    function generateSingle(itemId) {
+        var url = ApiClient.getUrl('Plugins/WhisperSubs/Items/' + itemId + '/Generate', { language: 'auto' });
+        return ApiClient.ajax({ type: 'POST', url: url });
+    }
+
+    function generateAll(itemId) {
+        var url = ApiClient.getUrl('Plugins/WhisperSubs/Items/' + itemId + '/GenerateAll', { language: 'auto' });
+        return ApiClient.ajax({ type: 'POST', url: url });
+    }
+
+    function onButtonClick(itemId, itemType, itemName, button) {
+        button.disabled = true;
+        var icon = button.querySelector('.detailButton-icon');
+        if (icon) icon.textContent = 'hourglass_empty';
+
+        var isBatch = BATCH_TYPES.indexOf(itemType) !== -1;
+        var promise = isBatch ? generateAll(itemId) : generateSingle(itemId);
+
+        promise.then(function (response) {
+            var data = typeof response === 'string' ? JSON.parse(response) : response;
+            var msg = isBatch
+                ? 'WhisperSubs: Queued ' + (data.count || 'all') + ' item(s) for "' + itemName + '"'
+                : 'WhisperSubs: Queued "' + itemName + '" for subtitle generation';
+            showToast(msg);
+            if (icon) icon.textContent = 'check';
+            setTimeout(function () {
+                if (icon) icon.textContent = 'subtitles';
+                button.disabled = false;
+            }, 3000);
+        }).catch(function (err) {
+            console.error('[WhisperSubs] Generation failed:', err);
+            showToast('WhisperSubs: Failed to queue generation');
+            if (icon) icon.textContent = 'subtitles';
+            button.disabled = false;
+        });
+    }
+
+    function createButton(itemId, itemType, itemName) {
+        var isBatch = BATCH_TYPES.indexOf(itemType) !== -1;
+        var label = isBatch ? 'Generate All Subtitles' : 'Generate Subtitles';
+
+        var button = document.createElement('button');
+        button.setAttribute('is', 'emby-button');
+        button.type = 'button';
+        button.className = 'button-flat ' + BUTTON_CLASS + ' detailButton emby-button';
+        button.title = label;
+
+        // Match Jellyfin's detail button structure
+        button.innerHTML =
+            '<div class="detailButton-content">' +
+                '<span class="material-icons detailButton-icon subtitles" aria-hidden="true"></span>' +
+                '<span class="detailButton-text">' + label + '</span>' +
+            '</div>';
+
+        button.addEventListener('click', function () {
+            onButtonClick(itemId, itemType, itemName, button);
+        });
+
+        return button;
+    }
+
+    function injectButton(itemId, itemType, itemName) {
+        // Find the detail buttons container
+        var container = document.querySelector('.mainDetailButtons');
+        if (!container) return;
+
+        // Don't inject twice
+        if (container.querySelector('.' + BUTTON_CLASS)) return;
+
+        var button = createButton(itemId, itemType, itemName);
+
+        // Insert before the "more commands" (three-dot) button if present
+        var moreBtn = container.querySelector('.btnMoreCommands');
+        if (moreBtn) {
+            container.insertBefore(button, moreBtn);
+        } else {
+            container.appendChild(button);
+        }
+    }
+
+    function waitForElement(selector, timeout) {
+        timeout = timeout || 5000;
+        return new Promise(function (resolve) {
+            var el = document.querySelector(selector);
+            if (el) return resolve(el);
+
+            var observer = new MutationObserver(function () {
+                var found = document.querySelector(selector);
+                if (found) {
+                    observer.disconnect();
+                    resolve(found);
+                }
+            });
+            observer.observe(document.body, { childList: true, subtree: true });
+            setTimeout(function () {
+                observer.disconnect();
+                resolve(null);
+            }, timeout);
+        });
+    }
+
+    function onViewShow() {
+        var hash = window.location.hash || '';
+        // Item detail pages: #!/details?id=xxx or #/details?id=xxx
+        if (hash.indexOf('details') === -1) return;
+
+        var qmark = hash.indexOf('?');
+        if (qmark === -1) return;
+
+        var params = new URLSearchParams(hash.substring(qmark + 1));
+        var itemId = params.get('id');
+        if (!itemId) return;
+
+        checkAdmin().then(function (admin) {
+            if (!admin) return;
+
+            // Fetch item info to know the type
+            ApiClient.getItem(ApiClient.getCurrentUserId(), itemId).then(function (item) {
+                if (!item || !item.Type) return;
+
+                var supported = BATCH_TYPES.indexOf(item.Type) !== -1 || LEAF_TYPES.indexOf(item.Type) !== -1;
+                if (!supported) return;
+
+                waitForElement('.mainDetailButtons').then(function (container) {
+                    if (container) {
+                        injectButton(itemId, item.Type, item.Name);
+                    }
+                });
+            }).catch(function (err) {
+                console.debug('[WhisperSubs] Could not fetch item:', err);
+            });
+        });
+    }
+
+    // Register the viewshow listener
+    document.addEventListener('viewshow', onViewShow);
+
+    console.debug('[WhisperSubs] Library integration loaded');
+})();

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -20,7 +20,9 @@
 
   <ItemGroup>
     <None Remove="Web\configPage.html" />
+    <None Remove="Web\whisperSubs.js" />
     <EmbeddedResource Include="Web\configPage.html" />
+    <EmbeddedResource Include="Web\whisperSubs.js" />
   </ItemGroup>
 
   <ItemGroup>

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.9.1.0</Version>
+    <Version>3.10.0.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
## Summary

Adds a **Generate Subtitles** button directly on Jellyfin item detail pages (admin-only), so users don't have to navigate to the plugin settings to trigger generation.

- **Single items** (Movie, Episode): button calls the existing `POST /Items/{id}/Generate` endpoint
- **Containers** (Series, Season, BoxSet): button calls a new `POST /Items/{id}/GenerateAll` endpoint that resolves all child episodes and enqueues them in batch
- Uses the same script injection pattern as [intro-skipper](https://github.com/ConfusedPolarBear/intro-skipper) and [JellyScrub](https://github.com/nicknsy/jellyscrub) — injects a `<script>` tag into Jellyfin's `index.html` at plugin startup
- Button renders in the `.mainDetailButtons` bar, before the three-dot "more commands" menu
- Admin check via `ApiClient.getCurrentUser()` — non-admin users see nothing

## Changes

| File | Change |
|---|---|
| `Api/SubtitleController.cs` | New `POST /Items/{id}/GenerateAll` batch endpoint |
| `Plugin.cs` | Script injection into `index.html` + JS registered in `IHasWebPages` |
| `Web/whisperSubs.js` | Client-side JS: `viewshow` listener, button injection, API calls |
| `WhisperSubs.csproj` | Embed `whisperSubs.js` as resource |

## Test plan

- [x] Build succeeds with 0 warnings
- [x] Script tag injected into `index.html` on startup (confirmed in logs)
- [x] JS served at `configurationpage?name=whisperSubs.js` (HTTP 200)
- [x] `GenerateAll` endpoint works on leaf items (falls back to single)
- [ ] Verify button renders on Movie detail page in browser
- [ ] Verify button renders on Series detail page in browser
- [ ] Verify non-admin user does NOT see the button
- [ ] Verify toast notification after clicking

Closes #22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added bulk subtitle and lyrics generation for all items within a container via new API endpoint.
  * Integrated "Generate Subtitles" action button in item menus for quick access (admin-only).
  * Supports configurable target language with automatic detection option.
  * Returns queued item count on successful generation request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->