### PR TITLE
feat(remote): support API key auth for remote Whisper API

### DIFF
--- a/Configuration/PluginConfiguration.cs
+++ b/Configuration/PluginConfiguration.cs
@@ -56,6 +56,15 @@ namespace WhisperSubs.Configuration
         /// </summary>
         public string RemoteWhisperModel { get; set; } = "Systran/faster-whisper-large-v3";
 
+        /// <summary>
+        /// Optional API key for the remote Whisper API. When set, the value is
+        /// sent as `Authorization: Bearer &lt;key&gt;` on every request. Required by
+        /// OpenAI-compatible servers that gate access (OpenAI, hosted speaches,
+        /// pfrankov/whisper-server when configured with auth, etc.). Leave
+        /// empty for unauthenticated local servers.
+        /// </summary>
+        public string RemoteWhisperApiKey { get; set; } = "";
+
         public List<string> EnabledLibraries { get; set; } = new List<string>();
 
         public PluginConfiguration()

--- a/Configuration/PluginConfiguration.cs
+++ b/Configuration/PluginConfiguration.cs
@@ -43,7 +43,7 @@ namespace WhisperSubs.Configuration
         public int WhisperThreadCount { get; set; } = 0;
 
         /// <summary>
-        /// Optional URL of an OpenAI-compatible Whisper API server (e.g. faster-whisper-server/speaches).
+        /// Optional URL of an OpenAI-compatible Whisper API server (e.g. faster-whisper-server/Speaches).
         /// When set, audio is sent to this endpoint instead of running whisper-cli locally.
         /// Example: http://192.168.1.100:8000
         /// </summary>
@@ -51,7 +51,7 @@ namespace WhisperSubs.Configuration
 
         /// <summary>
         /// Model name to request from the remote API.
-        /// For speaches/faster-whisper-server: a Hugging Face model ID (e.g. "Systran/faster-whisper-large-v3").
+        /// For Speaches/faster-whisper-server: a Hugging Face model ID (e.g. "Systran/faster-whisper-large-v3").
         /// For OpenAI: "whisper-1".
         /// </summary>
         public string RemoteWhisperModel { get; set; } = "Systran/faster-whisper-large-v3";
@@ -59,7 +59,7 @@ namespace WhisperSubs.Configuration
         /// <summary>
         /// Optional API key for the remote Whisper API. When set, the value is
         /// sent as `Authorization: Bearer &lt;key&gt;` on every request. Required by
-        /// OpenAI-compatible servers that gate access (OpenAI, hosted speaches,
+        /// OpenAI-compatible servers that gate access (OpenAI, hosted Speaches,
         /// pfrankov/whisper-server when configured with auth, etc.). Leave
         /// empty for unauthenticated local servers.
         /// </summary>

--- a/Providers/RemoteWhisperProvider.cs
+++ b/Providers/RemoteWhisperProvider.cs
@@ -23,14 +23,24 @@ namespace WhisperSubs.Providers
         private readonly ILogger _logger;
         private readonly string _apiUrl;
         private readonly string _model;
+        private readonly string _apiKey;
 
         public string Name => "RemoteWhisper";
 
-        public RemoteWhisperProvider(ILogger logger, string apiUrl, string model)
+        public RemoteWhisperProvider(ILogger logger, string apiUrl, string model, string apiKey = "")
         {
             _logger = logger;
             _apiUrl = apiUrl.TrimEnd('/');
             _model = model;
+            _apiKey = apiKey ?? string.Empty;
+        }
+
+        private void ApplyAuthorization(HttpRequestMessage request)
+        {
+            if (!string.IsNullOrWhiteSpace(_apiKey))
+            {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _apiKey);
+            }
         }
 
         public async Task<string> TranscribeAsync(string audioPath, string language, CancellationToken cancellationToken, bool translate = false)
@@ -63,7 +73,10 @@ namespace WhisperSubs.Providers
                 content.Add(new StringContent(language), "language");
             }
 
