### PR TITLE
ci: migrate workflows to self-hosted runner

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         include:
           # CPU-only builds
-          - os: ubuntu-latest
+          - os: [self-hosted, Linux, X64, geiserback]
             platform: linux-x64
             variant: cpu
             asset_name: whisper-cli-linux-x64
@@ -40,14 +40,14 @@ jobs:
             cmake_flags: ""
             pre_install: ""
           # CUDA 12 (NVIDIA GPU)
-          - os: ubuntu-latest
+          - os: [self-hosted, Linux, X64, geiserback]
             platform: linux-x64
             variant: cuda12
             asset_name: whisper-cli-linux-x64-cuda12
             cmake_flags: "-DGGML_CUDA=ON"
             pre_install: "cuda"
           # Vulkan (Intel/AMD/NVIDIA GPU)
-          - os: ubuntu-latest
+          - os: [self-hosted, Linux, X64, geiserback]
             platform: linux-x64
             variant: vulkan
             asset_name: whisper-cli-linux-x64-vulkan
@@ -106,7 +106,7 @@ jobs:
 
   # ── Build whisper.cpp ROCm binary (needs full SDK container) ───────
   build-whisper-rocm:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, geiserback]
     container:
       image: rocm/dev-ubuntu-22.04:6.1.2
     steps:
@@ -147,7 +147,7 @@ jobs:
   # ── Build plugin + create release ──────────────────────────────────
   build:
     needs: [build-whisper, build-whisper-rocm]
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, geiserback]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,7 @@ concurrency:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: [self-hosted, Linux, X64, geiserback]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,8 +5,13 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, geiserback]
     steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
       - uses: actions/stale@v9
         with:
           stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed in 14 days if no further activity occurs.'


### PR DESCRIPTION
## Summary
- Migrate all GitHub Actions workflows (build-release, ci, stale) from `ubuntu-latest` to self-hosted runner (`[self-hosted, Linux, X64, geiserback]`)
- ARM build (`ubuntu-24.04-arm`) kept on GitHub-hosted runner since self-hosted is X64-only
- Add `actions/setup-dotnet@v4` (already present), `actions/setup-node@v4` for stale workflow since self-hosted runner has no pre-installed tools
- Remove Windows matrix from CI (self-hosted runner is Linux-only)

## Test plan
- [ ] Verify stale workflow runs successfully with setup-node providing Node.js
- [ ] Verify CI build/test passes with .NET 9 on self-hosted runner
- [ ] Verify build-release whisper compilation works on geiserback
- [ ] Verify ARM build still works on GitHub-hosted ubuntu-24.04-arm