### PR TITLE
feat: add TranslationOnly subtitle mode

### DIFF
--- a/Configuration/SubtitleMode.cs
+++ b/Configuration/SubtitleMode.cs
@@ -16,5 +16,11 @@ namespace WhisperSubs.Configuration
         /// Generate both a complete and a forced subtitle file per track.
         /// </summary>
         FullAndForced = 2,
+
+        /// <summary>
+        /// Only generate English translated subtitles (skip native-language transcription).
+        /// Uses whisper's --translate flag in a single pass. Requires medium or large models.
+        /// </summary>
+        TranslationOnly = 3,
     }
 }

--- a/Controller/SubtitleManager.cs
+++ b/Controller/SubtitleManager.cs
@@ -46,23 +46,27 @@ namespace WhisperSubs.Controller
             var languages = await ResolveLanguagesAsync(mediaPath, language, cancellationToken);
             var subtitleMode = Plugin.Instance?.Configuration?.SubtitleMode ?? SubtitleMode.Full;
 
-            foreach (var lang in languages)
+            if (subtitleMode != SubtitleMode.TranslationOnly)
             {
-                if (subtitleMode == SubtitleMode.Full || subtitleMode == SubtitleMode.FullAndForced)
+                foreach (var lang in languages)
                 {
-                    await GenerateFullSubtitleForLanguageAsync(item, provider, lang, mediaPath, cancellationToken);
-                }
+                    if (subtitleMode == SubtitleMode.Full || subtitleMode == SubtitleMode.FullAndForced)
+                    {
+                        await GenerateFullSubtitleForLanguageAsync(item, provider, lang, mediaPath, cancellationToken);
+                    }
 
-                if (subtitleMode == SubtitleMode.ForcedOnly || subtitleMode == SubtitleMode.FullAndForced)
-                {
-                    await GenerateForcedSubtitleAsync(item, provider, lang, mediaPath, cancellationToken);
+                    if (subtitleMode == SubtitleMode.ForcedOnly || subtitleMode == SubtitleMode.FullAndForced)
+                    {
+                        await GenerateForcedSubtitleAsync(item, provider, lang, mediaPath, cancellationToken);
+                    }
                 }
             }
 
-            // Translation: generate English subs if enabled and no English audio present
+            // Translation: generate English subs when TranslationOnly mode or EnableTranslation with Full modes
             var config = Plugin.Instance?.Configuration;
-            if (config?.EnableTranslation == true
-                && (subtitleMode == SubtitleMode.Full || subtitleMode == SubtitleMode.FullAndForced))
+            if (subtitleMode == SubtitleMode.TranslationOnly
+                || (config?.EnableTranslation == true
+                    && (subtitleMode == SubtitleMode.Full || subtitleMode == SubtitleMode.FullAndForced)))
             {
                 await GenerateTranslatedSubtitleAsync(item, provider, mediaPath, languages, cancellationToken);
             }

--- a/ScheduledTasks/SubtitleGenerationTask.cs
+++ b/ScheduledTasks/SubtitleGenerationTask.cs
@@ -99,9 +99,10 @@ namespace WhisperSubs.ScheduledTasks
             // subtitles must still be considered. Only filter by HasSubtitles in Full mode.
             var needsForced = config.SubtitleMode == Configuration.SubtitleMode.ForcedOnly
                 || config.SubtitleMode == Configuration.SubtitleMode.FullAndForced;
-            var needsTranslation = config.EnableTranslation
-                && (config.SubtitleMode == Configuration.SubtitleMode.Full
-                    || config.SubtitleMode == Configuration.SubtitleMode.FullAndForced);
+            var needsTranslation = config.SubtitleMode == Configuration.SubtitleMode.TranslationOnly
+                || (config.EnableTranslation
+                    && (config.SubtitleMode == Configuration.SubtitleMode.Full
+                        || config.SubtitleMode == Configuration.SubtitleMode.FullAndForced));
 
             var includeKinds = new List<BaseItemKind> { BaseItemKind.Movie, BaseItemKind.Episode, BaseItemKind.Video };
             if (config.EnableLyricsGeneration)
