### PR TITLE
Fix virtual items, embedded subs, and English translation skip

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,18 @@ Plugin.cs                          Entry point, IHasWebPages (embeds config UI)
 4. **Save** — The SRT content is written alongside the media as `<filename>.<lang>.generated.srt`.
 5. **Metadata refresh** — `item.RefreshMetadata()` tells Jellyfin to pick up the new subtitle file.
 
+### Data Flow — English Translation (v3.11.0.0+)
+
+When `EnableTranslation` is enabled in config (and SubtitleMode is Full or FullAndForced):
+
+1. **English audio check** — FFprobe checks if any audio stream is already English. If so, translation is skipped entirely.
+2. **Existing file check** — If `<filename>.en.translated.srt` already exists, skip.
+3. **Source language selection** — Uses the first non-English language from resolved languages, or `"auto"` if none detected.
+4. **Transcription with translation** — Calls `WhisperProvider.TranscribeAsync(audioPath, sourceLanguage, ct, translate: true)`, which adds `--translate` to the whisper-cli invocation. Whisper's `--translate` flag always translates TO English.
+5. **Save** — Written as `<filename>.en.translated.srt`.
+
+**Important:** The `language` argument to `TranscribeAsync` must be the SOURCE language (e.g., `es`), not `en`. Whisper uses `-l` to set the source language and `--translate` to indicate output should be English.
+
 ### Data Flow — Forced Subtitles (v3.0.0+)
 
 Forced subtitles capture only foreign-language dialogue segments (e.g., Russian dialogue in an English film). The pipeline:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,9 +41,9 @@ Plugin.cs                          Entry point, IHasWebPages (embeds config UI)
 
 When `EnableTranslation` is enabled in config (and SubtitleMode is Full or FullAndForced):
 
-1. **English audio check** — FFprobe checks if any audio stream is already English. If so, translation is skipped entirely.
-2. **Existing file check** — If `<filename>.en.translated.srt` already exists, skip.
-3. **Source language selection** — Uses the first non-English language from resolved languages, or `"auto"` if none detected.
+1. **English audio check** — FFprobe checks if any audio stream is already English. If so, translation is skipped entirely. If FFprobe cannot resolve a language (returns `"auto"`), whisper detects the language from a 30-second audio sample; if English is detected with sufficient confidence (p>=0.3), translation is skipped.
+2. **Existing file check** — If `<filename>.en.translated.srt` already exists, skip. In `"auto"` mode, also checks for existing English subtitle files (`.en.srt`, `.eng.srt`, etc.).
+3. **Source language selection** — Uses the first non-English language from resolved languages. In `"auto"` mode, uses the whisper-detected language from step 1 if available, otherwise falls back to `"auto"`.
 4. **Transcription with translation** — Calls `WhisperProvider.TranscribeAsync(audioPath, sourceLanguage, ct, translate: true)`, which adds `--translate` to the whisper-cli invocation. Whisper's `--translate` flag always translates TO English.
 5. **Save** — Written as `<filename>.en.translated.srt`.
 

--- a/Api/SubtitleController.cs
+++ b/Api/SubtitleController.cs
@@ -214,7 +214,7 @@ namespace WhisperSubs.Api
                 }).Where(item => !string.IsNullOrEmpty(item.Path)).ToList();
 
                 // If this IS a leaf item itself, include it directly
-                if (children.Count == 0 && (parent is Video || (parent is MediaBrowser.Controller.Entities.Audio.Audio && config.EnableLyricsGeneration)))
+                if (children.Count == 0 && !string.IsNullOrEmpty(parent.Path) && (parent is Video || (parent is MediaBrowser.Controller.Entities.Audio.Audio && config.EnableLyricsGeneration)))
                 {
                     children = new List<BaseItem> { parent };
                 }

--- a/Api/SubtitleController.cs
+++ b/Api/SubtitleController.cs
@@ -96,7 +96,7 @@ namespace WhisperSubs.Api
                     ParentId = library.Id,
                     IncludeItemTypes = includeTypes,
                     Recursive = true
-                });
+                }).Where(item => !string.IsNullOrEmpty(item.Path)).ToList();
 
                 var totalCount = allItems.Count;
 
@@ -211,7 +211,7 @@ namespace WhisperSubs.Api
                     ParentId = parent.Id,
                     IncludeItemTypes = includeTypes,
                     Recursive = true
