### PR TITLE
ci: improve release workflow and fix manifest deployment

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -44,6 +44,11 @@ jobs:
             cmake_flags: "-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DGGML_NATIVE=OFF"
             pre_install: "arm64"
           - os: [self-hosted, Linux, X64]
+            variant: cpu-arm64-noavx
+            asset_name: whisper-cli-linux-arm64-noavx
+            cmake_flags: "-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DGGML_NATIVE=OFF -DGGML_OPENMP=OFF"
+            pre_install: "arm64"
+          - os: [self-hosted, Linux, X64]
             variant: cuda12
             asset_name: whisper-cli-linux-x64-cuda12
             cmake_flags: "-DGGML_CUDA=ON -DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON -DGGML_BMI2=ON"
@@ -243,28 +248,28 @@ jobs:
           CHECKSUM="${{ steps.checksum.outputs.checksum }}"
           TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-          cat > manifest.json << EOF
-          [
-            {
-              "guid": "97124bd9-c8cd-4a53-a213-e593aa3fef52",
-              "name": "WhisperSubs",
-              "description": "Automated subtitle generation for Jellyfin using local Whisper AI models.",
-              "overview": "Generate subtitles for your media library using local speech-to-text AI (whisper.cpp). Supports CPU and GPU-accelerated transcription. All processing happens locally on your server.",
-              "owner": "GeiserX",
-              "category": "Subtitles",
-              "versions": [
-                {
-                  "version": "${VERSION}",
-                  "changelog": "See https://github.com/GeiserX/whisper-subs/releases",
-                  "targetAbi": "10.11.0.0",
-                  "sourceUrl": "https://github.com/GeiserX/whisper-subs/releases/download/v${VERSION}/WhisperSubs_${VERSION}.zip",
-                  "checksum": "${CHECKSUM}",
-                  "timestamp": "${TIMESTAMP}"
-                }
-              ]
-            }
-          ]
-          EOF
+          NEW_ENTRY=$(jq -n \
+            --arg ver "$VERSION" \
+            --arg cs "$CHECKSUM" \
+            --arg ts "$TIMESTAMP" \
+            '{version: $ver, changelog: "See https://github.com/GeiserX/whisper-subs/releases", targetAbi: "10.11.0.0", sourceUrl: "https://github.com/GeiserX/whisper-subs/releases/download/v\($ver)/WhisperSubs_\($ver).zip", checksum: $cs, timestamp: $ts}')
+
+          if [ -f manifest.json ] && jq -e '.[0].versions' manifest.json > /dev/null 2>&1; then
+            # Prepend new version, keep last 5
+            jq --argjson entry "$NEW_ENTRY" \
+              '.[0].versions = ([$entry] + .[0].versions) | .[0].versions = .[0].versions[:5]' \
+              manifest.json > manifest.json.tmp && mv manifest.json.tmp manifest.json
+          else
+            jq -n --argjson entry "$NEW_ENTRY" '[{
+              guid: "97124bd9-c8cd-4a53-a213-e593aa3fef52",
+              name: "WhisperSubs",
+              description: "Automated subtitle generation for Jellyfin using local Whisper AI models.",
+              overview: "Generate subtitles for your media library using local speech-to-text AI (whisper.cpp). Supports CPU and GPU-accelerated transcription. All processing happens locally on your server.",
+              owner: "GeiserX",
+              category: "Subtitles",
+              versions: [$entry]
+            }]' > manifest.json
+          fi
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
@@ -276,6 +281,7 @@ jobs:
             whisper-cli-linux-x64
             whisper-cli-linux-x64-noavx
             whisper-cli-linux-arm64
+            whisper-cli-linux-arm64-noavx
             whisper-cli-linux-x64-cuda12
             whisper-cli-linux-x64-cuda12-noavx
             whisper-cli-linux-x64-vulkan
