### PR TITLE
fix(ci): correct CUDA and Vulkan package names for Ubuntu 24.04

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -87,15 +87,15 @@ jobs:
         with:
           cuda: '12.6.3'
           method: 'network'
-          sub-packages: '["nvcc", "cudart-dev", "cudart-static"]'
+          sub-packages: '["nvcc", "cudart-dev"]'
 
       - name: Install cuBLAS
         if: steps.cache-whisper.outputs.cache-hit != 'true' && matrix.pre_install == 'cuda'
-        run: sudo apt-get install -y libcublas-dev-12-6 libcublas-static-12-6
+        run: sudo apt-get install -y libcublas-dev-12-6
 
       - name: Install Vulkan SDK
         if: steps.cache-whisper.outputs.cache-hit != 'true' && matrix.pre_install == 'vulkan'
-        run: sudo apt-get install -y libvulkan-dev vulkan-headers shaderc
+        run: sudo apt-get install -y libvulkan-dev glslc
 
       - name: Install ARM64 cross-compilation toolchain
         if: steps.cache-whisper.outputs.cache-hit != 'true' && matrix.pre_install == 'arm64'


### PR DESCRIPTION
## Summary
- Remove non-existent `cudart-static` sub-package from Jimver action (static lib is already included in `cudart-dev`)
- Remove non-existent `libcublas-static-12-6` (static lib already included in `libcublas-dev-12-6`)
- Replace `vulkan-headers` + `shaderc` with `glslc` (correct Ubuntu 24.04 package names)

Fixes the build failures from #67 — these packages don't exist in NVIDIA's Ubuntu 24.04 repo or the Noble archive.

## Verification
Confirmed on the runner via `apt-cache search` and test install:
- `cuda-cudart-dev-12-6` provides `libcudart_static.a`
- `libcublas-dev-12-6` provides `libcublas_static.a`
- `glslc` provides the SPIR-V shader compiler needed by Vulkan builds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized GPU build dependencies by streamlining CUDA Toolkit, cuBLAS, and Vulkan SDK library installations for release builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GeiserX/whisper-subs/pull/68?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->