### PR TITLE
fix(ci): resolve self-hosted runner build failures

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -68,14 +68,14 @@ jobs:
             asset_name: whisper-cli-linux-x64-vulkan-noavx
             cmake_flags: "-DGGML_VULKAN=ON -DGGML_NATIVE=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_BMI2=OFF -DGGML_SSE42=ON -DGGML_OPENMP=OFF"
             pre_install: "vulkan"
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Cache whisper binary
         id: cache-whisper
         uses: actions/cache@v4
         with:
           path: /tmp/whisper-${{ matrix.variant }}/build/bin/whisper-cli
-          key: whisper-1.8.4-${{ matrix.asset_name }}-v7
+          key: whisper-1.8.4-${{ matrix.asset_name }}-v8
 
       - name: Install build dependencies
         if: steps.cache-whisper.outputs.cache-hit != 'true'
@@ -254,10 +254,16 @@ jobs:
             --arg ts "$TIMESTAMP" \
             '{version: $ver, changelog: "See https://github.com/GeiserX/whisper-subs/releases", targetAbi: "10.11.0.0", sourceUrl: "https://github.com/GeiserX/whisper-subs/releases/download/v\($ver)/WhisperSubs_\($ver).zip", checksum: $cs, timestamp: $ts}')
 
-          if [ -f manifest.json ] && jq -e '.[0].versions' manifest.json > /dev/null 2>&1; then
-            # Prepend new version, keep last 5
+          # Fetch live manifest from Pages (has accumulated history)
+          LIVE_MANIFEST=$(curl -sf https://geiserx.github.io/whisper-subs/manifest.json || echo "")
+
+          if [ -n "$LIVE_MANIFEST" ] && echo "$LIVE_MANIFEST" | jq -e '.[0].versions' > /dev/null 2>&1; then
+            echo "$LIVE_MANIFEST" | jq --argjson entry "$NEW_ENTRY" \
+              '.[0].versions = ([$entry] + [.[0].versions[] | select(.version != $entry.version)]) | .[0].versions = .[0].versions[:5]' \
+              > manifest.json
+          elif [ -f manifest.json ] && jq -e '.[0].versions' manifest.json > /dev/null 2>&1; then
             jq --argjson entry "$NEW_ENTRY" \
-              '.[0].versions = ([$entry] + .[0].versions) | .[0].versions = .[0].versions[:5]' \
+              '.[0].versions = ([$entry] + [.[0].versions[] | select(.version != $entry.version)]) | .[0].versions = .[0].versions[:5]' \
               manifest.json > manifest.json.tmp && mv manifest.json.tmp manifest.json
           else
             jq -n --argjson entry "$NEW_ENTRY" '[{
@@ -290,14 +296,6 @@ jobs:
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Commit updated manifest
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add manifest.json
-          git diff --cached --quiet || git commit -m "chore: update manifest.json for v${{ steps.version.outputs.version }}"
-          git push
 
       - name: Prepare Pages content
         run: |


### PR DESCRIPTION
## Summary
- **Fix missing x64 binaries in release** — `runs-on` was hardcoded instead of using `matrix.os`, and stale cache from GitHub-hosted runners caused path mismatches. Cache bumped to v8 for fresh builds.
- **Fix manifest deployment** — branch protection blocks `git push` from Actions. Now fetches live manifest from Pages and deploys updated version without committing back.
- **Deduplication** — prevents duplicate version entries if workflow is re-run.

## Context
PR #58 introduced the manifest improvements but the release failed because:
1. Only 3 of 10 binary artifacts were found by download-artifact (stale cache paths)
2. `git push` to main was rejected by branch protection ruleset

## Test plan
- [ ] Merge triggers build-release
- [ ] All whisper binary variants appear in release assets
- [ ] manifest.json at geiserx.github.io/whisper-subs/manifest.json shows v3.17.1.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build cache configuration for release builds.
  * Redesigned release manifest management—now fetches existing manifest from GitHub Pages, merges new releases with automatic version deduplication, retains recent versions, and deploys without repository commits.
  * Streamlined deployment workflow by removing redundant git operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GeiserX/whisper-subs/pull/59)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->