### PR TITLE
fix(ci): use shaderc package for glslc on Ubuntu 22.04

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -95,10 +95,7 @@ jobs:
 
       - name: Install Vulkan SDK
         if: steps.cache-whisper.outputs.cache-hit != 'true' && matrix.pre_install == 'vulkan'
-        run: |
-          wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo tee /etc/apt/trusted.gpg.d/lunarg.asc
-          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-jammy.list https://packages.lunarg.com/vulkan/lunarg-vulkan-jammy.list
-          sudo apt-get update && sudo apt-get install -y libvulkan-dev glslc
+        run: sudo apt-get install -y libvulkan-dev shaderc
 
       - name: Install ARM64 cross-compilation toolchain
         if: steps.cache-whisper.outputs.cache-hit != 'true' && matrix.pre_install == 'arm64'


### PR DESCRIPTION
## Summary
The LunarG Vulkan SDK repo is already configured on the self-hosted runner — just install `shaderc` package which provides `glslc`.

Previous attempts to get `glslc` failed because the package name on 22.04 is `shaderc` (not `glslc` which is only available as a standalone package on 24.04+).

## Test plan
- [ ] Vulkan and vulkan-noavx builds succeed
- [ ] Full release pipeline completes