### PR TITLE
feat: remote OpenAI-compatible Whisper API support

### DIFF
--- a/Api/SubtitleController.cs
+++ b/Api/SubtitleController.cs
@@ -161,11 +161,7 @@ namespace WhisperSubs.Api
 
                 // Ensure the background drain worker is running
                 var manager = GetSubtitleManager();
-                var provider = new WhisperProvider(
-                    _loggerFactory.CreateLogger<WhisperProvider>(),
-                    config.WhisperModelPath,
-                    config.WhisperBinaryPath,
-                    config.WhisperThreadCount);
+                var provider = SubtitleProviderFactory.Create(config, _loggerFactory);
                 queue.EnsureDraining(manager, provider, _logger, CancellationToken.None);
 
                 return Accepted(new
@@ -236,11 +232,7 @@ namespace WhisperSubs.Api
 
                 // Ensure the background drain worker is running
                 var manager = GetSubtitleManager();
-                var provider = new WhisperProvider(
-                    _loggerFactory.CreateLogger<WhisperProvider>(),
-                    config.WhisperModelPath,
-                    config.WhisperBinaryPath,
-                    config.WhisperThreadCount);
+                var provider = SubtitleProviderFactory.Create(config, _loggerFactory);
                 queue.EnsureDraining(manager, provider, _logger, CancellationToken.None);
 
                 return Accepted(new

--- a/Configuration/PluginConfiguration.cs
+++ b/Configuration/PluginConfiguration.cs
@@ -42,6 +42,20 @@ namespace WhisperSubs.Configuration
         /// </summary>
         public int WhisperThreadCount { get; set; } = 0;
 
+        /// <summary>
+        /// Optional URL of an OpenAI-compatible Whisper API server (e.g. faster-whisper-server/speaches).
+        /// When set, audio is sent to this endpoint instead of running whisper-cli locally.
+        /// Example: http://192.168.1.100:8000
+        /// </summary>
+        public string RemoteWhisperApiUrl { get; set; } = "";
+
+        /// <summary>
+        /// Model name to request from the remote API.
+        /// For speaches/faster-whisper-server: a Hugging Face model ID (e.g. "Systran/faster-whisper-large-v3").
+        /// For OpenAI: "whisper-1".
+        /// </summary>
+        public string RemoteWhisperModel { get; set; } = "Systran/faster-whisper-large-v3";
+
         public List<string> EnabledLibraries { get; set; } = new List<string>();
 
         public PluginConfiguration()

--- a/Providers/RemoteWhisperProvider.cs
+++ b/Providers/RemoteWhisperProvider.cs
@@ -1,0 +1,171 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace WhisperSubs.Providers
+{
+    public class RemoteWhisperProvider : ISubtitleProvider
+    {
+        private static readonly HttpClient _httpClient = new(new SocketsHttpHandler
+        {
+            PooledConnectionLifetime = TimeSpan.FromMinutes(10),
+            ConnectTimeout = TimeSpan.FromSeconds(10),
+        })
+        {
+            Timeout = TimeSpan.FromMinutes(30),
+        };
+
+        private readonly ILogger _logger;
+        private readonly string _apiUrl;
+        private readonly string _model;
+
+        public string Name => "RemoteWhisper";
+
+        public RemoteWhisperProvider(ILogger logger, string apiUrl, string model)
+        {
+            _logger = logger;
+            _apiUrl = apiUrl.TrimEnd('/');
+            _model = model;
+        }
+
+        public async Task<string> TranscribeAsync(string audioPath, string language, CancellationToken cancellationToken, bool translate = false)
+        {
+            if (!File.Exists(audioPath))
+            {
+                throw new FileNotFoundException($"Audio file not found: {audioPath}");
+            }
+
+            var endpoint = translate
+                ? $"{_apiUrl}/v1/audio/translations"
+                : $"{_apiUrl}/v1/audio/transcriptions";
+
+            _logger.LogInformation("Sending audio to remote Whisper API: {Endpoint} [lang={Language}, translate={Translate}]",
+                endpoint, language, translate);
+
+            using var content = new MultipartFormDataContent();
+
+            var audioBytes = await File.ReadAllBytesAsync(audioPath, cancellationToken).ConfigureAwait(false);
+            var fileContent = new ByteArrayContent(audioBytes);
+            fileContent.Headers.ContentType = new MediaTypeHeaderValue("audio/wav");
+            content.Add(fileContent, "file", "audio.wav");
+
+            content.Add(new StringContent(_model), "model");
+            content.Add(new StringContent("srt"), "response_format");
+
+            if (!translate && !string.IsNullOrEmpty(language) && language != "auto")
+            {
+                content.Add(new StringContent(language), "language");
+            }
+
+            using var response = await _httpClient.PostAsync(endpoint, content, cancellationToken).ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorBody = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+                throw new HttpRequestException($"Remote Whisper API returned {(int)response.StatusCode}: {errorBody}");
+            }
+
+            var srt = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+            if (string.IsNullOrWhiteSpace(srt))
+            {
+                throw new InvalidOperationException("Remote Whisper API returned empty response");
+            }
+
+            _logger.LogInformation("Remote transcription complete, received {Length} characters of SRT", srt.Length);
+            return srt;
+        }
+
+        public async Task<(string Language, float Probability)> DetectLanguageAsync(string audioPath, CancellationToken cancellationToken)
+        {
+            if (!File.Exists(audioPath))
+            {
+                throw new FileNotFoundException($"Audio file not found: {audioPath}");
+            }
+
+            _logger.LogInformation("Detecting language via remote Whisper API for {AudioPath}", audioPath);
+
+            using var content = new MultipartFormDataContent();
+
+            var audioBytes = await File.ReadAllBytesAsync(audioPath, cancellationToken).ConfigureAwait(false);
+            var fileContent = new ByteArrayContent(audioBytes);
+            fileContent.Headers.ContentType = new MediaTypeHeaderValue("audio/wav");
+            content.Add(fileContent, "file", "audio.wav");
+
+            content.Add(new StringContent(_model), "model");
+            content.Add(new StringContent("verbose_json"), "response_format");
+
+            var endpoint = $"{_apiUrl}/v1/audio/transcriptions";
+            using var response = await _httpClient.PostAsync(endpoint, content, cancellationToken).ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                var errorBody = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+                throw new HttpRequestException($"Remote Whisper API returned {(int)response.StatusCode}: {errorBody}");
+            }
+
+            var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            var language = root.TryGetProperty("language", out var langProp)
+                ? langProp.GetString() ?? "en"
+                : "en";
+
+            // Normalize full language names to ISO 639-1
+            language = NormalizeLangName(language);
+
+            _logger.LogInformation("Remote language detection: {Language}", language);
+
+            // The OpenAI API doesn't return a confidence score for language detection,
+            // so we use a high default since the model is generally accurate
+            return (language, 0.9f);
+        }
+
+        private static string NormalizeLangName(string lang)
+        {
+            if (lang.Length <= 3) return lang;
+
+            return lang.ToLowerInvariant() switch
+            {
+                "english" => "en",
+                "spanish" => "es",
+                "french" => "fr",
+                "german" => "de",
+                "italian" => "it",
+                "portuguese" => "pt",
+                "russian" => "ru",
+                "japanese" => "ja",
+                "chinese" => "zh",
+                "korean" => "ko",
+                "dutch" => "nl",
+                "polish" => "pl",
+                "turkish" => "tr",
+                "arabic" => "ar",
+                "hindi" => "hi",
+                "czech" => "cs",
+                "greek" => "el",
+                "hungarian" => "hu",
+                "romanian" => "ro",
+                "swedish" => "sv",
+                "danish" => "da",
+                "finnish" => "fi",
+                "norwegian" => "no",
+                "catalan" => "ca",
+                "ukrainian" => "uk",
+                "vietnamese" => "vi",
+                "thai" => "th",
+                "indonesian" => "id",
+                "malay" => "ms",
+                "hebrew" => "he",
+                _ => lang,
+            };
+        }
+    }
+}