@@ -285,13 +291,26 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Commit updated manifest
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add manifest.json
+          git diff --cached --quiet || git commit -m "chore: update manifest.json for v${{ steps.version.outputs.version }}"
+          git push
+
+      - name: Prepare Pages content
+        run: |
+          mkdir -p _pages
+          cp manifest.json _pages/
+
       - name: Setup Pages
         uses: actions/configure-pages@v4
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: .
+          path: _pages
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/manifest.json
+++ b/manifest.json
@@ -8,20 +8,44 @@
     "category": "Subtitles",
     "versions": [
       {
-        "version": "2.0.0.0",
+        "version": "3.17.0.0",
         "changelog": "See https://github.com/GeiserX/whisper-subs/releases",
         "targetAbi": "10.11.0.0",
-        "sourceUrl": "https://github.com/GeiserX/whisper-subs/releases/download/v2.0.0.0/WhisperSubs_2.0.0.0.zip",
-        "checksum": "aec2be0940106922bd3f002b2da8b414",
-        "timestamp": "2026-03-24T16:20:00Z"
+        "sourceUrl": "https://github.com/GeiserX/whisper-subs/releases/download/v3.17.0.0/WhisperSubs_3.17.0.0.zip",
+        "checksum": "d6ce12b9241b064b7e6f852017f84eb4",
+        "timestamp": "2026-05-12T09:15:19Z"
       },
       {
-        "version": "1.0.4.2",
+        "version": "3.16.0.0",
         "changelog": "See https://github.com/GeiserX/whisper-subs/releases",
         "targetAbi": "10.11.0.0",
-        "sourceUrl": "https://github.com/GeiserX/whisper-subs/releases/download/v1.0.4.2/WhisperSubs_1.0.4.2.zip",
-        "checksum": "a1ed1f0600f02cb8699faacf69472d01",
-        "timestamp": "2025-12-09T21:29:40Z"
+        "sourceUrl": "https://github.com/GeiserX/whisper-subs/releases/download/v3.16.0.0/WhisperSubs_3.16.0.0.zip",
+        "checksum": "67089ffc4844d631f1a58ffe286bf454",
+        "timestamp": "2026-05-11T10:49:18Z"
+      },
+      {
+        "version": "3.15.0.0",
+        "changelog": "See https://github.com/GeiserX/whisper-subs/releases",
+        "targetAbi": "10.11.0.0",
+        "sourceUrl": "https://github.com/GeiserX/whisper-subs/releases/download/v3.15.0.0/WhisperSubs_3.15.0.0.zip",
+        "checksum": "01a051fb6a6c0956bd441676349a64f3",
+        "timestamp": "2026-05-11T09:36:39Z"
+      },
+      {
+        "version": "3.14.2.0",
+        "changelog": "See https://github.com/GeiserX/whisper-subs/releases",
+        "targetAbi": "10.11.0.0",
+        "sourceUrl": "https://github.com/GeiserX/whisper-subs/releases/download/v3.14.2.0/WhisperSubs_3.14.2.0.zip",
+        "checksum": "5ef4abc9d9c73d1088b1d1b7934a3421",
+        "timestamp": "2026-05-07T22:59:39Z"
+      },
+      {
+        "version": "3.14.1.0",
+        "changelog": "See https://github.com/GeiserX/whisper-subs/releases",
+        "targetAbi": "10.11.0.0",
+        "sourceUrl": "https://github.com/GeiserX/whisper-subs/releases/download/v3.14.1.0/WhisperSubs_3.14.1.0.zip",
+        "checksum": "8dcbeae7fbc9c01c6184ec2cf8ef5aca",
+        "timestamp": "2026-05-07T21:48:47Z"
       }
     ]
   }


### PR DESCRIPTION
## Summary
- **Manifest preserves version history** — uses `jq` to prepend new version and keep last 5, instead of overwriting with only latest
- **Manifest committed back to repo** — so versions accumulate across releases
- **Pages deploys only manifest.json** — not the entire workspace (source code, binaries, etc.)
- **Seeded manifest** with actual checksums for v3.14.1 through v3.17.0
- **Added arm64-noavx build** — BinaryCatalog advertised it but CI never built it
- **Fixed Pages source** — switched from stale `master` branch to Actions-based deployment

## Test plan
- [ ] Merge triggers build-release workflow
- [ ] Version 3.17.1.0 release is created with all binary assets including arm64-noavx
- [ ] manifest.json at https://geiserx.github.io/whisper-subs/manifest.json shows v3.17.1.0 prepended
- [ ] Manifest retains previous versions (3.17.0, 3.16.0, etc.)