### PR TITLE
feat: pause subtitle generation during active playback

### DIFF
--- a/Configuration/PluginConfiguration.cs
+++ b/Configuration/PluginConfiguration.cs
@@ -65,6 +65,12 @@ namespace WhisperSubs.Configuration
         /// </summary>
         public string RemoteWhisperApiKey { get; set; } = "";
 
+        /// <summary>
+        /// When enabled, subtitle generation pauses while any user is actively
+        /// playing media and resumes automatically when playback stops.
+        /// </summary>
+        public bool PauseOnPlayback { get; set; } = false;
+
         public List<string> EnabledLibraries { get; set; } = new List<string>();
 
         public PluginConfiguration()

--- a/ScheduledTasks/SubtitleGenerationTask.cs
+++ b/ScheduledTasks/SubtitleGenerationTask.cs
@@ -308,8 +308,14 @@ namespace WhisperSubs.ScheduledTasks
         private async Task WaitForPlaybackIdleAsync(CancellationToken cancellationToken)
         {
             bool logged = false;
+            var deadline = DateTime.UtcNow.AddHours(4);
             while (_sessionManager.Sessions.Any(s => s.NowPlayingItem != null))
             {
+                if (DateTime.UtcNow >= deadline)
+                {
+                    _logger.LogWarning("Playback still active after 4 hours — resuming subtitle generation to avoid indefinite stall");
+                    break;
+                }
                 if (!logged)
                 {
                     _logger.LogInformation("Active playback detected — pausing subtitle generation until idle");

--- a/ScheduledTasks/SubtitleGenerationTask.cs
+++ b/ScheduledTasks/SubtitleGenerationTask.cs
@@ -305,10 +305,11 @@ namespace WhisperSubs.ScheduledTasks
                 completed, failed);
         }
 
-        private async Task WaitForPlaybackIdleAsync(CancellationToken cancellationToken)
+        internal async Task WaitForPlaybackIdleAsync(CancellationToken cancellationToken)
         {
             bool logged = false;
             var deadline = DateTime.UtcNow.AddHours(4);
+            var queue = SubtitleQueueService.Instance;
             while (_sessionManager.Sessions.Any(s => s.NowPlayingItem != null))
             {
                 if (DateTime.UtcNow >= deadline)
@@ -319,12 +320,14 @@ namespace WhisperSubs.ScheduledTasks
                 if (!logged)
                 {
                     _logger.LogInformation("Active playback detected — pausing subtitle generation until idle");
+                    queue.ReportPhase("Waiting for playback to stop");
                     logged = true;
                 }
                 await Task.Delay(TimeSpan.FromSeconds(15), cancellationToken);
             }
             if (logged)
             {
+                queue.ReportPhase(null!);
                 _logger.LogInformation("Playback stopped — resuming subtitle generation");
             }
         }

--- a/ScheduledTasks/SubtitleGenerationTask.cs
+++ b/ScheduledTasks/SubtitleGenerationTask.cs
@@ -8,6 +8,7 @@ using WhisperSubs.Providers;
 using Jellyfin.Data.Enums;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Session;
 using MediaBrowser.Model.Tasks;
 using Microsoft.Extensions.Logging;
 
@@ -16,15 +17,18 @@ namespace WhisperSubs.ScheduledTasks
     public class SubtitleGenerationTask : IScheduledTask
     {
         private readonly ILibraryManager _libraryManager;
+        private readonly ISessionManager _sessionManager;
         private readonly ILoggerFactory _loggerFactory;
         private readonly ILogger<SubtitleGenerationTask> _logger;
 
         public SubtitleGenerationTask(
             ILibraryManager libraryManager,
+            ISessionManager sessionManager,
             ILogger<SubtitleGenerationTask> logger,
             ILoggerFactory loggerFactory)
         {
             _libraryManager = libraryManager;
+            _sessionManager = sessionManager;
             _logger = logger;
             _loggerFactory = loggerFactory;
         }
@@ -156,6 +160,12 @@ namespace WhisperSubs.ScheduledTasks
             for (int i = 0; i < allItems.Count; i++)
             {
                 cancellationToken.ThrowIfCancellationRequested();
+
+                // Wait for active playback to finish before processing next item
+                if (config.PauseOnPlayback)
+                {
+                    await WaitForPlaybackIdleAsync(cancellationToken);
+                }
 
                 // Drain any priority (manual) requests first
                 if (queue.PriorityCount > 0)
@@ -293,6 +303,24 @@ namespace WhisperSubs.ScheduledTasks
             queue.ReportTaskComplete();
             _logger.LogInformation("Subtitle generation task complete. Processed: {Processed}, Failed: {Failed}",
                 completed, failed);
+        }
+
+        private async Task WaitForPlaybackIdleAsync(CancellationToken cancellationToken)
+        {
+            bool logged = false;
+            while (_sessionManager.Sessions.Any(s => s.NowPlayingItem != null))
+            {
+                if (!logged)
+                {
+                    _logger.LogInformation("Active playback detected — pausing subtitle generation until idle");
+                    logged = true;
+                }
+                await Task.Delay(TimeSpan.FromSeconds(15), cancellationToken);
+            }
+            if (logged)
+            {
+                _logger.LogInformation("Playback stopped — resuming subtitle generation");
+            }
         }
     }
 }

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -186,6 +186,17 @@
                         </div>
                     </div>
 
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label>
+                            <input is="emby-checkbox" type="checkbox" id="chkPauseOnPlayback" name="PauseOnPlayback" />
+                            <span>Pause generation during playback</span>
+                        </label>
+                        <div class="fieldDescription">
+                            When enabled, subtitle generation automatically pauses while any user is playing media
+                            and resumes when playback stops. Prevents transcoding stuttering on resource-constrained servers.
+                        </div>
+                    </div>
+
                     <!-- ── Advanced / Manual Install ──────────────────── -->
                     <details style="margin-top:1.5em;">
                         <summary style="cursor:pointer; font-size:1.2em; font-weight:bold; padding:0.5em 0;">Remote Whisper API (Optional)</summary>