-            using var response = await _httpClient.PostAsync(endpoint, content, cancellationToken).ConfigureAwait(false);
+            using var request = new HttpRequestMessage(HttpMethod.Post, endpoint) { Content = content };
+            ApplyAuthorization(request);
+
+            using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
             if (!response.IsSuccessStatusCode)
             {
@@ -102,7 +115,10 @@ namespace WhisperSubs.Providers
             content.Add(new StringContent("verbose_json"), "response_format");
 
             var endpoint = $"{_apiUrl}/v1/audio/transcriptions";
-            using var response = await _httpClient.PostAsync(endpoint, content, cancellationToken).ConfigureAwait(false);
+            using var request = new HttpRequestMessage(HttpMethod.Post, endpoint) { Content = content };
+            ApplyAuthorization(request);
+
+            using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
 
             if (!response.IsSuccessStatusCode)
             {

--- a/Providers/RemoteWhisperProvider.cs
+++ b/Providers/RemoteWhisperProvider.cs
@@ -32,7 +32,16 @@ namespace WhisperSubs.Providers
             _logger = logger;
             _apiUrl = apiUrl.TrimEnd('/');
             _model = model;
-            _apiKey = apiKey ?? string.Empty;
+            _apiKey = (apiKey ?? string.Empty).Trim();
+
+            if (!string.IsNullOrEmpty(_apiKey) &&
+                Uri.TryCreate(_apiUrl, UriKind.Absolute, out var uri) &&
+                !string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogWarning(
+                    "RemoteWhisper API key is configured with a non-HTTPS URL ({Scheme}). The key will be sent in cleartext. Consider switching to https://.",
+                    uri.Scheme);
+            }
         }
 
         private void ApplyAuthorization(HttpRequestMessage request)

--- a/Providers/SubtitleProviderFactory.cs
+++ b/Providers/SubtitleProviderFactory.cs
@@ -12,10 +12,12 @@ namespace WhisperSubs.Providers
                 var model = string.IsNullOrWhiteSpace(config.RemoteWhisperModel)
                     ? "Systran/faster-whisper-large-v3"
                     : config.RemoteWhisperModel.Trim();
+                var apiKey = (config.RemoteWhisperApiKey ?? string.Empty).Trim();
                 return new RemoteWhisperProvider(
                     loggerFactory.CreateLogger<RemoteWhisperProvider>(),
                     config.RemoteWhisperApiUrl,
-                    model);
+                    model,
+                    apiKey);
             }
 
             return new WhisperProvider(

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -196,6 +196,12 @@
                             <input type="text" id="txtRemoteWhisperModel" name="RemoteWhisperModel" class="emby-input" placeholder="Systran/faster-whisper-large-v3" />
                             <div class="fieldDescription">Model identifier to request from the remote API. For speaches: a Hugging Face model ID. For OpenAI: "whisper-1".</div>
                         </div>
+
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="txtRemoteWhisperApiKey">Remote API Key (Optional)</label>
+                            <input type="password" id="txtRemoteWhisperApiKey" name="RemoteWhisperApiKey" class="emby-input" autocomplete="off" />
+                            <div class="fieldDescription">Bearer token for OpenAI-compatible servers that require authentication (OpenAI, hosted speaches, pfrankov/whisper-server with auth, etc.). Sent as <code>Authorization: Bearer &lt;key&gt;</code>. Leave empty for unauthenticated local servers.</div>
+                        </div>
                     </details>
 
                     <details style="margin-top:1.5em;">
@@ -798,6 +804,7 @@
                             page.querySelector('#txtWhisperThreadCount').value = (config.WhisperThreadCount || 0).toString();
                             page.querySelector('#txtRemoteWhisperApiUrl').value = config.RemoteWhisperApiUrl || '';
                             page.querySelector('#txtRemoteWhisperModel').value = config.RemoteWhisperModel || 'Systran/faster-whisper-large-v3';
+                            page.querySelector('#txtRemoteWhisperApiKey').value = config.RemoteWhisperApiKey || '';
                             page.querySelector('#selectDefaultLanguage').value = config.DefaultLanguage || 'auto';
                             page.querySelector('#selectSubtitleMode').value = (config.SubtitleMode != null ? config.SubtitleMode : 0).toString();
                             page.querySelector('#chkEnableAutoGeneration').checked = config.EnableAutoGeneration || false;
@@ -817,6 +824,7 @@
                         config.WhisperThreadCount = parseInt(page.querySelector('#txtWhisperThreadCount').value, 10) || 0;
                         config.RemoteWhisperApiUrl = (page.querySelector('#txtRemoteWhisperApiUrl').value || '').trim();
                         config.RemoteWhisperModel = (page.querySelector('#txtRemoteWhisperModel').value || '').trim() || 'Systran/faster-whisper-large-v3';
+                        config.RemoteWhisperApiKey = (page.querySelector('#txtRemoteWhisperApiKey').value || '').trim();
                         config.DefaultLanguage = page.querySelector('#selectDefaultLanguage').value || 'auto';
                         config.SubtitleMode = parseInt(page.querySelector('#selectSubtitleMode').value, 10) || 0;
                         config.EnableAutoGeneration = page.querySelector('#chkEnableAutoGeneration').checked;

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -188,19 +188,19 @@
                         <div class="inputContainer">
                             <label class="inputLabel inputLabelUnfocused" for="txtRemoteWhisperApiUrl">Remote API URL</label>
                             <input type="text" id="txtRemoteWhisperApiUrl" name="RemoteWhisperApiUrl" class="emby-input" placeholder="http://192.168.1.100:8000" />
-                            <div class="fieldDescription">URL of an OpenAI-compatible Whisper API (e.g. faster-whisper-server, speaches). When set, audio is sent to this server instead of running whisper locally. Leave empty to use local whisper-cli.</div>
+                            <div class="fieldDescription">URL of an OpenAI-compatible Whisper API (e.g. faster-whisper-server, Speaches). When set, audio is sent to this server instead of running whisper locally. Leave empty to use local whisper-cli.</div>
                         </div>
 
                         <div class="inputContainer">
                             <label class="inputLabel inputLabelUnfocused" for="txtRemoteWhisperModel">Remote Model Name</label>
                             <input type="text" id="txtRemoteWhisperModel" name="RemoteWhisperModel" class="emby-input" placeholder="Systran/faster-whisper-large-v3" />
-                            <div class="fieldDescription">Model identifier to request from the remote API. For speaches: a Hugging Face model ID. For OpenAI: "whisper-1".</div>
+                            <div class="fieldDescription">Model identifier to request from the remote API. For Speaches: a Hugging Face model ID. For OpenAI: "whisper-1".</div>
                         </div>
 
                         <div class="inputContainer">
                             <label class="inputLabel inputLabelUnfocused" for="txtRemoteWhisperApiKey">Remote API Key (Optional)</label>
-                            <input type="password" id="txtRemoteWhisperApiKey" name="RemoteWhisperApiKey" class="emby-input" autocomplete="off" />
-                            <div class="fieldDescription">Bearer token for OpenAI-compatible servers that require authentication (OpenAI, hosted speaches, pfrankov/whisper-server with auth, etc.). Sent as <code>Authorization: Bearer &lt;key&gt;</code>. Leave empty for unauthenticated local servers.</div>
+                            <input type="password" id="txtRemoteWhisperApiKey" name="RemoteWhisperApiKey" class="emby-input" autocomplete="new-password" maxlength="256" spellcheck="false" />
+                            <div class="fieldDescription">Bearer token for OpenAI-compatible servers that require authentication (OpenAI, hosted Speaches, pfrankov/whisper-server with auth, etc.). Sent as <code>Authorization: Bearer &lt;key&gt;</code>. Leave empty for unauthenticated local servers.</div>
                         </div>
                     </details>
 


### PR DESCRIPTION
Resolves #40.

OpenAI-compatible Whisper servers commonly require a bearer token — OpenAI itself, hosted speaches, and pfrankov/whisper-server when configured with auth. The plugin had no field for one, so users running a private API server had no way to authenticate without a fork.

## Change

**`Configuration/PluginConfiguration.cs`**
- New `RemoteWhisperApiKey` string property. Empty preserves current unauthenticated behavior.

**`Providers/SubtitleProviderFactory.cs`**
- Reads the key, trims it, and passes to the provider constructor.

**`Providers/RemoteWhisperProvider.cs`**
- New constructor parameter `apiKey` (defaulted to `""` so existing call sites without the key are unaffected).
- New `ApplyAuthorization(HttpRequestMessage)` helper that sets `Authorization: Bearer <key>` only when the configured key is non-empty.
- Both `TranscribeAsync` and `DetectLanguageAsync` switch from `HttpClient.PostAsync` to `HttpClient.SendAsync` with an `HttpRequestMessage` so the authorization header can be attached request-scoped (the shared `HttpClient` instance is unchanged).

**`Web/configPage.html`**
- New password input under the Remote Whisper API collapsible, mirroring the URL / Model fields.
- `loadConfiguration` / `saveConfiguration` round-trip the new value with the same pattern.

## Acceptance

- [x] Optional API key field in plugin configuration.
- [x] When set, included as `Authorization: Bearer <key>` on transcription and language-detection requests.
- [x] Empty value keeps the existing unauthenticated path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional API key authentication for remote Whisper-compatible servers. Users can enter a key in Settings; it will be sent as a Bearer token with transcription and language-detection requests.

* **Documentation**
  * Clarified field descriptions on the Settings page (text/casing corrections) and ensured the API key field is handled/trimmed when saved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->