### PR TITLE
fix: interrupt transcription when playback starts mid-process

### DIFF
--- a/ScheduledTasks/SubtitleGenerationTask.cs
+++ b/ScheduledTasks/SubtitleGenerationTask.cs
@@ -362,6 +362,7 @@ namespace WhisperSubs.ScheduledTasks
                 {
                     // Transcription completed (or threw) before playback started — cancel monitor and propagate
                     await playbackCts.CancelAsync();
+                    try { await monitorTask; } catch (OperationCanceledException) { }
                     await transcribeTask; // propagate exceptions
                     return;
                 }

--- a/ScheduledTasks/SubtitleGenerationTask.cs
+++ b/ScheduledTasks/SubtitleGenerationTask.cs
@@ -277,7 +277,14 @@ namespace WhisperSubs.ScheduledTasks
                     await SubtitleQueueService.TranscriptionLock.WaitAsync(cancellationToken);
                     try
                     {
-                        await manager.GenerateSubtitleAsync(item, provider, language, cancellationToken);
+                        if (config.PauseOnPlayback)
+                        {
+                            await TranscribeWithPlaybackMonitorAsync(manager, item, provider, language, cancellationToken);
+                        }
+                        else
+                        {
+                            await manager.GenerateSubtitleAsync(item, provider, language, cancellationToken);
+                        }
                     }
                     finally
                     {
@@ -330,6 +337,69 @@ namespace WhisperSubs.ScheduledTasks
                 queue.ReportPhase(null!);
                 _logger.LogInformation("Playback stopped — resuming subtitle generation");
             }
+        }
+
+        /// <summary>
+        /// Runs transcription while monitoring for playback. If playback starts mid-transcription,
+        /// cancels whisper (saving partial SRT), waits for playback to end, then retries.
+        /// Resume logic in SubtitleManager picks up from where the partial SRT left off.
+        /// </summary>
+        private async Task TranscribeWithPlaybackMonitorAsync(
+            SubtitleManager manager, BaseItem item, ISubtitleProvider provider,
+            string language, CancellationToken cancellationToken)
+        {
+            while (true)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                using var playbackCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                var monitorTask = MonitorPlaybackAsync(playbackCts.Token);
+                var transcribeTask = manager.GenerateSubtitleAsync(item, provider, language, playbackCts.Token);
+
+                var finished = await Task.WhenAny(transcribeTask, monitorTask);
+
+                if (finished == transcribeTask)
+                {
+                    // Transcription completed (or threw) before playback started — cancel monitor and propagate
+                    await playbackCts.CancelAsync();
+                    await transcribeTask; // propagate exceptions
+                    return;
+                }
+
+                // Playback detected — cancel the transcription (whisper saves partial SRT)
+                _logger.LogInformation("Playback started during transcription of {ItemName} — interrupting", item.Name);
+                await playbackCts.CancelAsync();
+
+                try
+                {
+                    await transcribeTask;
+                }
+                catch (OperationCanceledException)
+                {
+                    // Expected — whisper was killed, partial SRT saved
+                }
+
+                // Wait for playback to finish, then retry (resume picks up from partial)
+                await WaitForPlaybackIdleAsync(cancellationToken);
+                _logger.LogInformation("Retrying transcription for {ItemName} (will resume from partial)", item.Name);
+            }
+        }
+
+        /// <summary>
+        /// Polls sessions every 10 seconds. Returns (completes) when playback is detected.
+        /// </summary>
+        private async Task MonitorPlaybackAsync(CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(10), cancellationToken);
+                if (_sessionManager.Sessions.Any(s => s.NowPlayingItem != null))
+                {
+                    return;
+                }
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
         }
     }
 }

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.17.0.0</Version>
+    <Version>3.17.1.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
## Summary
- Fixes pause-on-playback not working during active transcription (only worked between items)
- Monitors Jellyfin sessions every 10s during whisper-cli execution
- Kills whisper process when playback starts (partial SRT is saved automatically)
- Waits for playback to end, then retries — resume logic picks up from the partial file

## Test plan
- [ ] Start subtitle generation on a long file (>30 min)
- [ ] Begin playback mid-transcription → verify whisper is interrupted and task pauses
- [ ] Stop playback → verify transcription resumes from where it left off
- [ ] Verify normal (no playback) transcription completes unaffected
- [ ] Verify PauseOnPlayback=false skips monitoring entirely

Closes #49

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subtitle generation gains playback-aware transcription: when enabled, transcription pauses during active playback and automatically resumes when playback is idle, reducing conflicts and improving responsiveness.

* **Chores**
  * Project version bumped to 3.17.1.0

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GeiserX/whisper-subs/pull/56)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->