@@ -818,6 +829,7 @@
                             page.querySelector('#chkEnableAutoGeneration').checked = config.EnableAutoGeneration || false;
                             page.querySelector('#chkEnableLyricsGeneration').checked = config.EnableLyricsGeneration || false;
                             page.querySelector('#chkEnableTranslation').checked = config.EnableTranslation || false;
+                            page.querySelector('#chkPauseOnPlayback').checked = config.PauseOnPlayback || false;
                             updateTranslationVisibility();
                         }
                             WhisperSubsConfig.loadLibraries();
@@ -840,6 +852,7 @@
                         config.EnableLyricsGeneration = page.querySelector('#chkEnableLyricsGeneration').checked;
                         var subtitleMode = parseInt(page.querySelector('#selectSubtitleMode').value, 10) || 0;
                         config.EnableTranslation = subtitleMode !== 3 && page.querySelector('#chkEnableTranslation').checked;
+                        config.PauseOnPlayback = page.querySelector('#chkPauseOnPlayback').checked;
 
                         // Collect enabled libraries from checkboxes
                         var libraryCheckboxes = page.querySelectorAll('.chkLibrary');

--- a/WhisperSubs.Tests/ConfigurationTests.cs
+++ b/WhisperSubs.Tests/ConfigurationTests.cs
@@ -17,6 +17,7 @@ public class ConfigurationTests
         Assert.Equal("auto", config.DefaultLanguage);
         Assert.Equal(SubtitleMode.Full, config.SubtitleMode);
         Assert.False(config.EnableLyricsGeneration);
+        Assert.False(config.PauseOnPlayback);
         Assert.Equal(0, config.WhisperThreadCount);
         Assert.NotNull(config.EnabledLibraries);
         Assert.Empty(config.EnabledLibraries);

