### PR TITLE
feat: support Home Videos library + English translation

### DIFF
--- a/Api/SubtitleController.cs
+++ b/Api/SubtitleController.cs
@@ -89,7 +89,7 @@ namespace WhisperSubs.Api
                 }
 
                 var config = Plugin.Instance.Configuration;
-                var typeStr = config.EnableLyricsGeneration ? "Movie,Episode,Audio" : "Movie,Episode";
+                var typeStr = config.EnableLyricsGeneration ? "Movie,Episode,Video,Audio" : "Movie,Episode,Video";
                 var includeTypes = GetBaseItemKinds(typeStr);
                 var allItems = _libraryManager.GetItemList(new MediaBrowser.Controller.Entities.InternalItemsQuery
                 {
@@ -204,7 +204,7 @@ namespace WhisperSubs.Api
                 var targetLanguage = language ?? config.DefaultLanguage;
 
                 // Resolve leaf items (Video / Audio) from the container
-                var typeStr = config.EnableLyricsGeneration ? "Movie,Episode,Audio" : "Movie,Episode";
+                var typeStr = config.EnableLyricsGeneration ? "Movie,Episode,Video,Audio" : "Movie,Episode,Video";
                 var includeTypes = GetBaseItemKinds(typeStr);
                 var children = _libraryManager.GetItemList(new InternalItemsQuery
                 {

--- a/Configuration/PluginConfiguration.cs
+++ b/Configuration/PluginConfiguration.cs
@@ -30,6 +30,13 @@ namespace WhisperSubs.Configuration
         public bool EnableLyricsGeneration { get; set; } = false;
 
         /// <summary>
+        /// When enabled, generates English subtitles via whisper's --translate flag
+        /// for media that lacks an English audio track.
+        /// Only applies when SubtitleMode includes Full subtitles.
+        /// </summary>
+        public bool EnableTranslation { get; set; } = false;
+
+        /// <summary>
         /// Number of threads for whisper.cpp inference. 0 = whisper default (4).
         /// Higher values use more CPU cores for faster transcription.
         /// </summary>

--- a/Controller/SubtitleManager.cs
+++ b/Controller/SubtitleManager.cs
@@ -61,6 +61,14 @@ namespace WhisperSubs.Controller
                 }
             }
 
+            // Translation: generate English subs if enabled and no English audio present
+            var config = Plugin.Instance?.Configuration;
+            if (config?.EnableTranslation == true
+                && (subtitleMode == SubtitleMode.Full || subtitleMode == SubtitleMode.FullAndForced))
+            {
+                await GenerateTranslatedSubtitleAsync(item, provider, mediaPath, languages, cancellationToken);
+            }
+
             await item.RefreshMetadata(cancellationToken);
         }
 
@@ -130,6 +138,98 @@ namespace WhisperSubs.Controller
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error generating full subtitle for {ItemName} [{Language}], continuing with next language", item.Name, lang);
+            }
+            finally
+            {
+                if (File.Exists(tempAudioPath))
+                {
+                    try { File.Delete(tempAudioPath); }
+                    catch (Exception ex) { _logger.LogWarning(ex, "Failed to delete temp audio: {Path}", tempAudioPath); }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Generates English translated subtitles using whisper's --translate flag.
+        /// Only runs when: no English audio stream detected, no existing .en.translated.srt,
+        /// and (as fallback) no existing English subtitle files when FFprobe couldn't detect languages.
+        /// </summary>
+        private async Task GenerateTranslatedSubtitleAsync(
+            BaseItem item, ISubtitleProvider provider, string mediaPath,
+            List<string> resolvedLanguages, CancellationToken cancellationToken)
+        {
+            // Skip if English audio is present
+            if (resolvedLanguages.Any(l => string.Equals(l, "en", StringComparison.OrdinalIgnoreCase)))
+            {
+                _logger.LogInformation("Skipping translation for {ItemName}: English audio stream present", item.Name);
+                return;
+            }
+
+            var translatedSrtPath = Path.ChangeExtension(mediaPath, ".en.translated.srt");
+
+            // Skip if translated subs already exist
+            if (File.Exists(translatedSrtPath))
+            {
+                _logger.LogInformation("Translated subtitle already exists for {ItemName}, skipping", item.Name);
+                return;
+            }
+
+            // Fallback: if FFprobe couldn't detect languages (resolved to "auto"),
+            // check if English subtitles already exist — skip if they do
+            if (resolvedLanguages.Count == 1
+                && string.Equals(resolvedLanguages[0], "auto", StringComparison.OrdinalIgnoreCase))
+            {
+                var dir = Path.GetDirectoryName(mediaPath);
+                var baseName = Path.GetFileNameWithoutExtension(mediaPath);
+                if (dir != null)
+                {
+                    var subtitleExts = new[] { ".srt", ".ass", ".ssa", ".sub", ".vtt" };
+                    var hasEnglishSubs = Directory.GetFiles(dir, baseName + ".*")
+                        .Any(f =>
+                        {
+                            var name = Path.GetFileName(f).ToLowerInvariant();
+                            return subtitleExts.Any(ext => name.EndsWith(ext))
+                                && (name.Contains(".en.") || name.Contains(".eng.") || name.Contains(".english."));
+                        });
+
+                    if (hasEnglishSubs)
+                    {
+                        _logger.LogInformation(
+                            "Skipping translation for {ItemName}: English subtitles already exist (FFprobe language fallback)",
+                            item.Name);
+                        return;
+                    }
+                }
+            }
+
+            // Determine source language: first non-English language, or "auto"
+            var sourceLanguage = resolvedLanguages
+                .FirstOrDefault(l => !string.Equals(l, "en", StringComparison.OrdinalIgnoreCase)
+                    && !string.Equals(l, "auto", StringComparison.OrdinalIgnoreCase))
+                ?? "auto";
+
+            var tempAudioPath = Path.Combine(Path.GetTempPath(), $"{item.Id}_{Guid.NewGuid()}_translate.wav");
+            _logger.LogInformation("Generating English translation for {ItemName} (source: {SourceLanguage})",
+                item.Name, sourceLanguage);
+
+            try
+            {
+                SubtitleQueueService.Instance.ReportPhase("Extracting audio (translation)");
+                await ExtractAudioAsync(mediaPath, tempAudioPath, sourceLanguage, cancellationToken);
+                SubtitleQueueService.Instance.ReportPhase("Translating to English");
+                string srtContent = await provider.TranscribeAsync(tempAudioPath, sourceLanguage, cancellationToken, translate: true);
+
+                await File.WriteAllTextAsync(translatedSrtPath, srtContent, CancellationToken.None);
+                _logger.LogInformation("Saved translated subtitle to {SrtPath}", translatedSrtPath);
+            }
+            catch (OperationCanceledException)
+            {
+                _logger.LogInformation("Cancelled translation for {ItemName}", item.Name);
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error generating translated subtitle for {ItemName}", item.Name);
             }
             finally
             {

--- a/Providers/ISubtitleProvider.cs
+++ b/Providers/ISubtitleProvider.cs
@@ -6,7 +6,7 @@ namespace WhisperSubs.Providers
     public interface ISubtitleProvider
     {
         string Name { get; }
-        Task<string> TranscribeAsync(string audioPath, string language, CancellationToken cancellationToken);
+        Task<string> TranscribeAsync(string audioPath, string language, CancellationToken cancellationToken, bool translate = false);
 
         /// <summary>
         /// Detects the language spoken in an audio file.

--- a/Providers/WhisperProvider.cs
+++ b/Providers/WhisperProvider.cs
@@ -29,7 +29,7 @@ namespace WhisperSubs.Providers
             _threadCount = threadCount;
         }
 
-        public async Task<string> TranscribeAsync(string audioPath, string language, CancellationToken cancellationToken)
+        public async Task<string> TranscribeAsync(string audioPath, string language, CancellationToken cancellationToken, bool translate = false)
         {
             _logger.LogInformation("Starting Whisper transcription for {AudioPath} with model {ModelPath}", audioPath, _modelPath);
 
@@ -81,6 +81,10 @@ namespace WhisperSubs.Providers
                 startInfo.ArgumentList.Add("-mc");
                 startInfo.ArgumentList.Add("0");
                 startInfo.ArgumentList.Add("-sns");
+                if (translate)
+                {
+                    startInfo.ArgumentList.Add("--translate");
+                }
                 startInfo.ArgumentList.Add("-osrt");
                 startInfo.ArgumentList.Add("-of");
                 startInfo.ArgumentList.Add(tempOutputPrefix);

--- a/ScheduledTasks/SubtitleGenerationTask.cs
+++ b/ScheduledTasks/SubtitleGenerationTask.cs
@@ -103,8 +103,11 @@ namespace WhisperSubs.ScheduledTasks
             // subtitles must still be considered. Only filter by HasSubtitles in Full mode.
             var needsForced = config.SubtitleMode == Configuration.SubtitleMode.ForcedOnly
                 || config.SubtitleMode == Configuration.SubtitleMode.FullAndForced;
+            var needsTranslation = config.EnableTranslation
+                && (config.SubtitleMode == Configuration.SubtitleMode.Full
+                    || config.SubtitleMode == Configuration.SubtitleMode.FullAndForced);
 
-            var includeKinds = new List<BaseItemKind> { BaseItemKind.Movie, BaseItemKind.Episode };
+            var includeKinds = new List<BaseItemKind> { BaseItemKind.Movie, BaseItemKind.Episode, BaseItemKind.Video };
             if (config.EnableLyricsGeneration)
             {
                 includeKinds.Add(BaseItemKind.Audio);
@@ -127,7 +130,7 @@ namespace WhisperSubs.ScheduledTasks
                 {
                     if (queryItem is Video video)
                     {
-                        if (!needsForced && video.HasSubtitles) continue;
+                        if (!needsForced && !needsTranslation && video.HasSubtitles) continue;
                         allItems.Add((video, libraryName));
                     }
                     else if (queryItem is MediaBrowser.Controller.Entities.Audio.Audio)
@@ -222,11 +225,18 @@ namespace WhisperSubs.ScheduledTasks
                         }
                         var hasForcedSrt = existingFiles.Any(f => System.IO.Path.GetFileName(f).Contains(".forced.")) || noForeignMarkers.Length > 0;
 
+                        var hasTranslatedSrt = false;
+                        if (needsTranslation && dir != null)
+                        {
+                            hasTranslatedSrt = System.IO.File.Exists(
+                                System.IO.Path.Combine(dir, baseName + ".en.translated.srt"));
+                        }
+
                         bool alreadyComplete = config.SubtitleMode switch
                         {
-                            Configuration.SubtitleMode.Full => hasFullSrt,
+                            Configuration.SubtitleMode.Full => hasFullSrt && (!needsTranslation || hasTranslatedSrt),
                             Configuration.SubtitleMode.ForcedOnly => hasForcedSrt,
-                            Configuration.SubtitleMode.FullAndForced => hasFullSrt && hasForcedSrt,
+                            Configuration.SubtitleMode.FullAndForced => hasFullSrt && hasForcedSrt && (!needsTranslation || hasTranslatedSrt),
                             _ => hasFullSrt
                         };
 

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -167,6 +167,20 @@
                         </div>
                     </div>
 
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label>
+                            <input is="emby-checkbox" type="checkbox" id="chkEnableTranslation" name="EnableTranslation" />
+                            <span>Enable Translation (English)</span>
+                        </label>
+                        <div class="fieldDescription">
+                            When enabled, generates English subtitles via translation for media without an English audio track.
+                            Uses whisper's built-in <code>--translate</code> capability &mdash; no external services required.
+                            <br />
+                            <strong>Note:</strong> Only applies when Subtitle Mode includes Full subtitles (not Forced Only).
+                            Skipped automatically when English audio or English subtitles are already present.
+                        </div>
+                    </div>
+
                     <!-- ── Advanced / Manual Install ──────────────────── -->
                     <details style="margin-top:1.5em;">
                         <summary style="cursor:pointer; font-size:1.2em; font-weight:bold; padding:0.5em 0;">Advanced / Manual Install</summary>
@@ -770,6 +784,7 @@
                             page.querySelector('#selectSubtitleMode').value = (config.SubtitleMode != null ? config.SubtitleMode : 0).toString();
                             page.querySelector('#chkEnableAutoGeneration').checked = config.EnableAutoGeneration || false;
                             page.querySelector('#chkEnableLyricsGeneration').checked = config.EnableLyricsGeneration || false;
+                            page.querySelector('#chkEnableTranslation').checked = config.EnableTranslation || false;
                         }
                             WhisperSubsConfig.loadLibraries();
                         WhisperSubsConfig.loadLibrarySelector(config ? config.EnabledLibraries || [] : []);
@@ -786,6 +801,7 @@
                         config.SubtitleMode = parseInt(page.querySelector('#selectSubtitleMode').value, 10) || 0;
                         config.EnableAutoGeneration = page.querySelector('#chkEnableAutoGeneration').checked;
                         config.EnableLyricsGeneration = page.querySelector('#chkEnableLyricsGeneration').checked;
+                        config.EnableTranslation = page.querySelector('#chkEnableTranslation').checked;
 
                         // Collect enabled libraries from checkboxes
                         var libraryCheckboxes = page.querySelectorAll('.chkLibrary');

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.10.0.0</Version>
+    <Version>3.11.0.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
## Summary

- **Home Videos support**: Adds `BaseItemKind.Video` to item type filters across scheduled task, API listing, and GenerateAll endpoints. "Home Videos and Photos" libraries (courses, personal videos) are now processed for subtitle generation. Photos are naturally excluded (`BaseItemKind.Photo`).

- **English translation**: New `EnableTranslation` config toggle that uses whisper-cli's native `--translate` flag to produce `.en.translated.srt` files for media lacking an English audio track. Translation is:
  - Conditional: skipped when English audio exists, English subs already present, or SubtitleMode is ForcedOnly
  - Additive: runs after normal transcription, never replaces existing subtitles
  - Zero external dependencies: uses whisper's built-in translation capability

## Changes

| File | Change |
|------|--------|
| `Configuration/PluginConfiguration.cs` | Add `EnableTranslation` property |
| `Providers/ISubtitleProvider.cs` | Add `translate` param to `TranscribeAsync` |
| `Providers/WhisperProvider.cs` | Pass `--translate` flag when requested |
| `Controller/SubtitleManager.cs` | New `GenerateTranslatedSubtitleAsync` method |
| `ScheduledTasks/SubtitleGenerationTask.cs` | Add `Video` type + translation-aware skip gates |
| `Api/SubtitleController.cs` | Add `Video` to type filter strings |
| `Web/configPage.html` | Translation checkbox + load/save JS |
| `WhisperSubs.csproj` | Version bump 3.10.0.0 → 3.11.0.0 |

## Test plan

- [ ] Movie WITHOUT English audio + translation ON → `.en.translated.srt` produced
- [ ] Movie WITH English audio + translation ON → translation skipped
- [ ] SubtitleMode=ForcedOnly + translation ON → translation skipped
- [ ] Home Videos library items appear in scheduled task scan
- [ ] Home Videos items support context menu "Generate Subtitles"
- [ ] Config page checkbox loads/saves correctly
- [ ] Existing subtitle generation unchanged (no regression)

Closes #24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * English subtitle translation generation now available when enabled in plugin settings
  * Subtitle and lyrics processing expanded to support Video media items in addition to Movie, Episode, and Audio types

* **Configuration**
  * New "Enable Translation (English)" checkbox added to plugin settings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->