### PR TITLE
feat: custom whisper-cli arguments

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Install Vulkan SDK
         if: steps.cache-whisper.outputs.cache-hit != 'true' && matrix.pre_install == 'vulkan'
-        run: sudo apt-get install -y libvulkan-dev shaderc
+        run: sudo apt-get install -y libvulkan-dev vulkan-headers shaderc
 
       - name: Install ARM64 cross-compilation toolchain
         if: steps.cache-whisper.outputs.cache-hit != 'true' && matrix.pre_install == 'arm64'

--- a/Configuration/PluginConfiguration.cs
+++ b/Configuration/PluginConfiguration.cs
@@ -71,6 +71,13 @@ namespace WhisperSubs.Configuration
         /// </summary>
         public bool PauseOnPlayback { get; set; } = false;
 
+        /// <summary>
+        /// Extra arguments appended to every whisper-cli invocation (space-separated).
+        /// Only applies to local whisper-cli, not the remote API.
+        /// Example: --max-len 47 --split-on-word
+        /// </summary>
+        public string CustomWhisperArgs { get; set; } = "";
+
         public List<string> EnabledLibraries { get; set; } = new List<string>();
 
         public PluginConfiguration()

--- a/Providers/SubtitleProviderFactory.cs
+++ b/Providers/SubtitleProviderFactory.cs
@@ -24,7 +24,8 @@ namespace WhisperSubs.Providers
                 loggerFactory.CreateLogger<WhisperProvider>(),
                 config.WhisperModelPath,
                 config.WhisperBinaryPath,
-                config.WhisperThreadCount);
+                config.WhisperThreadCount,
+                config.CustomWhisperArgs);
         }
     }
 }

--- a/Providers/WhisperProvider.cs
+++ b/Providers/WhisperProvider.cs
@@ -18,16 +18,33 @@ namespace WhisperSubs.Providers
         private readonly string _modelPath;
         private readonly string _binaryPath;
         private readonly int _threadCount;
+        private readonly string _customArgs;
         private string? _resolvedExecutable;
+
+        private static readonly HashSet<string> DeniedArgs = new(StringComparer.OrdinalIgnoreCase)
+        {
+            "-m", "--model", "-f", "--file", "-l", "--language",
+            "-t", "--threads", "-mc", "--max-context",
+            "-sns", "--suppress-nst",
+            "-osrt", "--output-srt", "-ovtt", "--output-vtt",
+            "-otxt", "--output-txt", "-olrc", "--output-lrc",
+            "-ocsv", "--output-csv", "-oj", "--output-json",
+            "-ojf", "--output-json-full", "-owts", "--output-words",
+            "-of", "--output-file", "--translate", "-tr",
+            "--detect-language", "-dl", "--no-timestamps", "-nt",
+            "--prompt", "--offset-n", "-on", "--offset-t", "-ot",
+            "--duration", "-d"
+        };
 
         public string Name => "Whisper";
 
-        public WhisperProvider(ILogger<WhisperProvider> logger, string modelPath, string binaryPath = "", int threadCount = 0)
+        public WhisperProvider(ILogger<WhisperProvider> logger, string modelPath, string binaryPath = "", int threadCount = 0, string customArgs = "")
         {
             _logger = logger;
             _modelPath = modelPath;
             _binaryPath = binaryPath;
             _threadCount = threadCount;
+            _customArgs = customArgs ?? "";
         }
 
         public async Task<string> TranscribeAsync(string audioPath, string language, CancellationToken cancellationToken, bool translate = false)
@@ -100,6 +117,8 @@ namespace WhisperSubs.Providers
                     startInfo.ArgumentList.Add("--prompt");
                     startInfo.ArgumentList.Add(langPrompt);
                 }
+
+                AppendCustomArgs(startInfo);
 
                 _logger.LogInformation("Running: {Executable} {Arguments} (cwd: {WorkingDirectory})",
                     whisperExecutable, string.Join(" ", startInfo.ArgumentList), startInfo.WorkingDirectory);
@@ -478,6 +497,22 @@ namespace WhisperSubs.Providers
             if (string.IsNullOrWhiteSpace(srtContent)) return 0;
             var matches = Regex.Matches(srtContent, @"-->"); // Each entry has one --> line
             return matches.Count;
+        }
+
+        private void AppendCustomArgs(ProcessStartInfo startInfo)
+        {
+            if (string.IsNullOrWhiteSpace(_customArgs)) return;
+
+            foreach (var token in _customArgs.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries))
+            {
+                var flagName = token.Contains('=') ? token[..token.IndexOf('=')] : token;
+                if (DeniedArgs.Contains(flagName))
+                {
+                    _logger.LogWarning("Skipping denied custom argument: {Arg}", token);
+                    continue;
+                }
+                startInfo.ArgumentList.Add(token);
+            }
         }
 
         private string? FindWhisperExecutable()

