### PR TITLE
fix: add noavx compatibility variant to Setup tab

### DIFF
--- a/Setup/BinaryCatalog.cs
+++ b/Setup/BinaryCatalog.cs
@@ -9,6 +9,8 @@ namespace WhisperSubs.Setup
         {
             new BinaryVariant("cpu", "CPU Only",
                 "Works on any system. No GPU required.", true),
+            new BinaryVariant("noavx", "CPU (Compatibility)",
+                "Maximum compatibility — no AVX, no OpenMP. Recommended for containers (TrueNAS Scale, minimal Docker images).", false),
             new BinaryVariant("cuda12", "NVIDIA CUDA 12",
                 "Hardware-accelerated via NVIDIA GPU (CUDA 12). Requires NVIDIA drivers.", false),
             new BinaryVariant("vulkan", "Vulkan (Intel / AMD / NVIDIA)",
@@ -37,7 +39,7 @@ namespace WhisperSubs.Setup
             return platform switch
             {
                 "linux-x64" => Variants,
-                "linux-arm64" => Variants.Where(v => v.Id == "cpu").ToArray(),
+                "linux-arm64" => Variants.Where(v => v.Id == "cpu" || v.Id == "noavx").ToArray(),
                 _ => Array.Empty<BinaryVariant>()
             };
         }

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -701,6 +701,9 @@
                             hint.textContent = 'No GPU render device detected. This variant requires a GPU with Vulkan support.';
                             hint.style.color = '#CC7B19';
                         }
+                    } else if (variant === 'noavx') {
+                        hint.textContent = 'Compatibility variant \u2014 no AVX or OpenMP required. Recommended for containers (TrueNAS Scale, minimal Docker).';
+                        hint.style.color = '';
                     } else {
                         // CPU
                         if (gpuInfo.HasNvidia || gpuInfo.HasAmdGpu || gpuInfo.HasRenderDevice) {

--- a/WhisperSubs.Tests/BinaryCatalogTests.cs
+++ b/WhisperSubs.Tests/BinaryCatalogTests.cs
@@ -8,8 +8,9 @@ public class BinaryCatalogTests
     [Fact]
     public void Variants_ContainsExpectedEntries()
     {
-        Assert.Equal(4, BinaryCatalog.Variants.Length);
+        Assert.Equal(5, BinaryCatalog.Variants.Length);
         Assert.Contains(BinaryCatalog.Variants, v => v.Id == "cpu");
+        Assert.Contains(BinaryCatalog.Variants, v => v.Id == "noavx");
         Assert.Contains(BinaryCatalog.Variants, v => v.Id == "cuda12");
         Assert.Contains(BinaryCatalog.Variants, v => v.Id == "vulkan");
         Assert.Contains(BinaryCatalog.Variants, v => v.Id == "rocm");
@@ -23,6 +24,14 @@ public class BinaryCatalogTests
     }
 
     [Fact]
+    public void Variants_NoavxIsNotDefault()
+    {
+        var noavx = Assert.Single(BinaryCatalog.Variants, v => v.Id == "noavx");
+        Assert.Equal("CPU (Compatibility)", noavx.DisplayName);
+        Assert.False(noavx.IsDefault);
+    }
+
+    [Fact]
     public void Variants_NonCpuAreNotDefault()
     {
         foreach (var v in BinaryCatalog.Variants.Where(v => v.Id != "cpu"))
@@ -33,10 +42,12 @@ public class BinaryCatalogTests
 
     [Theory]
     [InlineData("linux-x64", "cpu", "whisper-cli-linux-x64")]
+    [InlineData("linux-x64", "noavx", "whisper-cli-linux-x64-noavx")]
     [InlineData("linux-x64", "cuda12", "whisper-cli-linux-x64-cuda12")]
     [InlineData("linux-x64", "vulkan", "whisper-cli-linux-x64-vulkan")]
     [InlineData("linux-x64", "rocm", "whisper-cli-linux-x64-rocm")]
     [InlineData("linux-arm64", "cpu", "whisper-cli-linux-arm64")]
+    [InlineData("linux-arm64", "noavx", "whisper-cli-linux-arm64-noavx")]
     [InlineData("win-x64", "cpu", "whisper-cli-win-x64")]
     [InlineData("osx-arm64", "cpu", "whisper-cli-osx-arm64")]
     public void GetAssetName_ReturnsCorrectName(string platform, string variant, string expected)
@@ -48,15 +59,16 @@ public class BinaryCatalogTests
     public void GetAvailableVariants_LinuxX64_ReturnsAll()
     {
         var variants = BinaryCatalog.GetAvailableVariants("linux-x64");
-        Assert.Equal(4, variants.Length);
+        Assert.Equal(5, variants.Length);
     }
 
     [Fact]
-    public void GetAvailableVariants_LinuxArm64_ReturnsCpuOnly()
+    public void GetAvailableVariants_LinuxArm64_ReturnsCpuAndNoavx()
     {
         var variants = BinaryCatalog.GetAvailableVariants("linux-arm64");
-        Assert.Single(variants);
-        Assert.Equal("cpu", variants[0].Id);
+        Assert.Equal(2, variants.Length);
+        Assert.Contains(variants, v => v.Id == "cpu");
+        Assert.Contains(variants, v => v.Id == "noavx");
     }
 
     [Theory]

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.14.1.0</Version>
+    <Version>3.14.2.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
## Summary
- Adds "CPU (Compatibility)" variant to `BinaryCatalog` mapping to the `whisper-cli-linux-x64-noavx` release asset
- Adds dedicated hint text in the Setup UI explaining this is for containers without AVX/OpenMP
- Makes noavx available on linux-arm64 too (same container limitation applies)
- Version bump to 3.14.2.0

Users on TrueNAS Scale / minimal Docker containers couldn't find the noavx binary in the plugin's Setup tab — it only existed as a manual download from the releases page.

Fixes #46