### PR TITLE
feat: add search/filter box in Subtitle Management

### DIFF
--- a/Api/SubtitleController.cs
+++ b/Api/SubtitleController.cs
@@ -92,22 +92,21 @@ namespace WhisperSubs.Api
                 var config = Plugin.Instance.Configuration;
                 var typeStr = config.EnableLyricsGeneration ? "Movie,Episode,Video,Audio" : "Movie,Episode,Video";
                 var includeTypes = GetBaseItemKinds(typeStr);
-                var allItems = _libraryManager.GetItemList(new MediaBrowser.Controller.Entities.InternalItemsQuery
+                var query = new MediaBrowser.Controller.Entities.InternalItemsQuery
                 {
                     ParentId = library.Id,
                     IncludeItemTypes = includeTypes,
                     Recursive = true
-                }).Where(item => !string.IsNullOrEmpty(item.Path));
+                };
 
                 if (!string.IsNullOrWhiteSpace(searchTerm))
                 {
-                    var term = searchTerm.Trim();
-                    allItems = allItems.Where(item =>
-                        (item.Name != null && item.Name.Contains(term, StringComparison.OrdinalIgnoreCase)) ||
-                        (item.Path != null && System.IO.Path.GetFileName(item.Path).Contains(term, StringComparison.OrdinalIgnoreCase)));
+                    query.SearchTerm = searchTerm.Trim();
                 }
 
-                var filteredList = allItems.ToList();
+                var filteredList = _libraryManager.GetItemList(query)
+                    .Where(item => !string.IsNullOrEmpty(item.Path))
+                    .ToList();
                 var totalCount = filteredList.Count;
 
                 var items = filteredList

--- a/Api/SubtitleController.cs
+++ b/Api/SubtitleController.cs
@@ -78,7 +78,8 @@ namespace WhisperSubs.Api
         public ActionResult<PagedItemResult> GetLibraryItems(
             [FromRoute] string libraryId,
             [FromQuery] int startIndex = 0,
-            [FromQuery] int limit = 50)
+            [FromQuery] int limit = 50,
+            [FromQuery] string? searchTerm = null)
         {
             try
             {
@@ -96,11 +97,20 @@ namespace WhisperSubs.Api
                     ParentId = library.Id,
                     IncludeItemTypes = includeTypes,
                     Recursive = true
-                }).Where(item => !string.IsNullOrEmpty(item.Path)).ToList();
+                }).Where(item => !string.IsNullOrEmpty(item.Path));
 
-                var totalCount = allItems.Count;
+                if (!string.IsNullOrWhiteSpace(searchTerm))
+                {
+                    var term = searchTerm.Trim();
+                    allItems = allItems.Where(item =>
+                        (item.Name != null && item.Name.Contains(term, StringComparison.OrdinalIgnoreCase)) ||
+                        (item.Path != null && System.IO.Path.GetFileName(item.Path).Contains(term, StringComparison.OrdinalIgnoreCase)));
+                }
 
-                var items = allItems
+                var filteredList = allItems.ToList();
+                var totalCount = filteredList.Count;
+
+                var items = filteredList
                     .Skip(startIndex)
                     .Take(limit)
                     .Select(item => new ItemInfo

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -279,6 +279,11 @@
                     </div>
                 </div>
 
+                <div class="inputContainer" style="margin-top: 0.8em;">
+                    <label class="inputLabel inputLabelUnfocused" for="txtSearchItems">Search Items</label>
+                    <input type="text" id="txtSearchItems" class="emby-input" placeholder="Filter by file name or title..." />
+                </div>
+
                 <div id="mediaTableContainer" style="margin-top: 1em;">
                     <table class="tblMediaInfo" style="width: 100%;">
                         <thead>
@@ -312,6 +317,8 @@
                 currentStartIndex: 0,
                 currentTotalCount: 0,
                 currentLibraryId: '',
+                currentSearchTerm: '',
+                _searchDebounceTimer: null,
                 _progressPollTimer: null,
                 _queuePollTimer: null,
                 _queueHideTimer: null,
@@ -910,11 +917,16 @@
 
                     tbody.innerHTML = '<tr><td colspan="5" style="text-align:center;padding:2em;">Loading...</td></tr>';
 
+                    var queryParams = {
+                        startIndex: startIndex,
+                        limit: WhisperSubsConfig.pageSize
+                    };
+                    if (WhisperSubsConfig.currentSearchTerm) {
+                        queryParams.searchTerm = WhisperSubsConfig.currentSearchTerm;
+                    }
+
                     WhisperSubsConfig.ajaxGet(
-                        ApiClient.getUrl('Plugins/WhisperSubs/Libraries/' + libraryId + '/Items', {
-                            startIndex: startIndex,
-                            limit: WhisperSubsConfig.pageSize
-                        })
+                        ApiClient.getUrl('Plugins/WhisperSubs/Libraries/' + libraryId + '/Items', queryParams)
                     ).then(function (result) {
                         tbody.innerHTML = '';
 
@@ -1241,7 +1253,22 @@
 
             document.querySelector('#selectLibrary').addEventListener('change', function (e) {
                 WhisperSubsConfig.currentStartIndex = 0;
+                WhisperSubsConfig.currentSearchTerm = '';
+                document.querySelector('#txtSearchItems').value = '';
                 WhisperSubsConfig.loadLibraryItems(e.target.value, 0);
+            });
+
+            document.querySelector('#txtSearchItems').addEventListener('input', function (e) {
+                if (WhisperSubsConfig._searchDebounceTimer) {
+                    clearTimeout(WhisperSubsConfig._searchDebounceTimer);
+                }
+                WhisperSubsConfig._searchDebounceTimer = setTimeout(function () {
+                    WhisperSubsConfig.currentSearchTerm = e.target.value.trim();
+                    WhisperSubsConfig.currentStartIndex = 0;
+                    if (WhisperSubsConfig.currentLibraryId) {
+                        WhisperSubsConfig.loadLibraryItems(WhisperSubsConfig.currentLibraryId, 0);
+                    }
+                }, 300);
             });
 
             document.querySelector('#btnPrevPage').addEventListener('click', function () {

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -281,7 +281,7 @@
 
                 <div class="inputContainer" style="margin-top: 0.8em;">
                     <label class="inputLabel inputLabelUnfocused" for="txtSearchItems">Search Items</label>
-                    <input type="text" id="txtSearchItems" class="emby-input" placeholder="Filter by file name or title..." />
+                    <input type="text" id="txtSearchItems" class="emby-input" placeholder="Filter by file name or title..." maxlength="200" />
                 </div>
 
                 <div id="mediaTableContainer" style="margin-top: 1em;">

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.16.0.0</Version>
+    <Version>3.17.0.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
## Summary
- Adds a text search input in the Subtitle Management section between the library selector and items table
- Filters items by name or filename server-side via new `searchTerm` query parameter
- 300ms debounce on keystrokes to avoid excessive API calls
- Resets search when switching libraries
- Pagination works correctly with filtered results

Closes #54

## Test plan
- [ ] CI build passes
- [ ] Select a library, type in the search box — table filters instantly
- [ ] Pagination reflects filtered count
- [ ] Clearing search shows all items again
- [ ] Switching library clears search field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subtitle library search: add a debounced text search that filters items (case-insensitive) on the server. Results and total counts reflect the filtered set; switching libraries clears the search and resets pagination.

* **Chores**
  * Version bumped to 3.17.0.0

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GeiserX/whisper-subs/pull/55)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->