--- a/Providers/RemoteWhisperProvider.cs
+++ b/Providers/RemoteWhisperProvider.cs
@@ -57,7 +57,8 @@ namespace WhisperSubs.Providers
             content.Add(new StringContent(_model), "model");
             content.Add(new StringContent("srt"), "response_format");
 
-            if (!translate && !string.IsNullOrEmpty(language) && language != "auto")
+            if (!string.IsNullOrWhiteSpace(language) &&
+                !string.Equals(language, "auto", StringComparison.OrdinalIgnoreCase))
             {
                 content.Add(new StringContent(language), "language");
             }
@@ -115,17 +116,14 @@ namespace WhisperSubs.Providers
             var root = doc.RootElement;
 
             var language = root.TryGetProperty("language", out var langProp)
-                ? langProp.GetString() ?? "en"
-                : "en";
+                ? (langProp.GetString() ?? "auto")
+                : "auto";
 
-            // Normalize full language names to ISO 639-1
             language = NormalizeLangName(language);
 
             _logger.LogInformation("Remote language detection: {Language}", language);
 
-            // The OpenAI API doesn't return a confidence score for language detection,
-            // so we use a high default since the model is generally accurate
-            return (language, 0.9f);
+            return (language, 0.0f);
         }
 
         private static string NormalizeLangName(string lang)

