### PR TITLE
fix(ci): resolve self-hosted runner dependency issues

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Install build dependencies
         if: steps.cache-whisper.outputs.cache-hit != 'true'
-        run: sudo apt-get update && sudo apt-get install -y cmake g++ make
+        run: sudo apt-get update && sudo apt-get install -y cmake g++ make software-properties-common wget
 
       - name: Install CUDA Toolkit
         if: steps.cache-whisper.outputs.cache-hit != 'true' && matrix.pre_install == 'cuda'
@@ -95,7 +95,10 @@ jobs:
 
       - name: Install Vulkan SDK
         if: steps.cache-whisper.outputs.cache-hit != 'true' && matrix.pre_install == 'vulkan'
-        run: sudo apt-get install -y libvulkan-dev glslc
+        run: |
+          wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo tee /etc/apt/trusted.gpg.d/lunarg.asc
+          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-jammy.list https://packages.lunarg.com/vulkan/lunarg-vulkan-jammy.list
+          sudo apt-get update && sudo apt-get install -y libvulkan-dev glslc
 
       - name: Install ARM64 cross-compilation toolchain
         if: steps.cache-whisper.outputs.cache-hit != 'true' && matrix.pre_install == 'arm64'
@@ -103,7 +106,9 @@ jobs:
 
       - name: Clone whisper.cpp
         if: steps.cache-whisper.outputs.cache-hit != 'true'
-        run: git clone --depth 1 --branch v1.8.4 https://github.com/ggml-org/whisper.cpp.git /tmp/whisper-${{ matrix.variant }}
+        run: |
+          rm -rf /tmp/whisper-${{ matrix.variant }}
+          git clone --depth 1 --branch v1.8.4 https://github.com/ggml-org/whisper.cpp.git /tmp/whisper-${{ matrix.variant }}
 
       - name: Build whisper-cli
         if: steps.cache-whisper.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary
- **CUDA builds**: add `software-properties-common` (needed by `add-apt-repository` in CUDA toolkit action)
- **Vulkan builds**: add LunarG Vulkan SDK repo for `glslc` (not available in base Ubuntu 22.04)
- **All builds**: clean `/tmp/whisper-*` before clone (self-hosted runners persist `/tmp` across jobs, causing "directory already exists" failures)

## Context
Run #25926199458 failed: only cpu and cpu-noavx succeeded because they don't need CUDA/Vulkan/ARM deps and had no stale `/tmp` dirs. The self-hosted runner (watchtower-whisper-subs) is a minimal Ubuntu 22.04 container without GitHub-hosted runner tooling.

## Test plan
- [ ] All 9 matrix variants succeed
- [ ] Release v3.17.1.0 is created with all binary assets
- [ ] Manifest deployed to Pages