### PR TITLE
feat: add GPU compatibility variants for older CPUs

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -273,7 +273,9 @@ jobs:
             whisper-cli-linux-x64-noavx
             whisper-cli-linux-arm64
             whisper-cli-linux-x64-cuda12
+            whisper-cli-linux-x64-cuda12-noavx
             whisper-cli-linux-x64-vulkan
+            whisper-cli-linux-x64-vulkan-noavx
             whisper-cli-linux-x64-rocm
           generate_release_notes: true
         env:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -46,12 +46,22 @@ jobs:
           - os: ubuntu-22.04
             variant: cuda12
             asset_name: whisper-cli-linux-x64-cuda12
-            cmake_flags: "-DGGML_CUDA=ON"
+            cmake_flags: "-DGGML_CUDA=ON -DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON -DGGML_BMI2=ON"
+            pre_install: "cuda"
+          - os: ubuntu-22.04
+            variant: cuda12-noavx
+            asset_name: whisper-cli-linux-x64-cuda12-noavx
+            cmake_flags: "-DGGML_CUDA=ON -DGGML_NATIVE=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_BMI2=OFF -DGGML_SSE42=ON -DGGML_OPENMP=OFF"
             pre_install: "cuda"
           - os: ubuntu-24.04
             variant: vulkan
             asset_name: whisper-cli-linux-x64-vulkan
-            cmake_flags: "-DGGML_VULKAN=ON"
+            cmake_flags: "-DGGML_VULKAN=ON -DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON -DGGML_BMI2=ON"
+            pre_install: "vulkan"
+          - os: ubuntu-24.04
+            variant: vulkan-noavx
+            asset_name: whisper-cli-linux-x64-vulkan-noavx
+            cmake_flags: "-DGGML_VULKAN=ON -DGGML_NATIVE=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_BMI2=OFF -DGGML_SSE42=ON -DGGML_OPENMP=OFF"
             pre_install: "vulkan"
     runs-on: ${{ matrix.os }}
     steps:
@@ -60,7 +70,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/whisper-${{ matrix.variant }}/build/bin/whisper-cli
-          key: whisper-1.8.4-${{ matrix.asset_name }}-v6
+          key: whisper-1.8.4-${{ matrix.asset_name }}-v7
 
       - name: Install build dependencies
         if: steps.cache-whisper.outputs.cache-hit != 'true'

--- a/Setup/BinaryCatalog.cs
+++ b/Setup/BinaryCatalog.cs
@@ -13,8 +13,12 @@ namespace WhisperSubs.Setup
                 "Maximum compatibility — no AVX, no OpenMP. Recommended for containers (TrueNAS Scale, minimal Docker images).", false),
             new BinaryVariant("cuda12", "NVIDIA CUDA 12",
                 "Hardware-accelerated via NVIDIA GPU (CUDA 12). Requires NVIDIA drivers.", false),
+            new BinaryVariant("cuda12-noavx", "NVIDIA CUDA 12 (Compatibility)",
+                "CUDA 12 GPU acceleration with no AVX/OpenMP. For older CPUs + NVIDIA GPU (e.g. TrueNAS Scale).", false),
             new BinaryVariant("vulkan", "Vulkan (Intel / AMD / NVIDIA)",
                 "Cross-vendor GPU acceleration via Vulkan. Works with Intel iGPU, AMD, and NVIDIA.", false),
+            new BinaryVariant("vulkan-noavx", "Vulkan (Compatibility)",
+                "Vulkan GPU acceleration with no AVX/OpenMP. For older CPUs + GPU (e.g. TrueNAS Scale).", false),
             new BinaryVariant("rocm", "AMD ROCm",
                 "Hardware-accelerated via AMD GPU (ROCm / HIP). Requires AMD ROCm drivers.", false),
         };