--- a/Providers/SubtitleProviderFactory.cs
+++ b/Providers/SubtitleProviderFactory.cs
@@ -1,0 +1,25 @@
+using Microsoft.Extensions.Logging;
+using WhisperSubs.Configuration;
+
+namespace WhisperSubs.Providers
+{
+    internal static class SubtitleProviderFactory
+    {
+        public static ISubtitleProvider Create(PluginConfiguration config, ILoggerFactory loggerFactory)
+        {
+            if (!string.IsNullOrWhiteSpace(config.RemoteWhisperApiUrl))
+            {
+                return new RemoteWhisperProvider(
+                    loggerFactory.CreateLogger<RemoteWhisperProvider>(),
+                    config.RemoteWhisperApiUrl,
+                    config.RemoteWhisperModel);
+            }
+
+            return new WhisperProvider(
+                loggerFactory.CreateLogger<WhisperProvider>(),
+                config.WhisperModelPath,
+                config.WhisperBinaryPath,
+                config.WhisperThreadCount);
+        }
+    }
+}

--- a/Providers/SubtitleProviderFactory.cs
+++ b/Providers/SubtitleProviderFactory.cs
@@ -9,10 +9,13 @@ namespace WhisperSubs.Providers
         {
             if (!string.IsNullOrWhiteSpace(config.RemoteWhisperApiUrl))
             {
+                var model = string.IsNullOrWhiteSpace(config.RemoteWhisperModel)
+                    ? "Systran/faster-whisper-large-v3"
+                    : config.RemoteWhisperModel.Trim();
                 return new RemoteWhisperProvider(
                     loggerFactory.CreateLogger<RemoteWhisperProvider>(),
                     config.RemoteWhisperApiUrl,
-                    config.RemoteWhisperModel);
+                    model);
             }
 
             return new WhisperProvider(

--- a/ScheduledTasks/SubtitleGenerationTask.cs
+++ b/ScheduledTasks/SubtitleGenerationTask.cs
@@ -61,7 +61,7 @@ namespace WhisperSubs.ScheduledTasks
                 return;
             }
 
-            if (string.IsNullOrWhiteSpace(config.RemoteWhisperApiUrl) && string.IsNullOrEmpty(config.WhisperModelPath))
+            if (string.IsNullOrWhiteSpace(config.RemoteWhisperApiUrl) && string.IsNullOrWhiteSpace(config.WhisperModelPath))
             {
                 _logger.LogWarning("Neither remote API URL nor local model path is configured, aborting task");
                 return;

--- a/ScheduledTasks/SubtitleGenerationTask.cs
+++ b/ScheduledTasks/SubtitleGenerationTask.cs
@@ -61,18 +61,14 @@ namespace WhisperSubs.ScheduledTasks
                 return;
             }
 
-            if (string.IsNullOrEmpty(config.WhisperModelPath))
+            if (string.IsNullOrWhiteSpace(config.RemoteWhisperApiUrl) && string.IsNullOrEmpty(config.WhisperModelPath))
             {
-                _logger.LogWarning("Whisper model path is not configured, aborting task");
+                _logger.LogWarning("Neither remote API URL nor local model path is configured, aborting task");
                 return;
             }
 
             var manager = new SubtitleManager(_libraryManager, _loggerFactory.CreateLogger<SubtitleManager>());
-            var provider = new WhisperProvider(
-                _loggerFactory.CreateLogger<WhisperProvider>(),
-                config.WhisperModelPath,
-                config.WhisperBinaryPath,
-                config.WhisperThreadCount);
+            var provider = SubtitleProviderFactory.Create(config, _loggerFactory);
             var language = config.DefaultLanguage;
             var queue = SubtitleQueueService.Instance;
 

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -815,8 +815,8 @@
                         config.WhisperBinaryPath = page.querySelector('#txtWhisperBinaryPath').value;
                         config.WhisperModelPath = page.querySelector('#txtWhisperModelPath').value;
                         config.WhisperThreadCount = parseInt(page.querySelector('#txtWhisperThreadCount').value, 10) || 0;
-                        config.RemoteWhisperApiUrl = page.querySelector('#txtRemoteWhisperApiUrl').value;
-                        config.RemoteWhisperModel = page.querySelector('#txtRemoteWhisperModel').value;
+                        config.RemoteWhisperApiUrl = (page.querySelector('#txtRemoteWhisperApiUrl').value || '').trim();
+                        config.RemoteWhisperModel = (page.querySelector('#txtRemoteWhisperModel').value || '').trim() || 'Systran/faster-whisper-large-v3';
                         config.DefaultLanguage = page.querySelector('#selectDefaultLanguage').value || 'auto';
                         config.SubtitleMode = parseInt(page.querySelector('#selectSubtitleMode').value, 10) || 0;
                         config.EnableAutoGeneration = page.querySelector('#chkEnableAutoGeneration').checked;

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -183,6 +183,22 @@
 
                     <!-- ── Advanced / Manual Install ──────────────────── -->
                     <details style="margin-top:1.5em;">
