### PR TITLE
fix: disable OpenMP in noavx build to remove libgomp dependency

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -36,7 +36,7 @@ jobs:
           - os: ubuntu-24.04
             variant: cpu-noavx
             asset_name: whisper-cli-linux-x64-noavx
-            cmake_flags: "-DGGML_NATIVE=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_BMI2=OFF -DGGML_SSE42=ON"
+            cmake_flags: "-DGGML_NATIVE=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_BMI2=OFF -DGGML_SSE42=ON -DGGML_OPENMP=OFF"
             pre_install: ""
           - os: ubuntu-24.04-arm
             variant: cpu
@@ -60,7 +60,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/whisper-${{ matrix.variant }}/build/bin/whisper-cli
-          key: whisper-1.8.4-${{ matrix.asset_name }}-v4
+          key: whisper-1.8.4-${{ matrix.asset_name }}-v5
 
       - name: Install build dependencies
         if: steps.cache-whisper.outputs.cache-hit != 'true'

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.14.0.0</Version>
+    <Version>3.14.1.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
## Summary
- Adds `-DGGML_OPENMP=OFF` to the `cpu-noavx` whisper-cli build variant
- Bumps cache key to force rebuild
- Version bump to 3.14.1.0

The noavx binary targets minimal container environments (TrueNAS Scale, barebones Docker) that don't ship `libgomp.so.1`. whisper.cpp falls back to its own pthreads thread pool when OpenMP is disabled — negligible performance difference for inference.

Fixes #46