### PR TITLE
fix: pin Jellyfin SDK to 10.11.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -364,7 +364,8 @@ docker inspect jellyfin --format '{{range .Mounts}}{{.Source}} -> {{.Destination
 
 ## Development Notes
 
-- The `.csproj` targets `net9.0` and references `Jellyfin.Model` and `Jellyfin.Controller` 10.11.8.
+- The `.csproj` targets `net9.0` and references `Jellyfin.Model` and `Jellyfin.Controller` 10.11.0.
+- **Jellyfin SDK pinning**: ALWAYS pin `Jellyfin.Controller` and `Jellyfin.Model` to the MINIMUM supported minor version (e.g., `10.11.0`), NEVER use wildcards like `10.11.*` or exact higher patches like `10.11.8`. Wildcards resolve to the latest patch at build time, which breaks users on older patch versions with `ReflectionTypeLoadException`. All plugin APIs used are stable across patch versions.
 - The config page HTML is an embedded resource — changes require rebuilding the DLL.
 - `Plugin.Instance` is a static singleton set in the constructor. All components access config via `Plugin.Instance.Configuration`.
 - The `ISubtitleProvider` interface is designed for extensibility (Parakeet, custom commands), but only `WhisperProvider` is currently implemented.

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.11.2.0</Version>
+    <Version>3.11.3.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Model" Version="10.11.8" />
-    <PackageReference Include="Jellyfin.Controller" Version="10.11.8" />
+    <PackageReference Include="Jellyfin.Model" Version="10.11.0" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.11.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.15" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Pin `Jellyfin.Controller` and `Jellyfin.Model` from `10.11.8` to `10.11.0`
- Bump version to `3.11.3.0`
- Add SDK pinning rule to AGENTS.md

Exact higher patch versions (e.g. `10.11.8`) break users on older Jellyfin patch versions (e.g. `10.11.6`) with `ReflectionTypeLoadException`. All plugin APIs are stable across patch versions, so pinning to `.0` ensures maximum compatibility.

## Test plan
- [x] `dotnet build` succeeds with pinned versions
- [ ] Verify plugin loads on Jellyfin 10.11.x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Bumped project version to 3.11.3.0.
  * Updated Jellyfin package dependencies to pinned versions for improved stability and compatibility.

* **Documentation**
  * Updated development guidelines to reflect new SDK version pinning requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->