+                        <summary style="cursor:pointer; font-size:1.2em; font-weight:bold; padding:0.5em 0;">Remote Whisper API (Optional)</summary>
+
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="txtRemoteWhisperApiUrl">Remote API URL</label>
+                            <input type="text" id="txtRemoteWhisperApiUrl" name="RemoteWhisperApiUrl" class="emby-input" placeholder="http://192.168.1.100:8000" />
+                            <div class="fieldDescription">URL of an OpenAI-compatible Whisper API (e.g. faster-whisper-server, speaches). When set, audio is sent to this server instead of running whisper locally. Leave empty to use local whisper-cli.</div>
+                        </div>
+
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="txtRemoteWhisperModel">Remote Model Name</label>
+                            <input type="text" id="txtRemoteWhisperModel" name="RemoteWhisperModel" class="emby-input" placeholder="Systran/faster-whisper-large-v3" />
+                            <div class="fieldDescription">Model identifier to request from the remote API. For speaches: a Hugging Face model ID. For OpenAI: "whisper-1".</div>
+                        </div>
+                    </details>
+
+                    <details style="margin-top:1.5em;">
                         <summary style="cursor:pointer; font-size:1.2em; font-weight:bold; padding:0.5em 0;">Advanced / Manual Install</summary>
 
                         <div class="inputContainer">
@@ -780,6 +796,8 @@
                             page.querySelector('#txtWhisperBinaryPath').value = config.WhisperBinaryPath || '';
                             page.querySelector('#txtWhisperModelPath').value = config.WhisperModelPath || '';
                             page.querySelector('#txtWhisperThreadCount').value = (config.WhisperThreadCount || 0).toString();
+                            page.querySelector('#txtRemoteWhisperApiUrl').value = config.RemoteWhisperApiUrl || '';
+                            page.querySelector('#txtRemoteWhisperModel').value = config.RemoteWhisperModel || 'Systran/faster-whisper-large-v3';
                             page.querySelector('#selectDefaultLanguage').value = config.DefaultLanguage || 'auto';
                             page.querySelector('#selectSubtitleMode').value = (config.SubtitleMode != null ? config.SubtitleMode : 0).toString();
                             page.querySelector('#chkEnableAutoGeneration').checked = config.EnableAutoGeneration || false;
@@ -797,6 +815,8 @@
                         config.WhisperBinaryPath = page.querySelector('#txtWhisperBinaryPath').value;
                         config.WhisperModelPath = page.querySelector('#txtWhisperModelPath').value;
                         config.WhisperThreadCount = parseInt(page.querySelector('#txtWhisperThreadCount').value, 10) || 0;
+                        config.RemoteWhisperApiUrl = page.querySelector('#txtRemoteWhisperApiUrl').value;
+                        config.RemoteWhisperModel = page.querySelector('#txtRemoteWhisperModel').value;
                         config.DefaultLanguage = page.querySelector('#selectDefaultLanguage').value || 'auto';
                         config.SubtitleMode = parseInt(page.querySelector('#selectSubtitleMode').value, 10) || 0;
                         config.EnableAutoGeneration = page.querySelector('#chkEnableAutoGeneration').checked;

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.11.3.0</Version>
+    <Version>3.12.0.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
## Summary
- Adds support for sending audio to a remote OpenAI-compatible Whisper API (faster-whisper-server, speaches, etc.) instead of running whisper-cli locally
- New `SubtitleProviderFactory` selects between local/remote providers based on plugin configuration
- Config page UI includes Remote Whisper API section with URL and model name fields
- Supports transcription, translation, and language detection via the remote endpoint

Closes #17

## Test plan
- [ ] Configure remote API URL pointing to a faster-whisper-server instance
- [ ] Verify transcription generates .srt files correctly
- [ ] Verify translation mode produces English subtitles
- [ ] Verify language detection works via verbose_json response
- [ ] Confirm local whisper-cli still works when remote URL is empty
- [ ] Verify scheduled task runs with remote provider
- [ ] Check config page saves/loads remote API settings correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for remote OpenAI-compatible Whisper API transcription
  * New configuration options for remote API URL and model identifier
  * Settings UI updated with remote Whisper configuration fields
  * Remote language detection capability

* **Chores**
  * Updated version to 3.12.0.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->