@@ -242,6 +243,7 @@ namespace WhisperSubs.ScheduledTasks
                             Configuration.SubtitleMode.Full => hasFullSrt && (!needsTranslation || hasTranslatedSrt),
                             Configuration.SubtitleMode.ForcedOnly => hasForcedSrt,
                             Configuration.SubtitleMode.FullAndForced => hasFullSrt && hasForcedSrt && (!needsTranslation || hasTranslatedSrt),
+                            Configuration.SubtitleMode.TranslationOnly => hasTranslatedSrt,
                             _ => hasFullSrt
                         };
 

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -120,12 +120,16 @@
                             <option value="0">Full</option>
                             <option value="1">Forced Only</option>
                             <option value="2">Full + Forced</option>
+                            <option value="3">Translation Only (English)</option>
                         </select>
                         <div class="fieldDescription">
                             <strong>Full</strong> transcribes all speech (default).
                             <strong>Forced Only</strong> generates subtitles only for segments where the spoken language
                             differs from the audio track's primary language (e.g., French dialogue in an English movie).
                             <strong>Full + Forced</strong> generates both files per track.
+                            <strong>Translation Only</strong> skips native-language transcription entirely and only produces
+                            English translated subtitles in a single whisper pass &mdash; ideal when you only need English subs.
+                            Requires a medium or large whisper model (turbo does not support translation).
                             Forced subtitles are saved as <code>.forced.generated.srt</code> and auto-recognized by Jellyfin.
                         </div>
                     </div>
@@ -167,7 +171,7 @@
                         </div>
                     </div>
 
-                    <div class="checkboxContainer checkboxContainer-withDescription">
+                    <div id="translationCheckboxContainer" class="checkboxContainer checkboxContainer-withDescription">
                         <label>
                             <input is="emby-checkbox" type="checkbox" id="chkEnableTranslation" name="EnableTranslation" />
                             <span>Enable Translation (English)</span>
@@ -178,6 +182,7 @@
                             <br />
                             <strong>Note:</strong> Only applies when Subtitle Mode includes Full subtitles (not Forced Only).
                             Skipped automatically when English audio or English subtitles are already present.
+                            This option is implicit when using "Translation Only" mode.
                         </div>
                     </div>
 
@@ -1164,9 +1169,26 @@
                 }
             };
 
