### PR TITLE
fix: statically link CUDA runtime to eliminate container deps

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -51,12 +51,12 @@ jobs:
           - os: [self-hosted, Linux, X64]
             variant: cuda12
             asset_name: whisper-cli-linux-x64-cuda12
-            cmake_flags: "-DGGML_CUDA=ON -DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON -DGGML_BMI2=ON"
+            cmake_flags: "-DGGML_CUDA=ON -DGGML_STATIC=ON -DCMAKE_CUDA_ARCHITECTURES=61;70;75;80;86;89;90 -DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON -DGGML_BMI2=ON"
             pre_install: "cuda"
           - os: [self-hosted, Linux, X64]
             variant: cuda12-noavx
             asset_name: whisper-cli-linux-x64-cuda12-noavx
-            cmake_flags: "-DGGML_CUDA=ON -DGGML_NATIVE=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_BMI2=OFF -DGGML_SSE42=ON -DGGML_OPENMP=OFF"
+            cmake_flags: "-DGGML_CUDA=ON -DGGML_STATIC=ON -DCMAKE_CUDA_ARCHITECTURES=61;70;75;80;86;89;90 -DGGML_NATIVE=OFF -DGGML_AVX=OFF -DGGML_AVX2=OFF -DGGML_FMA=OFF -DGGML_F16C=OFF -DGGML_BMI2=OFF -DGGML_SSE42=ON -DGGML_OPENMP=OFF"
             pre_install: "cuda"
           - os: [self-hosted, Linux, X64]
             variant: vulkan
@@ -75,7 +75,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/whisper-${{ matrix.variant }}/build/bin/whisper-cli
-          key: whisper-1.8.4-${{ matrix.asset_name }}-v8
+          key: whisper-1.8.4-${{ matrix.asset_name }}-v9
 
       - name: Install build dependencies
         if: steps.cache-whisper.outputs.cache-hit != 'true'
@@ -87,11 +87,11 @@ jobs:
         with:
           cuda: '12.6.3'
           method: 'network'
-          sub-packages: '["nvcc", "cudart-dev"]'
+          sub-packages: '["nvcc", "cudart-dev", "cudart-static"]'
 
       - name: Install cuBLAS
         if: steps.cache-whisper.outputs.cache-hit != 'true' && matrix.pre_install == 'cuda'
-        run: sudo apt-get install -y libcublas-dev-12-6
+        run: sudo apt-get install -y libcublas-dev-12-6 libcublas-static-12-6
 
       - name: Install Vulkan SDK
         if: steps.cache-whisper.outputs.cache-hit != 'true' && matrix.pre_install == 'vulkan'

--- a/Setup/WhisperSetupService.cs
+++ b/Setup/WhisperSetupService.cs
@@ -442,6 +442,22 @@ namespace WhisperSubs.Setup
                 if (validationError != null)
                 {
                     _logger.LogWarning("Binary validation warning: {Error}", validationError);
+
+                    // Auto-fallback: if a GPU variant fails, try the CPU equivalent
+                    var fallbackVariant = GetCpuFallbackVariant(variant);
+                    if (fallbackVariant != null)
+                    {
+                        _logger.LogInformation("GPU binary failed validation — auto-downloading CPU fallback ({Fallback})", fallbackVariant);
+                        lock (_lock)
+                        {
+                            _progress = 50;
+                            _progressMessage = $"GPU binary failed ({validationError}). Downloading CPU fallback...";
+                            _error = null;
+                        }
+                        await DownloadBinaryAsync(fallbackVariant, cancellationToken);
+                        return;
+                    }
+
                     lock (_lock)
                     {
                         _progress = 100;
@@ -452,8 +468,6 @@ namespace WhisperSubs.Setup
 
                 if (validationError == null)
                 {
-                    // Only auto-apply to config when the binary actually works —
-                    // don't overwrite a working config with a known-bad binary.
                     var config = Plugin.Instance.Configuration;
                     config.WhisperBinaryPath = BinaryPath;
                     Plugin.Instance.SaveConfiguration();
@@ -546,6 +560,17 @@ namespace WhisperSubs.Setup
                 return null; // Can't probe — don't block the download
             }
         }
+
+        /// <summary>
+        /// Maps GPU variants to their CPU fallback for auto-recovery.
+        /// Returns null for CPU variants (no further fallback).
+        /// </summary>
+        private static string? GetCpuFallbackVariant(string variant) => variant switch
+        {
+            "cuda12" or "vulkan" => "cpu",
+            "cuda12-noavx" or "vulkan-noavx" or "rocm" => "noavx",
+            _ => null
+        };
 
         /// <summary>
         /// Returns an apt-install hint for a missing shared library.

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.18.0.0</Version>
+    <Version>3.18.1.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
## Summary

- Add `-DGGML_STATIC=ON` to both CUDA build matrix entries (cuda12, cuda12-noavx), which statically links `libcudart`, `libcublas`, and `libcublasLt` into the whisper-cli binary
- Add `-DCMAKE_CUDA_ARCHITECTURES=61;70;75;80;86;89;90` to compile SASS for Pascal through Ada Lovelace GPUs
- Install `libcublas-static-12-6` and `cudart-static` packages in CI
- Bump cache key v8→v9 to force rebuild with new flags
- Add auto-fallback: if GPU binary fails validation (missing shared libs), automatically download the CPU variant

After this change, the only runtime dependency for CUDA binaries is `libcuda.so.1` (the driver API), which nvidia-container-toolkit always provides. `libcudart.so.12` and `libcublas.so.12` are no longer needed.

Binary size will increase (~150-200MB due to embedded cuBLAS) but this is a one-time download.

## Test plan

- [ ] CI builds successfully with new flags
- [ ] Verify with `ldd` that CUDA binary no longer links libcudart/libcublas dynamically
- [ ] Test on TrueNAS Scale container (nvidia-container-toolkit only) — should work without CUDA toolkit installed
- [ ] Verify auto-fallback: download CUDA variant in container without GPU → should auto-switch to CPU

Fixes #66

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced GPU variant handling with automatic CPU fallback when GPU validation fails, ensuring reliable operation across different hardware configurations.

* **Chores**
  * Version updated to 3.18.1.0

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GeiserX/whisper-subs/pull/67?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->