--- a/WhisperSubs.Tests/BinaryCatalogTests.cs
+++ b/WhisperSubs.Tests/BinaryCatalogTests.cs
@@ -8,11 +8,13 @@ public class BinaryCatalogTests
     [Fact]
     public void Variants_ContainsExpectedEntries()
     {
-        Assert.Equal(5, BinaryCatalog.Variants.Length);
+        Assert.Equal(7, BinaryCatalog.Variants.Length);
         Assert.Contains(BinaryCatalog.Variants, v => v.Id == "cpu");
         Assert.Contains(BinaryCatalog.Variants, v => v.Id == "noavx");
         Assert.Contains(BinaryCatalog.Variants, v => v.Id == "cuda12");
+        Assert.Contains(BinaryCatalog.Variants, v => v.Id == "cuda12-noavx");
         Assert.Contains(BinaryCatalog.Variants, v => v.Id == "vulkan");
+        Assert.Contains(BinaryCatalog.Variants, v => v.Id == "vulkan-noavx");
         Assert.Contains(BinaryCatalog.Variants, v => v.Id == "rocm");
     }
 
@@ -44,7 +46,9 @@ public class BinaryCatalogTests
     [InlineData("linux-x64", "cpu", "whisper-cli-linux-x64")]
     [InlineData("linux-x64", "noavx", "whisper-cli-linux-x64-noavx")]
     [InlineData("linux-x64", "cuda12", "whisper-cli-linux-x64-cuda12")]
+    [InlineData("linux-x64", "cuda12-noavx", "whisper-cli-linux-x64-cuda12-noavx")]
     [InlineData("linux-x64", "vulkan", "whisper-cli-linux-x64-vulkan")]
+    [InlineData("linux-x64", "vulkan-noavx", "whisper-cli-linux-x64-vulkan-noavx")]
     [InlineData("linux-x64", "rocm", "whisper-cli-linux-x64-rocm")]
     [InlineData("linux-arm64", "cpu", "whisper-cli-linux-arm64")]
     [InlineData("linux-arm64", "noavx", "whisper-cli-linux-arm64-noavx")]
@@ -59,7 +63,7 @@ public class BinaryCatalogTests
     public void GetAvailableVariants_LinuxX64_ReturnsAll()
     {
         var variants = BinaryCatalog.GetAvailableVariants("linux-x64");
-        Assert.Equal(5, variants.Length);
+        Assert.Equal(7, variants.Length);
     }
 
     [Fact]

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.15.0.0</Version>
+    <Version>3.16.0.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
## Summary
- Adds `cuda12-noavx` and `vulkan-noavx` build variants for users with older CPUs (no AVX) + dedicated GPU
- Pins explicit CPU flags (`NATIVE=OFF`, `AVX=ON/OFF`, etc.) on all GPU builds to prevent runner-native instructions leaking into release binaries
- Addresses https://github.com/GeiserX/whisper-subs/issues/46#issuecomment-4407821934 — user with GTX 1050 Ti on TrueNAS Scale couldn't use GPU acceleration

## Changes
- `.github/workflows/build-release.yml`: 2 new matrix entries (cuda12-noavx, vulkan-noavx), explicit flags on cuda12/vulkan, cache key v7
- `Setup/BinaryCatalog.cs`: 2 new dropdown entries ("NVIDIA CUDA 12 (Compatibility)", "Vulkan (Compatibility)")
- `WhisperSubs.csproj`: version bump 3.15.0.0 → 3.16.0.0

## Test plan
- [ ] CI builds all 9 variants successfully (cpu, noavx, arm64, cuda12, cuda12-noavx, vulkan, vulkan-noavx, rocm)
- [ ] Setup tab shows new variants in dropdown
- [ ] User with old CPU + NVIDIA GPU can download and run cuda12-noavx without illegal instruction crash

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced additional GPU-accelerated build variants (CUDA and Vulkan) designed for compatibility with systems featuring older processors or limited instruction set support.

* **Chores**
  * Version bumped to 3.16.0.0.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GeiserX/whisper-subs/pull/53)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->