+            function updateTranslationVisibility() {
+                var mode = parseInt(document.querySelector('#selectSubtitleMode').value, 10);
+                var container = document.querySelector('#translationCheckboxContainer');
+                var checkbox = document.querySelector('#chkEnableTranslation');
+                if (mode === 3) {
+                    checkbox.checked = true;
+                    checkbox.disabled = true;
+                    container.style.opacity = '0.5';
+                } else {
+                    checkbox.disabled = false;
+                    container.style.opacity = '1';
+                }
+            }
+
+            document.querySelector('#selectSubtitleMode').addEventListener('change', updateTranslationVisibility);
+
             document.querySelector('[data-role="page"]').addEventListener('pageshow', function () {
                 WhisperSubsConfig.loadConfiguration(this);
                 WhisperSubsConfig.loadEngine();
+                setTimeout(updateTranslationVisibility, 100);
                 // Check if transcription is already running and show banner
                 WhisperSubsConfig.pollQueueStatus();
                 WhisperSubsConfig.ajaxGet(ApiClient.getUrl('Plugins/WhisperSubs/Queue'))

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -815,6 +815,7 @@
                             page.querySelector('#chkEnableAutoGeneration').checked = config.EnableAutoGeneration || false;
                             page.querySelector('#chkEnableLyricsGeneration').checked = config.EnableLyricsGeneration || false;
                             page.querySelector('#chkEnableTranslation').checked = config.EnableTranslation || false;
+                            updateTranslationVisibility();
                         }
                             WhisperSubsConfig.loadLibraries();
                         WhisperSubsConfig.loadLibrarySelector(config ? config.EnabledLibraries || [] : []);
@@ -834,7 +835,8 @@
                         config.SubtitleMode = parseInt(page.querySelector('#selectSubtitleMode').value, 10) || 0;
                         config.EnableAutoGeneration = page.querySelector('#chkEnableAutoGeneration').checked;
                         config.EnableLyricsGeneration = page.querySelector('#chkEnableLyricsGeneration').checked;
-                        config.EnableTranslation = page.querySelector('#chkEnableTranslation').checked;
+                        var subtitleMode = parseInt(page.querySelector('#selectSubtitleMode').value, 10) || 0;
+                        config.EnableTranslation = subtitleMode !== 3 && page.querySelector('#chkEnableTranslation').checked;
 
                         // Collect enabled libraries from checkboxes
                         var libraryCheckboxes = page.querySelectorAll('.chkLibrary');
@@ -1196,7 +1198,6 @@
             document.querySelector('[data-role="page"]').addEventListener('pageshow', function () {
                 WhisperSubsConfig.loadConfiguration(this);
                 WhisperSubsConfig.loadEngine();
-                setTimeout(updateTranslationVisibility, 100);
                 // Check if transcription is already running and show banner
                 WhisperSubsConfig.pollQueueStatus();
                 WhisperSubsConfig.ajaxGet(ApiClient.getUrl('Plugins/WhisperSubs/Queue'))

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -1169,15 +1169,23 @@
                 }
             };
 
+            var _savedTranslationState = null;
             function updateTranslationVisibility() {
                 var mode = parseInt(document.querySelector('#selectSubtitleMode').value, 10);
                 var container = document.querySelector('#translationCheckboxContainer');
                 var checkbox = document.querySelector('#chkEnableTranslation');
                 if (mode === 3) {
+                    if (_savedTranslationState === null) {
+                        _savedTranslationState = checkbox.checked;
+                    }
                     checkbox.checked = true;
                     checkbox.disabled = true;
                     container.style.opacity = '0.5';
                 } else {
+                    if (_savedTranslationState !== null) {
+                        checkbox.checked = _savedTranslationState;
+                        _savedTranslationState = null;
+                    }
                     checkbox.disabled = false;
                     container.style.opacity = '1';
                 }

--- a/WhisperSubs.Tests/ConfigurationTests.cs
+++ b/WhisperSubs.Tests/ConfigurationTests.cs
@@ -28,13 +28,14 @@ public class ConfigurationTests
         Assert.Equal(0, (int)SubtitleMode.Full);
         Assert.Equal(1, (int)SubtitleMode.ForcedOnly);
         Assert.Equal(2, (int)SubtitleMode.FullAndForced);
+        Assert.Equal(3, (int)SubtitleMode.TranslationOnly);
     }
 
     [Fact]
     public void SubtitleMode_AllValuesAreDefined()
     {
         var values = Enum.GetValues<SubtitleMode>();
-        Assert.Equal(3, values.Length);
+        Assert.Equal(4, values.Length);
     }
 
     [Theory]
@@ -42,9 +43,11 @@ public class ConfigurationTests
     [InlineData("{\"SubtitleMode\": 0}", SubtitleMode.Full)]
     [InlineData("{\"SubtitleMode\": 1}", SubtitleMode.ForcedOnly)]
     [InlineData("{\"SubtitleMode\": 2}", SubtitleMode.FullAndForced)]
+    [InlineData("{\"SubtitleMode\": 3}", SubtitleMode.TranslationOnly)]
     [InlineData("{\"SubtitleMode\": 99}", SubtitleMode.Full)]
     [InlineData("{\"SubtitleMode\": -1}", SubtitleMode.Full)]
     [InlineData("{\"SubtitleMode\": \"ForcedOnly\"}", SubtitleMode.ForcedOnly)]
+    [InlineData("{\"SubtitleMode\": \"TranslationOnly\"}", SubtitleMode.TranslationOnly)]
     public void SubtitleModeConverter_HandlesEdgeCases(string json, SubtitleMode expected)
     {
         var config = JsonSerializer.Deserialize<PluginConfiguration>(json);

--- a/WhisperSubs.Tests/SubtitleModeConverterTests.cs
+++ b/WhisperSubs.Tests/SubtitleModeConverterTests.cs
@@ -20,6 +20,7 @@ public class SubtitleModeConverterTests
     [InlineData("0", SubtitleMode.Full)]
     [InlineData("1", SubtitleMode.ForcedOnly)]
     [InlineData("2", SubtitleMode.FullAndForced)]
+    [InlineData("3", SubtitleMode.TranslationOnly)]
     public void Read_ValidIntegers(string value, SubtitleMode expected)
     {
         var json = value;
@@ -49,8 +50,10 @@ public class SubtitleModeConverterTests
     [InlineData("\"Full\"", SubtitleMode.Full)]
     [InlineData("\"ForcedOnly\"", SubtitleMode.ForcedOnly)]
     [InlineData("\"FullAndForced\"", SubtitleMode.FullAndForced)]
+    [InlineData("\"TranslationOnly\"", SubtitleMode.TranslationOnly)]
     [InlineData("\"full\"", SubtitleMode.Full)]
     [InlineData("\"forcedonly\"", SubtitleMode.ForcedOnly)]
+    [InlineData("\"translationonly\"", SubtitleMode.TranslationOnly)]
     public void Read_ValidStrings(string json, SubtitleMode expected)
     {
         var result = JsonSerializer.Deserialize<SubtitleMode>(json, Options);
@@ -80,6 +83,7 @@ public class SubtitleModeConverterTests
     [InlineData(SubtitleMode.Full, "0")]
     [InlineData(SubtitleMode.ForcedOnly, "1")]
     [InlineData(SubtitleMode.FullAndForced, "2")]
+    [InlineData(SubtitleMode.TranslationOnly, "3")]
     public void Write_ProducesInteger(SubtitleMode mode, string expected)
     {
         var json = JsonSerializer.Serialize(mode, Options);
@@ -92,6 +96,7 @@ public class SubtitleModeConverterTests
     [InlineData(SubtitleMode.Full)]
     [InlineData(SubtitleMode.ForcedOnly)]
     [InlineData(SubtitleMode.FullAndForced)]
+    [InlineData(SubtitleMode.TranslationOnly)]
     public void Roundtrip_AllValues(SubtitleMode original)
     {
         var json = JsonSerializer.Serialize(original, Options);

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.13.2.0</Version>
+    <Version>3.14.0.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
## Summary

Closes #44.

Adds a new `TranslationOnly` subtitle mode (`SubtitleMode=3`) that skips native-language transcription entirely and only produces English translated subtitles via whisper's `--translate` flag in a single pass.

This halves processing time for users who only want English subs from foreign-language media — instead of transcribing the original language first and then translating, it goes directly to English output.

### Changes

- **`Configuration/SubtitleMode.cs`**: New enum value `TranslationOnly = 3`
- **`Controller/SubtitleManager.cs`**: When TranslationOnly mode is active, the native transcription `foreach` loop is skipped entirely. Translation runs unconditionally (no `EnableTranslation` guard needed since the mode itself implies it)
- **`ScheduledTasks/SubtitleGenerationTask.cs`**: Updated `needsTranslation` computation and `alreadyComplete` switch to handle TranslationOnly (only checks for `.en.translated.srt`)
- **`Web/configPage.html`**: New dropdown option "Translation Only (English)" with description. Translation checkbox auto-checks and disables when this mode is selected (implicit)
- **Version bump**: 3.13.2.0 → 3.14.0.0

### Important notes

- Requires a **medium or large** whisper model — the turbo model does not support translation
- Skipped automatically when English audio is already present (same safeguard as regular translation)
- The `EnableTranslation` checkbox becomes implicit/redundant when TranslationOnly is selected

## Test plan

- [ ] Set mode to "Translation Only", verify no `.generated.srt` files are created (only `.en.translated.srt`)
- [ ] Verify items with existing `.en.translated.srt` are skipped
- [ ] Verify English-audio items are skipped entirely
- [ ] Switch back to "Full" mode, verify normal transcription resumes
- [ ] Verify UI: translation checkbox auto-checks and greys out when TranslationOnly selected
- [ ] Verify UI: translation checkbox re-enables when switching to other modes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Translation Only (English)" subtitle mode to generate exclusively English-translated subtitles without per-language versions
  * Updated interface to automatically manage translation settings when this mode is selected
  * Requires medium or large Whisper models for this mode
  * Version bumped to 3.14.0.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->