### PR TITLE
fix(ci): add vulkan-headers for Vulkan builds

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Install Vulkan SDK
         if: steps.cache-whisper.outputs.cache-hit != 'true' && matrix.pre_install == 'vulkan'
-        run: sudo apt-get install -y libvulkan-dev shaderc
+        run: sudo apt-get install -y libvulkan-dev vulkan-headers shaderc
 
       - name: Install ARM64 cross-compilation toolchain
         if: steps.cache-whisper.outputs.cache-hit != 'true' && matrix.pre_install == 'arm64'


### PR DESCRIPTION
## Summary
LunarG's `libvulkan-dev` on Ubuntu 22.04 doesn't include `vulkan.h` — it's in the separate `vulkan-headers` package. Verified working directly on the runner via `cmake -DGGML_VULKAN=ON`.

## Test plan
- [ ] Vulkan and vulkan-noavx builds pass
- [ ] Full release pipeline completes with all 10 binary assets

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build dependencies to include additional Vulkan build tools for improved compatibility and compilation support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GeiserX/whisper-subs/pull/62)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->