### PR TITLE
fix: build whisper binaries on Ubuntu 22.04 for glibc compatibility

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -28,12 +28,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-24.04
+          - os: ubuntu-22.04
             variant: cpu
             asset_name: whisper-cli-linux-x64
             cmake_flags: "-DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON -DGGML_BMI2=ON"
             pre_install: ""
-          - os: ubuntu-24.04
+          - os: ubuntu-22.04
             variant: cpu-noavx
             asset_name: whisper-cli-linux-x64-noavx
             cmake_flags: "-DGGML_NATIVE=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_BMI2=OFF -DGGML_SSE42=ON -DGGML_OPENMP=OFF"
@@ -43,12 +43,12 @@ jobs:
             asset_name: whisper-cli-linux-arm64
             cmake_flags: ""
             pre_install: ""
-          - os: ubuntu-24.04
+          - os: ubuntu-22.04
             variant: cuda12
             asset_name: whisper-cli-linux-x64-cuda12
             cmake_flags: "-DGGML_CUDA=ON"
             pre_install: "cuda"
-          - os: ubuntu-24.04
+          - os: ubuntu-22.04
             variant: vulkan
             asset_name: whisper-cli-linux-x64-vulkan
             cmake_flags: "-DGGML_VULKAN=ON"
@@ -60,7 +60,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/whisper-${{ matrix.variant }}/build/bin/whisper-cli
-          key: whisper-1.8.4-${{ matrix.asset_name }}-v5
+          key: whisper-1.8.4-${{ matrix.asset_name }}-v6
 
       - name: Install build dependencies
         if: steps.cache-whisper.outputs.cache-hit != 'true'

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.14.2.0</Version>
+    <Version>3.14.3.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
## Summary
- Switches x64 whisper-cli builds from Ubuntu 24.04 to Ubuntu 22.04
- Ubuntu 24.04 links against glibc 2.38, which doesn't exist on Debian 12 (glibc 2.36)
- Ubuntu 22.04 targets glibc 2.35, covering Debian 12+, Ubuntu 22.04+, and all current distros
- Bumps cache key to force rebuild
- Version bump to 3.14.3.0

ARM64 stays on 24.04 (no 22.04-arm runner available). ROCm already uses `rocm/dev-ubuntu-22.04` container so it's unaffected.

Fixes #50