--- a/WhisperSubs.Tests/PlaybackPauseTests.cs
+++ b/WhisperSubs.Tests/PlaybackPauseTests.cs
@@ -1,0 +1,98 @@
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Session;
+using MediaBrowser.Model.Dto;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using WhisperSubs.ScheduledTasks;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+public class PlaybackPauseTests
+{
+    private readonly Mock<ILibraryManager> _libraryManager = new();
+    private readonly Mock<ISessionManager> _sessionManager = new();
+    private readonly ILogger<SubtitleGenerationTask> _logger = NullLogger<SubtitleGenerationTask>.Instance;
+    private readonly ILoggerFactory _loggerFactory = NullLoggerFactory.Instance;
+
+    private SubtitleGenerationTask CreateTask() =>
+        new(_libraryManager.Object, _sessionManager.Object, _logger, _loggerFactory);
+
+    [Fact]
+    public async Task WaitForPlaybackIdle_NoActiveSessions_ReturnsImmediately()
+    {
+        _sessionManager.Setup(s => s.Sessions)
+            .Returns(Array.Empty<SessionInfo>());
+
+        var task = CreateTask();
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+
+        await task.WaitForPlaybackIdleAsync(cts.Token);
+        // Should not throw or timeout
+    }
+
+    [Fact]
+    public async Task WaitForPlaybackIdle_NoPlayingItem_ReturnsImmediately()
+    {
+        var session = new SessionInfo(null!, null!) { NowPlayingItem = null };
+        _sessionManager.Setup(s => s.Sessions)
+            .Returns(new[] { session });
+
+        var task = CreateTask();
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+
+        await task.WaitForPlaybackIdleAsync(cts.Token);
+    }
+
+    [Fact]
+    public async Task WaitForPlaybackIdle_ActivePlayback_WaitsUntilStopped()
+    {
+        var playingItem = new BaseItemDto { Name = "Test Movie" };
+        var session = new SessionInfo(null!, null!) { NowPlayingItem = playingItem };
+
+        int callCount = 0;
+        _sessionManager.Setup(s => s.Sessions)
+            .Returns(() =>
+            {
+                callCount++;
+                if (callCount >= 2)
+                    session.NowPlayingItem = null;
+                return new[] { session };
+            });
+
+        var task = CreateTask();
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+        await task.WaitForPlaybackIdleAsync(cts.Token);
+
+        Assert.True(callCount >= 2);
+    }
+
+    [Fact]
+    public async Task WaitForPlaybackIdle_CancellationToken_ThrowsOnCancel()
+    {
+        var playingItem = new BaseItemDto { Name = "Test Movie" };
+        var session = new SessionInfo(null!, null!) { NowPlayingItem = playingItem };
+        _sessionManager.Setup(s => s.Sessions)
+            .Returns(new[] { session });
+
+        var task = CreateTask();
+        var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => task.WaitForPlaybackIdleAsync(cts.Token));
+    }
+
+    [Fact]
+    public async Task WaitForPlaybackIdle_EmptySessions_ReturnsImmediately()
+    {
+        _sessionManager.Setup(s => s.Sessions)
+            .Returns(new List<SessionInfo>());
+
+        var task = CreateTask();
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+
+        await task.WaitForPlaybackIdleAsync(cts.Token);
+    }
+}

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.14.3.0</Version>
+    <Version>3.15.0.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
## Summary
- Adds `PauseOnPlayback` config option with UI checkbox
- When enabled, the scheduled task checks `ISessionManager.Sessions` between items
- If any user is actively playing media, generation waits (polls every 15s) until playback stops
- Logs when pausing and resuming for visibility
- No performance overhead when disabled (single boolean check)

## Implementation
Minimal approach: polls `Sessions.Any(s => s.NowPlayingItem != null)` at the natural yield point between items in the task loop. No event subscriptions, no background services, no new classes — just one method on the existing task.

Closes #49