-                });
+                }).Where(item => !string.IsNullOrEmpty(item.Path)).ToList();
 
                 // If this IS a leaf item itself, include it directly
                 if (children.Count == 0 && (parent is Video || (parent is MediaBrowser.Controller.Entities.Audio.Audio && config.EnableLyricsGeneration)))
@@ -356,6 +356,7 @@ namespace WhisperSubs.Api
                         ItemId = itemId,
                         HasGeneratedSubtitle = fullFiles.Count > 0,
                         HasForcedSubtitle = forcedFiles.Count > 0,
+                        HasExistingSubtitles = item is Video v1 && v1.HasSubtitles,
                         SubtitlePath = found.Count > 0 ? string.Join("; ", found) : null
                     });
                 }
@@ -370,6 +371,7 @@ namespace WhisperSubs.Api
                     ItemId = itemId,
                     HasGeneratedSubtitle = hasGeneratedSubtitle,
                     HasForcedSubtitle = hasForcedSubtitle,
+                    HasExistingSubtitles = item is Video v2 && v2.HasSubtitles,
                     SubtitlePath = hasGeneratedSubtitle ? subtitlePath : null
                 });
             }
@@ -724,6 +726,7 @@ namespace WhisperSubs.Api
         public string ItemId { get; set; } = string.Empty;
         public bool HasGeneratedSubtitle { get; set; }
         public bool HasForcedSubtitle { get; set; }
+        public bool HasExistingSubtitles { get; set; }
         public string? SubtitlePath { get; set; }
     }
 

--- a/Controller/SubtitleManager.cs
+++ b/Controller/SubtitleManager.cs
@@ -204,10 +204,8 @@ namespace WhisperSubs.Controller
                 Directory.CreateDirectory(probeDir);
                 try
                 {
-                    var probeAudio = Path.Combine(probeDir, "probe.wav");
-                    await ExtractAudioAsync(mediaPath, probeAudio, null, cancellationToken);
                     var probeChunk = Path.Combine(probeDir, "probe_chunk.wav");
-                    await ExtractAudioChunkAsync(probeAudio, probeChunk, 0, 30.0, cancellationToken);
+                    await ExtractAudioChunkAsync(mediaPath, probeChunk, 0, 30.0, cancellationToken);
                     var (detectedLang, probability) = await provider.DetectLanguageAsync(probeChunk, cancellationToken);
 
                     if (string.Equals(detectedLang, "en", StringComparison.OrdinalIgnoreCase) && probability >= 0.3f)

--- a/Controller/SubtitleManager.cs
+++ b/Controller/SubtitleManager.cs
@@ -170,11 +170,12 @@ namespace WhisperSubs.Controller
                 return;
             }
 
-            // Fallback: if FFprobe couldn't detect languages (resolved to "auto"),
-            // check if English subtitles already exist — skip if they do
+            // Determine source language and perform additional checks for "auto" mode
+            string sourceLanguage;
             if (resolvedLanguages.Count == 1
                 && string.Equals(resolvedLanguages[0], "auto", StringComparison.OrdinalIgnoreCase))
             {
+                // FFprobe couldn't detect languages — check if English subtitles already exist
                 var dir = Path.GetDirectoryName(mediaPath);
                 var baseName = Path.GetFileNameWithoutExtension(mediaPath);
                 if (dir != null)
@@ -196,13 +197,49 @@ namespace WhisperSubs.Controller
                         return;
                     }
                 }
-            }
 