--- a/Providers/WhisperProvider.cs
+++ b/Providers/WhisperProvider.cs
@@ -499,16 +499,20 @@ namespace WhisperSubs.Providers
             return matches.Count;
         }
 
-        private void AppendCustomArgs(ProcessStartInfo startInfo)
+        internal void AppendCustomArgs(ProcessStartInfo startInfo)
         {
             if (string.IsNullOrWhiteSpace(_customArgs)) return;
 
-            foreach (var token in _customArgs.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries))
+            var tokens = _customArgs.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+            for (int i = 0; i < tokens.Length; i++)
             {
+                var token = tokens[i];
                 var flagName = token.Contains('=') ? token[..token.IndexOf('=')] : token;
                 if (DeniedArgs.Contains(flagName))
                 {
                     _logger.LogWarning("Skipping denied custom argument: {Arg}", token);
+                    if (!token.Contains('=') && i + 1 < tokens.Length && !tokens[i + 1].StartsWith('-'))
+                        i++;
                     continue;
                 }
                 startInfo.ArgumentList.Add(token);

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -240,6 +240,12 @@
                             <input type="number" id="txtWhisperThreadCount" name="WhisperThreadCount" class="emby-input" min="0" max="64" step="1" />
                             <div class="fieldDescription">Number of CPU threads for whisper inference. 0 = whisper default (4). Set to your CPU core count for faster transcription.</div>
                         </div>
+
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="txtCustomWhisperArgs">Custom Whisper Arguments</label>
+                            <input type="text" id="txtCustomWhisperArgs" name="CustomWhisperArgs" class="emby-input" placeholder="e.g., --max-len 47 --split-on-word" />
+                            <div class="fieldDescription">Extra arguments appended to whisper-cli (space-separated). Only applies to local whisper-cli, not the remote API. Useful for timing improvements (e.g., <code>--max-len 47 --split-on-word</code>) or tuning (<code>--beam-size 8</code>). Flags managed by the plugin (model, language, output format) are automatically blocked.</div>
+                        </div>
                     </details>
 
                     <button is="emby-button" type="submit" class="raised button-submit block" style="margin-top:1.5em;">
@@ -828,6 +834,7 @@
                             page.querySelector('#txtWhisperBinaryPath').value = config.WhisperBinaryPath || '';
                             page.querySelector('#txtWhisperModelPath').value = config.WhisperModelPath || '';
                             page.querySelector('#txtWhisperThreadCount').value = (config.WhisperThreadCount || 0).toString();
+                            page.querySelector('#txtCustomWhisperArgs').value = config.CustomWhisperArgs || '';
                             page.querySelector('#txtRemoteWhisperApiUrl').value = config.RemoteWhisperApiUrl || '';
                             page.querySelector('#txtRemoteWhisperModel').value = config.RemoteWhisperModel || 'Systran/faster-whisper-large-v3';
                             page.querySelector('#txtRemoteWhisperApiKey').value = config.RemoteWhisperApiKey || '';
@@ -850,6 +857,7 @@
                         config.WhisperBinaryPath = page.querySelector('#txtWhisperBinaryPath').value;
                         config.WhisperModelPath = page.querySelector('#txtWhisperModelPath').value;
                         config.WhisperThreadCount = parseInt(page.querySelector('#txtWhisperThreadCount').value, 10) || 0;
+                        config.CustomWhisperArgs = (page.querySelector('#txtCustomWhisperArgs').value || '').trim();
                         config.RemoteWhisperApiUrl = (page.querySelector('#txtRemoteWhisperApiUrl').value || '').trim();
                         config.RemoteWhisperModel = (page.querySelector('#txtRemoteWhisperModel').value || '').trim() || 'Systran/faster-whisper-large-v3';
                         config.RemoteWhisperApiKey = (page.querySelector('#txtRemoteWhisperApiKey').value || '').trim();

--- a/WhisperSubs.Tests/CustomArgsTests.cs
+++ b/WhisperSubs.Tests/CustomArgsTests.cs
@@ -1,0 +1,113 @@
+using System.Diagnostics;
+using WhisperSubs.Providers;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+public class CustomArgsTests
+{
+    private static WhisperProvider CreateProvider(string customArgs = "")
+    {
+        var logger = NullLoggerFactory.Instance.CreateLogger<WhisperProvider>();
+        return new WhisperProvider(logger, "/tmp/model.bin", "", 0, customArgs);
+    }
+
+    private static ProcessStartInfo CreateStartInfo()
+    {
+        return new ProcessStartInfo { FileName = "whisper-cli", UseShellExecute = false };
+    }
+
+    [Fact]
+    public void AppendCustomArgs_EmptyString_AddsNothing()
+    {
+        var provider = CreateProvider("");
+        var si = CreateStartInfo();
+        provider.AppendCustomArgs(si);
+        Assert.Empty(si.ArgumentList);
+    }
+
+    [Fact]
+    public void AppendCustomArgs_WhitespaceOnly_AddsNothing()
+    {
+        var provider = CreateProvider("   \t  ");
+        var si = CreateStartInfo();
+        provider.AppendCustomArgs(si);
+        Assert.Empty(si.ArgumentList);
+    }
+
+    [Fact]
+    public void AppendCustomArgs_ValidArgs_AllAppended()
+    {
+        var provider = CreateProvider("--max-len 47 --split-on-word");
+        var si = CreateStartInfo();
+        provider.AppendCustomArgs(si);
+        Assert.Equal(new[] { "--max-len", "47", "--split-on-word" }, si.ArgumentList);
+    }
+
+    [Fact]
+    public void AppendCustomArgs_DeniedFlag_IsSkipped()
+    {
+        var provider = CreateProvider("-m");
+        var si = CreateStartInfo();
+        provider.AppendCustomArgs(si);
+        Assert.Empty(si.ArgumentList);
+    }
+
+    [Fact]
+    public void AppendCustomArgs_DeniedFlagWithValue_BothSkipped()
+    {
+        var provider = CreateProvider("--model /evil/path --beam-size 5");
+        var si = CreateStartInfo();
+        provider.AppendCustomArgs(si);
+        Assert.Equal(new[] { "--beam-size", "5" }, si.ArgumentList);
+    }
+
+    [Fact]
+    public void AppendCustomArgs_DeniedFlagEqualsStyle_IsSkipped()
+    {
+        var provider = CreateProvider("--model=/evil.bin --beam-size 8");
+        var si = CreateStartInfo();
+        provider.AppendCustomArgs(si);
+        Assert.Equal(new[] { "--beam-size", "8" }, si.ArgumentList);
+    }
+
+    [Fact]
+    public void AppendCustomArgs_DeniedFlagCaseInsensitive()
+    {
+        var provider = CreateProvider("-M --MODEL --File");
+        var si = CreateStartInfo();
+        provider.AppendCustomArgs(si);
+        Assert.Empty(si.ArgumentList);
+    }
+
+    [Fact]
+    public void AppendCustomArgs_MixedValidAndDenied_OnlyValidPass()
+    {
+        var provider = CreateProvider("--max-len 47 -osrt --split-on-word -f /tmp/x");
+        var si = CreateStartInfo();
+        provider.AppendCustomArgs(si);
+        Assert.Equal(new[] { "--max-len", "47", "--split-on-word" }, si.ArgumentList);
+    }
+
+    [Fact]
+    public void AppendCustomArgs_DeniedFlagValueStartsWithDash_OnlyFlagSkipped()
+    {
+        // If the "value" starts with -, it's treated as its own flag, not a value
+        var provider = CreateProvider("--translate --beam-size 5");
+        var si = CreateStartInfo();
+        provider.AppendCustomArgs(si);
+        Assert.Equal(new[] { "--beam-size", "5" }, si.ArgumentList);
+    }
+
+    [Fact]
+    public void AppendCustomArgs_NullCustomArgs_NoException()
+    {
+        var logger = NullLoggerFactory.Instance.CreateLogger<WhisperProvider>();
+        var provider = new WhisperProvider(logger, "/tmp/model.bin", "", 0, null!);
+        var si = CreateStartInfo();
+        provider.AppendCustomArgs(si);
+        Assert.Empty(si.ArgumentList);
+    }
+}

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.17.1.0</Version>
+    <Version>3.18.0.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
## Summary
- Adds a "Custom Whisper Arguments" text field in the Advanced settings section
- Arguments are split by whitespace and appended to whisper-cli via `ProcessStartInfo.ArgumentList` (injection-safe)
- A denylist blocks plugin-managed flags (`-m`, `-f`, `-l`, `-osrt`, `-of`, `--translate`, etc.) to prevent conflicts
- Only applies to local whisper-cli, not the remote API provider

## Context
Requested in #64 — user reported subtitles appearing before characters speak in English-dubbed anime with frequent pauses. The recommended fix is `--max-len 47 --split-on-word` which forces tighter timestamp boundaries.

Note: The `--word_timestamps` flag mentioned in the issue does NOT exist in whisper-cli (whisper.cpp). That's a Python openai-whisper flag. The equivalent in whisper.cpp is `--max-len` (which implicitly enables token-level timestamps) combined with `--split-on-word`.

## Test plan
- [ ] Build passes on CI (self-hosted runner)
- [ ] Config page shows new field under Advanced / Manual Install
- [ ] Setting `--max-len 47 --split-on-word` produces tighter subtitle timing
- [ ] Denied flags (e.g., `-m`, `-osrt`) are logged as warnings and skipped
- [ ] Remote API mode ignores the field entirely

Closes #64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v3.18.0

* **New Features**
  * Users can now provide custom command-line arguments for local Whisper transcription via a new "Custom Whisper Arguments" configuration field
  * Custom arguments are safely appended to transcription commands with validation against potentially harmful flags

* **Chores**
  * Version updated to 3.18.0
  * Enhanced build configuration for Vulkan support

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GeiserX/whisper-subs/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->