-            // Determine source language: first non-English language, or "auto"
-            var sourceLanguage = resolvedLanguages
-                .FirstOrDefault(l => !string.Equals(l, "en", StringComparison.OrdinalIgnoreCase)
-                    && !string.Equals(l, "auto", StringComparison.OrdinalIgnoreCase))
-                ?? "auto";
+                // Detect actual audio language via whisper before translating
+                sourceLanguage = "auto";
+                var probeDir = Path.Combine(Path.GetTempPath(), $"whispersubs_translate_probe_{Guid.NewGuid():N}");
+                Directory.CreateDirectory(probeDir);
+                try
+                {
+                    var probeAudio = Path.Combine(probeDir, "probe.wav");
+                    await ExtractAudioAsync(mediaPath, probeAudio, null, cancellationToken);
+                    var probeChunk = Path.Combine(probeDir, "probe_chunk.wav");
+                    await ExtractAudioChunkAsync(probeAudio, probeChunk, 0, 30.0, cancellationToken);
+                    var (detectedLang, probability) = await provider.DetectLanguageAsync(probeChunk, cancellationToken);
+
+                    if (string.Equals(detectedLang, "en", StringComparison.OrdinalIgnoreCase) && probability >= 0.3f)
+                    {
+                        _logger.LogInformation(
+                            "Skipping translation for {ItemName}: whisper detected English audio (p={Probability:F3})",
+                            item.Name, probability);
+                        return;
+                    }
+
+                    sourceLanguage = detectedLang;
+                    _logger.LogInformation(
+                        "Detected source language {Language} (p={Probability:F3}) for translation of {ItemName}",
+                        detectedLang, probability, item.Name);
+                }
+                catch (OperationCanceledException) { throw; }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Language detection failed for {ItemName}, proceeding with auto translation", item.Name);
+                }
+                finally
+                {
+                    try { if (Directory.Exists(probeDir)) Directory.Delete(probeDir, true); } catch { }
+                }
+            }
+            else
+            {
+                sourceLanguage = resolvedLanguages
+                    .FirstOrDefault(l => !string.Equals(l, "en", StringComparison.OrdinalIgnoreCase)
+                        && !string.Equals(l, "auto", StringComparison.OrdinalIgnoreCase))
+                    ?? "auto";
+            }
 
             var tempAudioPath = Path.Combine(Path.GetTempPath(), $"{item.Id}_{Guid.NewGuid()}_translate.wav");
             _logger.LogInformation("Generating English translation for {ItemName} (source: {SourceLanguage})",

--- a/ScheduledTasks/SubtitleGenerationTask.cs
+++ b/ScheduledTasks/SubtitleGenerationTask.cs
@@ -128,6 +128,9 @@ namespace WhisperSubs.ScheduledTasks
 
                 foreach (var queryItem in items)
                 {
+                    // Skip virtual/placeholder items with no media file
+                    if (string.IsNullOrEmpty(queryItem.Path)) continue;
+
                     if (queryItem is Video video)
                     {
                         if (!needsForced && !needsTranslation && video.HasSubtitles) continue;
@@ -222,6 +225,12 @@ namespace WhisperSubs.ScheduledTasks
                                         && !name.Contains(".forced.")
                                         && !name.Contains(".generated.");
                                 });
+                        }
+
+                        // Check for embedded subtitle streams (MKV, MP4, etc.)
+                        if (!hasFullSrt && item is Video embeddedCheck && embeddedCheck.HasSubtitles)
+                        {
+                            hasFullSrt = true;
                         }
                         var hasForcedSrt = existingFiles.Any(f => System.IO.Path.GetFileName(f).Contains(".forced.")) || noForeignMarkers.Length > 0;
 

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.11.1.0</Version>
+    <Version>3.11.2.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
## Summary
- **Virtual/placeholder items**: Filter items with null `Path` (LocationType=Virtual) from UI listings, batch generation endpoint, and scheduled task collection — eliminates phantom entries
- **Embedded subtitle detection**: Check Jellyfin's `HasSubtitles` property (which includes MKV/MP4 embedded streams) in the scheduled task's completion check, so items with embedded subs aren't reprocessed. Also exposed as `HasExistingSubtitles` in the status API
- **English translation skip**: When FFprobe can't detect audio language tags (resolves to "auto"), use whisper's language detection on a 30s audio sample before running translation. If English is detected, skip the redundant translate pass
- **Inflated candidate count**: Automatically fixed by the above — virtual items and items with embedded subs no longer inflate the "Found N candidate items" count (reported as 3476 vs ~162)

Fixes #26

## Test plan
- [ ] Verify virtual items no longer appear in library item listings
- [ ] Confirm items with MKV-embedded subtitles are skipped by scheduled task
- [ ] Test translation skip: English-audio content with no FFprobe language tags should log "whisper detected English audio" and skip
- [ ] Verify scheduled task candidate count reflects actual items needing generation
- [ ] Regression: items genuinely missing subtitles still get generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced automatic language detection to skip translation when audio is detected as English; added subtitle status reporting in API responses.

* **Bug Fixes**
  * Skip virtual/placeholder media items without file paths during subtitle generation.
  * Treat embedded subtitle tracks as existing “full” subtitles to avoid redundant generation.

* **Documentation**
  * Added Data Flow — English Translation (v3.11.0.0+) documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->