### PR TITLE
fix: self-contained CPU binary + surface transcription failures (#70)

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -31,7 +31,7 @@ jobs:
           - os: [self-hosted, Linux, X64]
             variant: cpu
             asset_name: whisper-cli-linux-x64
-            cmake_flags: "-DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON -DGGML_BMI2=ON"
+            cmake_flags: "-DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON -DGGML_BMI2=ON -DGGML_OPENMP=OFF"
             pre_install: ""
           - os: [self-hosted, Linux, X64]
             variant: cpu-noavx
@@ -41,7 +41,7 @@ jobs:
           - os: [self-hosted, Linux, X64]
             variant: cpu-arm64
             asset_name: whisper-cli-linux-arm64
-            cmake_flags: "-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DGGML_NATIVE=OFF"
+            cmake_flags: "-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DGGML_NATIVE=OFF -DGGML_OPENMP=OFF"
             pre_install: "arm64"
           - os: [self-hosted, Linux, X64]
             variant: cpu-arm64-noavx
@@ -51,7 +51,7 @@ jobs:
           - os: [self-hosted, Linux, X64]
             variant: cuda12
             asset_name: whisper-cli-linux-x64-cuda12
-            cmake_flags: "-DGGML_CUDA=ON -DGGML_STATIC=ON -DCMAKE_CUDA_ARCHITECTURES='61;70;75;80;86;89;90' -DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON -DGGML_BMI2=ON"
+            cmake_flags: "-DGGML_CUDA=ON -DGGML_STATIC=ON -DCMAKE_CUDA_ARCHITECTURES='61;70;75;80;86;89;90' -DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON -DGGML_BMI2=ON -DGGML_OPENMP=OFF"
             pre_install: "cuda"
           - os: [self-hosted, Linux, X64]
             variant: cuda12-noavx
@@ -61,7 +61,7 @@ jobs:
           - os: [self-hosted, Linux, X64]
             variant: vulkan
             asset_name: whisper-cli-linux-x64-vulkan
-            cmake_flags: "-DGGML_VULKAN=ON -DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON -DGGML_BMI2=ON"
+            cmake_flags: "-DGGML_VULKAN=ON -DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON -DGGML_BMI2=ON -DGGML_OPENMP=OFF"
             pre_install: "vulkan"
           - os: [self-hosted, Linux, X64]
             variant: vulkan-noavx
@@ -75,7 +75,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/whisper-${{ matrix.variant }}/build/bin/whisper-cli
-          key: whisper-1.8.4-${{ matrix.asset_name }}-v9
+          key: whisper-1.8.4-${{ matrix.asset_name }}-v10
 
       - name: Install build dependencies
         if: steps.cache-whisper.outputs.cache-hit != 'true'
@@ -138,7 +138,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/rocm-output/whisper-cli
-          key: whisper-1.8.4-rocm-6.1.2-v2
+          key: whisper-1.8.4-rocm-6.1.2-v3
 
       - name: Build whisper-cli with ROCm
         if: steps.cache-whisper-rocm.outputs.cache-hit != 'true'
@@ -156,6 +156,7 @@ jobs:
                 -DBUILD_SHARED_LIBS=OFF \
                 -DCMAKE_EXE_LINKER_FLAGS="-static-libgcc -static-libstdc++" \
                 -DGGML_HIP=ON \
+                -DGGML_OPENMP=OFF \
                 -DCMAKE_C_COMPILER=hipcc \
                 -DCMAKE_CXX_COMPILER=hipcc &&
               cmake --build build --config Release -j$(nproc) &&

--- a/Api/SubtitleController.cs
+++ b/Api/SubtitleController.cs
@@ -275,7 +275,8 @@ namespace WhisperSubs.Api
                     ? queue.PriorityCount + (queue.TaskTotal - queue.TaskProcessed)
                     : queue.PriorityCount,
                 processed = queue.ProcessedCount + queue.TaskProcessed,
-                failed = queue.TaskFailed,
+                failed = queue.TaskFailed + queue.FailedCount,
+                lastError = queue.LastError,
                 taskTotal = queue.IsTaskRunning ? queue.TaskTotal : 0,
                 fileProgress = queue.CurrentFileProgress,
                 phase = queue.CurrentPhase,

--- a/Controller/SubtitleManager.cs
+++ b/Controller/SubtitleManager.cs
@@ -416,7 +416,8 @@ namespace WhisperSubs.Controller
                 if (totalDuration <= 0)
                 {
                     _logger.LogWarning("Cannot determine duration for {ItemName}, aborting forced subtitle", item.Name);
-                    return (GenerationOutcome.Failed, null);
+                    return (GenerationOutcome.Failed,
+                        new InvalidOperationException($"Cannot determine media duration for forced subtitles: {item.Name}"));
                 }
 
                 // Step 3: VAD-based speech segmentation via silencedetect
@@ -475,7 +476,8 @@ namespace WhisperSubs.Controller
                 {
                     _logger.LogWarning("All {Count} language detection attempts failed for {ItemName} — not writing marker (will retry next run)",
                         chunks.Count, item.Name);
-                    return (GenerationOutcome.Failed, null);
+                    return (GenerationOutcome.Failed,
+                        new InvalidOperationException($"All language detection attempts failed for forced subtitles: {item.Name}"));
                 }
 
                 if (foreignChunks.Count == 0)
@@ -535,7 +537,8 @@ namespace WhisperSubs.Controller
                 {
                     // Foreign chunks were detected but every transcription attempt produced nothing.
                     _logger.LogInformation("Foreign segments detected but no content transcribed for {ItemName}", item.Name);
-                    return (GenerationOutcome.Failed, null);
+                    return (GenerationOutcome.Failed,
+                        new InvalidOperationException($"Foreign segments were detected but produced no subtitle content: {item.Name}"));
                 }
             }
             catch (OperationCanceledException)

--- a/Controller/SubtitleManager.cs
+++ b/Controller/SubtitleManager.cs
@@ -46,18 +46,35 @@ namespace WhisperSubs.Controller
             var languages = await ResolveLanguagesAsync(mediaPath, language, cancellationToken);
             var subtitleMode = Plugin.Instance?.Configuration?.SubtitleMode ?? SubtitleMode.Full;
 
+            int attempted = 0;
+            int failed = 0;
+            Exception? firstError = null;
+
+            void Record(GenerationOutcome outcome, Exception? error)
+            {
+                if (outcome == GenerationOutcome.Skipped) return;
+                attempted++;
+                if (outcome == GenerationOutcome.Failed)
+                {
+                    failed++;
+                    firstError ??= error;
+                }
+            }
+
             if (subtitleMode != SubtitleMode.TranslationOnly)
             {
                 foreach (var lang in languages)
                 {
                     if (subtitleMode == SubtitleMode.Full || subtitleMode == SubtitleMode.FullAndForced)
                     {
-                        await GenerateFullSubtitleForLanguageAsync(item, provider, lang, mediaPath, cancellationToken);
+                        var (outcome, error) = await GenerateFullSubtitleForLanguageAsync(item, provider, lang, mediaPath, cancellationToken);
+                        Record(outcome, error);
                     }
 
                     if (subtitleMode == SubtitleMode.ForcedOnly || subtitleMode == SubtitleMode.FullAndForced)
                     {
-                        await GenerateForcedSubtitleAsync(item, provider, lang, mediaPath, cancellationToken);
+                        var (outcome, error) = await GenerateForcedSubtitleAsync(item, provider, lang, mediaPath, cancellationToken);
+                        Record(outcome, error);
                     }
                 }
             }
@@ -68,17 +85,38 @@ namespace WhisperSubs.Controller
                 || (config?.EnableTranslation == true
                     && (subtitleMode == SubtitleMode.Full || subtitleMode == SubtitleMode.FullAndForced)))
             {
-                await GenerateTranslatedSubtitleAsync(item, provider, mediaPath, languages, cancellationToken);
+                var (outcome, error) = await GenerateTranslatedSubtitleAsync(item, provider, mediaPath, languages, cancellationToken);
+                Record(outcome, error);
+            }
+
+            // If we attempted real work and every attempt failed, surface the failure
+            // so the queue/scheduled task report it instead of a false success.
+            if (attempted > 0 && failed == attempted)
+            {
+                throw new InvalidOperationException(
+                    $"Subtitle generation failed for \"{item.Name}\" — all {attempted} attempt(s) failed.",
+                    firstError);
             }
 
             await item.RefreshMetadata(cancellationToken);
+        }
+
+        /// <summary>Outcome of a single subtitle generation attempt.</summary>
+        private enum GenerationOutcome
+        {
+            /// <summary>Produced output (or partial output) successfully.</summary>
+            Succeeded,
+            /// <summary>Nothing to do (already exists, no foreign dialogue, English audio, etc.).</summary>
+            Skipped,
+            /// <summary>Attempted but failed with an error.</summary>
+            Failed
         }
 
         /// <summary>
         /// Generates a full (complete) subtitle file for a single language. Existing v2.5 behavior.
         /// </summary>
         [ExcludeFromCodeCoverage(Justification = "Orchestrates FFmpeg audio extraction and whisper transcription processes")]
-        private async Task GenerateFullSubtitleForLanguageAsync(
+        private async Task<(GenerationOutcome Outcome, Exception? Error)> GenerateFullSubtitleForLanguageAsync(
             BaseItem item, ISubtitleProvider provider, string lang,
             string mediaPath, CancellationToken cancellationToken)
         {
@@ -97,7 +135,7 @@ namespace WhisperSubs.Controller
                 {
                     _logger.LogInformation("Subtitle already complete for {ItemName} [{Language}] ({Last:F0}s / {Duration:F0}s), skipping",
                         item.Name, lang, lastTimestamp, mediaDuration);
-                    return;
+                    return (GenerationOutcome.Skipped, null);
                 }
 
                 if (lastTimestamp > 0)
@@ -110,7 +148,7 @@ namespace WhisperSubs.Controller
                 else if (mediaDuration <= 0)
                 {
                     _logger.LogInformation("Subtitle exists for {ItemName} [{Language}] (can't verify completeness), skipping", item.Name, lang);
-                    return;
+                    return (GenerationOutcome.Skipped, null);
                 }
             }
 
@@ -132,6 +170,7 @@ namespace WhisperSubs.Controller
 
                 await File.WriteAllTextAsync(srtPath, srtContent, CancellationToken.None);
                 _logger.LogInformation("Saved full subtitle to {SrtPath}", srtPath);
+                return (GenerationOutcome.Succeeded, null);
             }
             catch (OperationCanceledException)
             {
@@ -141,6 +180,7 @@ namespace WhisperSubs.Controller
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error generating full subtitle for {ItemName} [{Language}], continuing with next language", item.Name, lang);
+                return (GenerationOutcome.Failed, ex);
             }
             finally
             {
@@ -158,7 +198,7 @@ namespace WhisperSubs.Controller
         /// and (as fallback) no existing English subtitle files when FFprobe couldn't detect languages.
         /// </summary>
         [ExcludeFromCodeCoverage(Justification = "Orchestrates FFmpeg + whisper processes for translation")]
-        private async Task GenerateTranslatedSubtitleAsync(
+        private async Task<(GenerationOutcome Outcome, Exception? Error)> GenerateTranslatedSubtitleAsync(
             BaseItem item, ISubtitleProvider provider, string mediaPath,
             List<string> resolvedLanguages, CancellationToken cancellationToken)
         {
@@ -166,7 +206,7 @@ namespace WhisperSubs.Controller
             if (resolvedLanguages.Any(l => string.Equals(l, "en", StringComparison.OrdinalIgnoreCase)))
             {
                 _logger.LogInformation("Skipping translation for {ItemName}: English audio stream present", item.Name);
-                return;
+                return (GenerationOutcome.Skipped, null);
             }
 
             var translatedSrtPath = Path.ChangeExtension(mediaPath, ".en.translated.srt");
@@ -175,7 +215,7 @@ namespace WhisperSubs.Controller
             if (File.Exists(translatedSrtPath))
             {
                 _logger.LogInformation("Translated subtitle already exists for {ItemName}, skipping", item.Name);
-                return;
+                return (GenerationOutcome.Skipped, null);
             }
 
             // Determine source language and perform additional checks for "auto" mode
@@ -202,7 +242,7 @@ namespace WhisperSubs.Controller
                         _logger.LogInformation(
                             "Skipping translation for {ItemName}: English subtitles already exist (FFprobe language fallback)",
                             item.Name);
-                        return;
+                        return (GenerationOutcome.Skipped, null);
                     }
                 }
 
@@ -221,7 +261,7 @@ namespace WhisperSubs.Controller
                         _logger.LogInformation(
                             "Skipping translation for {ItemName}: whisper detected English audio (p={Probability:F3})",
                             item.Name, probability);
-                        return;
+                        return (GenerationOutcome.Skipped, null);
                     }
 
                     sourceLanguage = detectedLang;
@@ -260,6 +300,7 @@ namespace WhisperSubs.Controller
 
                 await File.WriteAllTextAsync(translatedSrtPath, srtContent, CancellationToken.None);
                 _logger.LogInformation("Saved translated subtitle to {SrtPath}", translatedSrtPath);
+                return (GenerationOutcome.Succeeded, null);
             }
             catch (OperationCanceledException)
             {
@@ -269,6 +310,7 @@ namespace WhisperSubs.Controller
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error generating translated subtitle for {ItemName}", item.Name);
+                return (GenerationOutcome.Failed, ex);
             }
             finally
             {
@@ -286,7 +328,7 @@ namespace WhisperSubs.Controller
         /// Output: Movie.{lang}.forced.generated.srt
         /// </summary>
         [ExcludeFromCodeCoverage(Justification = "Orchestrates FFmpeg VAD + whisper language detection processes")]
-        private async Task GenerateForcedSubtitleAsync(
+        private async Task<(GenerationOutcome Outcome, Exception? Error)> GenerateForcedSubtitleAsync(
             BaseItem item, ISubtitleProvider provider, string primaryLanguage,
             string mediaPath, CancellationToken cancellationToken)
         {
@@ -321,7 +363,7 @@ namespace WhisperSubs.Controller
                     {
                         _logger.LogWarning(ex, "Cannot determine primary language for forced subtitles of {ItemName} — " +
                             "tag your audio streams or set a specific language in config", item.Name);
-                        return;
+                        return (GenerationOutcome.Failed, ex);
                     }
                     finally
                     {
@@ -341,7 +383,7 @@ namespace WhisperSubs.Controller
                 {
                     _logger.LogInformation("Forced subtitle already exists for {ItemName} [{Language}], skipping",
                         item.Name, resolvedPrimary);
-                    return;
+                    return (GenerationOutcome.Skipped, null);
                 }
             }
 
@@ -350,7 +392,7 @@ namespace WhisperSubs.Controller
             {
                 _logger.LogInformation("No-foreign-language marker exists for {ItemName} [{Language}], skipping",
                     item.Name, resolvedPrimary);
-                return;
+                return (GenerationOutcome.Skipped, null);
             }
 
             var tempDir = Path.Combine(Path.GetTempPath(), $"whispersubs_{item.Id:N}_{Guid.NewGuid():N}");
@@ -374,7 +416,7 @@ namespace WhisperSubs.Controller
                 if (totalDuration <= 0)
                 {
                     _logger.LogWarning("Cannot determine duration for {ItemName}, aborting forced subtitle", item.Name);
-                    return;
+                    return (GenerationOutcome.Failed, null);
                 }
 
                 // Step 3: VAD-based speech segmentation via silencedetect
@@ -433,7 +475,7 @@ namespace WhisperSubs.Controller
                 {
                     _logger.LogWarning("All {Count} language detection attempts failed for {ItemName} — not writing marker (will retry next run)",
                         chunks.Count, item.Name);
-                    return;
+                    return (GenerationOutcome.Failed, null);
                 }
 
                 if (foreignChunks.Count == 0)
@@ -442,7 +484,7 @@ namespace WhisperSubs.Controller
                     await File.WriteAllTextAsync(noForeignMarkerPath, "", CancellationToken.None);
                     _logger.LogInformation("No foreign language segments found in {ItemName} ({Checked} chunks checked), wrote no-foreign marker",
                         item.Name, successfulDetections);
-                    return;
+                    return (GenerationOutcome.Skipped, null);
                 }
 
                 _logger.LogInformation("Found {Count} foreign language chunk(s) in {ItemName}, transcribing",
@@ -487,10 +529,13 @@ namespace WhisperSubs.Controller
                     await File.WriteAllTextAsync(forcedSrtPath, forcedSrt.ToString(), CancellationToken.None);
                     _logger.LogInformation("Saved forced subtitle to {Path} ({Entries} entries)",
                         forcedSrtPath, entryNum - 1);
+                    return (GenerationOutcome.Succeeded, null);
                 }
                 else
                 {
+                    // Foreign chunks were detected but every transcription attempt produced nothing.
                     _logger.LogInformation("Foreign segments detected but no content transcribed for {ItemName}", item.Name);
+                    return (GenerationOutcome.Failed, null);
                 }
             }
             catch (OperationCanceledException)
@@ -501,6 +546,7 @@ namespace WhisperSubs.Controller
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error generating forced subtitle for {ItemName}", item.Name);
+                return (GenerationOutcome.Failed, ex);
             }
             finally
             {
@@ -580,13 +626,19 @@ namespace WhisperSubs.Controller
             var languages = await ResolveLanguagesAsync(mediaPath, language, cancellationToken);
             var transcriptionLang = languages.FirstOrDefault() ?? "auto";
 
-            await GenerateLyricsForTrackAsync(item, provider, transcriptionLang, mediaPath, cancellationToken);
+            var (outcome, error) = await GenerateLyricsForTrackAsync(item, provider, transcriptionLang, mediaPath, cancellationToken);
+
+            if (outcome == GenerationOutcome.Failed)
+            {
+                throw new InvalidOperationException(
+                    $"Lyrics generation failed for \"{item.Name}\".", error);
+            }
 
             await item.RefreshMetadata(cancellationToken);
         }
 
         [ExcludeFromCodeCoverage(Justification = "Orchestrates FFmpeg + whisper processes for lyrics track")]
-        private async Task GenerateLyricsForTrackAsync(
+        private async Task<(GenerationOutcome Outcome, Exception? Error)> GenerateLyricsForTrackAsync(
             BaseItem item, ISubtitleProvider provider, string lang,
             string mediaPath, CancellationToken cancellationToken)
         {
@@ -598,7 +650,7 @@ namespace WhisperSubs.Controller
             if (File.Exists(lrcPath))
             {
                 _logger.LogInformation("Lyrics already exist for {ItemName}, skipping", item.Name);
-                return;
+                return (GenerationOutcome.Skipped, null);
             }
 
             var tempAudioPath = Path.Combine(Path.GetTempPath(), $"{item.Id}_{Guid.NewGuid()}.wav");
@@ -614,6 +666,7 @@ namespace WhisperSubs.Controller
 
                 await File.WriteAllTextAsync(lrcPath, lrcContent, CancellationToken.None);
                 _logger.LogInformation("Saved lyrics to {LrcPath}", lrcPath);
+                return (GenerationOutcome.Succeeded, null);
             }
             catch (OperationCanceledException)
             {
@@ -623,6 +676,7 @@ namespace WhisperSubs.Controller
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error generating lyrics for {ItemName} [{Language}]", item.Name, lang);
+                return (GenerationOutcome.Failed, ex);
             }
             finally
             {

--- a/Controller/SubtitleQueueService.cs
+++ b/Controller/SubtitleQueueService.cs
@@ -33,6 +33,8 @@ namespace WhisperSubs.Controller
         private int _isDraining;
         private string? _currentItemName;
         private int _processedCount;
+        private int _failedCount;
+        private string? _lastError;
         private static readonly object _fileLock = new();
 
         /// <summary>
@@ -52,6 +54,12 @@ namespace WhisperSubs.Controller
         public string? CurrentItemName => _currentItemName ?? _taskCurrentItemName;
         public bool IsDraining => _isDraining == 1;
         public int ProcessedCount => _processedCount;
+
+        /// <summary>Number of manual-queue items that failed (whisper error, missing binary, etc.).</summary>
+        public int FailedCount => _failedCount;
+
+        /// <summary>Last error message from a failed manual-queue item, for surfacing in the UI.</summary>
+        public string? LastError => _lastError;
 
         // ── Per-file progress (updated by WhisperProvider stderr) ──
         private int _currentFileProgress;
@@ -306,11 +314,14 @@ namespace WhisperSubs.Controller
                 catch (Exception ex)
                 {
                     Interlocked.Increment(ref _processedCount);
+                    Interlocked.Increment(ref _failedCount);
+                    _lastError = $"{workItem.Item.Name}: {ex.Message}";
                     workItem.Completion?.TrySetException(ex);
                     logger.LogError(ex, "[Queue] Failed: {ItemName}", workItem.Item.Name);
                 }
             }
-            logger.LogInformation("[Queue] Drain complete. Processed {Count} items total.", _processedCount);
+            logger.LogInformation("[Queue] Drain complete. Processed {Count} items total ({Failed} failed).",
+                _processedCount, _failedCount);
         }
 
         /// <summary>
@@ -351,6 +362,8 @@ namespace WhisperSubs.Controller
                 }
                 catch (Exception ex)
                 {
+                    Interlocked.Increment(ref _failedCount);
+                    _lastError = $"{workItem.Item.Name}: {ex.Message}";
                     workItem.Completion?.TrySetException(ex);
                     logger.LogError(ex, "[Priority] Failed: {ItemName}", workItem.Item.Name);
                 }

--- a/Providers/WhisperProvider.cs
+++ b/Providers/WhisperProvider.cs
@@ -185,8 +185,22 @@ namespace WhisperSubs.Providers
 
                 if (process.ExitCode != 0)
                 {
+                    var stderr = errorBuilder.ToString();
+
+                    // Exit 127 = dynamic linker couldn't load a shared library. Surface a clear,
+                    // actionable message instead of a raw dump (the binary itself is missing a runtime dep).
+                    if (process.ExitCode == 127)
+                    {
+                        var match = Regex.Match(stderr, @"error while loading shared libraries:\s*(\S+?):");
+                        var lib = match.Success ? match.Groups[1].Value : "a shared library";
+                        throw new InvalidOperationException(
+                            $"whisper-cli could not start: missing {lib}. The binary requires a system library " +
+                            $"that isn't present in this container. Install it (e.g. 'apt install libgomp1' for " +
+                            $"libgomp.so.1) or switch to a binary variant that doesn't need it. Raw error: {stderr.Trim()}");
+                    }
+
                     throw new InvalidOperationException(
-                        $"Whisper process failed with exit code {process.ExitCode}. Error: {errorBuilder}");
+                        $"Whisper process failed with exit code {process.ExitCode}. Error: {stderr}");
                 }
 
                 if (File.Exists(tempSrtPath))

--- a/README.md
+++ b/README.md
@@ -125,22 +125,14 @@ Then configure the plugin with:
 
 #### <a id="container-setup"></a>Container Library Requirements
 
-The plugin's built-in binary downloader fetches pre-built whisper-cli binaries. These require runtime libraries that are **not included** in the default Jellyfin Docker image:
+The plugin's built-in binary downloader fetches pre-built whisper-cli binaries. As of **v3.18.2.0** the CPU binary is fully self-contained (OpenMP is compiled out, so `libgomp1` is no longer required). GPU variants still need their respective userspace driver libraries, which are **not included** in the default Jellyfin Docker image:
 
 | Variant | Required packages | Install command |
 |---------|-------------------|-----------------|
-| **CPU** | `libgomp1` | `apt install libgomp1` |
-| **Vulkan** | `libgomp1`, `libvulkan1`, `mesa-vulkan-drivers` | `apt install libgomp1 libvulkan1 mesa-vulkan-drivers` |
-| **CUDA 12** | `libgomp1` + NVIDIA Container Toolkit on host | See [CUDA section](#cuda-nvidia) |
-| **ROCm** | `libgomp1` + ROCm runtime | See [ROCm docs](https://rocm.docs.amd.com/) |
-
-> `libgomp1` (OpenMP threading) is required by **all** variants, including CPU.
-
-To install persistently, add to your container's entrypoint or Dockerfile:
-
-```bash
-apt-get update -qq && apt-get install -y -qq --no-install-recommends libgomp1 && rm -rf /var/lib/apt/lists/*
-```
+| **CPU** | none (self-contained) | — |
+| **Vulkan** | `libvulkan1`, `mesa-vulkan-drivers` | `apt install libvulkan1 mesa-vulkan-drivers` |
+| **CUDA 12** | NVIDIA Container Toolkit on host | See [CUDA section](#cuda-nvidia) |
+| **ROCm** | ROCm runtime | See [ROCm docs](https://rocm.docs.amd.com/) |
 
 The plugin's setup page will detect missing libraries and warn you before downloading.
 
@@ -195,10 +187,9 @@ The Vulkan binary requires these libraries at runtime:
 |---|---|
 | `libvulkan1` | Vulkan loader |
 | `mesa-vulkan-drivers` | Intel (ANV) and AMD (RADV) Vulkan ICDs |
-| `libgomp1` | OpenMP threading |
 
 ```bash
-apt-get install -y libvulkan1 mesa-vulkan-drivers libgomp1
+apt-get install -y libvulkan1 mesa-vulkan-drivers
 ```
 
 #### Docker: GPU Passthrough for Vulkan
@@ -225,7 +216,7 @@ The container also needs the Vulkan runtime libraries. If using the official Jel
         dpkg -s libvulkan1 > /dev/null 2>&1 || \
           (apt-get update -qq && \
            apt-get install -y -qq --no-install-recommends \
-             libvulkan1 mesa-vulkan-drivers libgomp1 > /dev/null 2>&1 && \
+             libvulkan1 mesa-vulkan-drivers > /dev/null 2>&1 && \
            rm -rf /var/lib/apt/lists/*)
         exec /jellyfin/jellyfin
 ```

--- a/Setup/WhisperSetupService.cs
+++ b/Setup/WhisperSetupService.cs
@@ -339,7 +339,9 @@ namespace WhisperSubs.Setup
             };
             info.HasVulkanLibrary = Array.Exists(vulkanPaths, File.Exists);
 
-            // OpenMP runtime — required by ALL whisper.cpp variants (CPU, Vulkan, CUDA, ROCm)
+            // OpenMP runtime detection (informational only). As of v3.18.2.0 the distributed
+            // binaries are built with -DGGML_OPENMP=OFF and no longer link libgomp, so a missing
+            // libgomp.so.1 is NOT a blocker. Kept for diagnostics and older/self-built binaries.
             var openmpPaths = new[]
             {
                 "/lib/x86_64-linux-gnu/libgomp.so.1",

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -1071,26 +1071,42 @@
                             // ── Idle: hide or show "Finished" briefly ──
                             if (!q.isProcessing && q.remaining === 0) {
                                 if (banner.style.display !== 'none' && q.processed > 0) {
+                                    var hadFailure = q.failed > 0;
                                     spinner.style.animation = 'none';
                                     spinner.style.borderColor = 'transparent';
-                                    spinner.innerHTML = '\u2714';
                                     spinner.style.fontSize = '1.1em';
-                                    spinner.style.color = '#52B54B';
-                                    title.textContent = 'Finished';
                                     bar.style.width = '100%';
                                     pct.textContent = '';
-                                    current.textContent = '';
-                                    var finishParts = [q.processed.toLocaleString() + ' processed'];
-                                    if (q.failed > 0) finishParts.push(q.failed + ' failed');
-                                    stats.textContent = finishParts.join(' \u00b7 ');
+                                    if (hadFailure) {
+                                        // Failure state (red)
+                                        spinner.innerHTML = '\u2716';
+                                        spinner.style.color = '#cc3333';
+                                        bar.style.background = '#cc3333';
+                                        var succeeded = q.processed - q.failed;
+                                        title.textContent = succeeded > 0 ? 'Finished with errors' : 'Failed';
+                                        current.textContent = q.lastError
+                                            ? WhisperSubsConfig.truncate(q.lastError, 160) : '';
+                                        var failParts = [];
+                                        if (succeeded > 0) failParts.push(succeeded.toLocaleString() + ' succeeded');
+                                        failParts.push(q.failed + ' failed');
+                                        stats.textContent = failParts.join(' \u00b7 ');
+                                    } else {
+                                        // Success state (green)
+                                        spinner.innerHTML = '\u2714';
+                                        spinner.style.color = '#52B54B';
+                                        title.textContent = 'Finished';
+                                        current.textContent = '';
+                                        stats.textContent = q.processed.toLocaleString() + ' processed';
+                                    }
                                     if (WhisperSubsConfig._queueHideTimer) {
                                         clearTimeout(WhisperSubsConfig._queueHideTimer);
                                     }
+                                    // Keep failures visible longer so the user can read the error.
                                     WhisperSubsConfig._queueHideTimer = setTimeout(function () {
                                         banner.style.display = 'none';
                                         WhisperSubsConfig.resetQueueBanner();
                                         WhisperSubsConfig._queueHideTimer = null;
-                                    }, 8000);
+                                    }, hadFailure ? 20000 : 8000);
                                 } else {
                                     banner.style.display = 'none';
                                 }
@@ -1150,6 +1166,11 @@
                     return div.innerHTML;
                 },
 
+                truncate: function (str, max) {
+                    if (!str) return '';
+                    return str.length > max ? str.slice(0, max - 1) + '…' : str;
+                },
+
                 resetQueueBanner: function () {
                     var spinner = document.querySelector('#transcriptionSpinner');
                     spinner.innerHTML = '';
@@ -1161,7 +1182,9 @@
                     document.querySelector('#transcriptionTitle').textContent = 'Generating Subtitles';
                     document.querySelector('#transcriptionStats').textContent = '';
                     document.querySelector('#transcriptionCurrentItem').textContent = '';
-                    document.querySelector('#transcriptionProgressBar').style.width = '0%';
+                    var resetBar = document.querySelector('#transcriptionProgressBar');
+                    resetBar.style.width = '0%';
+                    resetBar.style.background = '#52B54B';
                     document.querySelector('#transcriptionProgressPct').textContent = '';
                 },
 

--- a/WhisperSubs.Tests/SubtitleQueueServiceTests.cs
+++ b/WhisperSubs.Tests/SubtitleQueueServiceTests.cs
@@ -107,6 +107,25 @@ public class SubtitleQueueServiceTests
         var queue = SubtitleQueueService.Instance;
         Assert.True(queue.PriorityCount >= 0);
     }
+
+    [Fact]
+    public void FailedCount_IsNonNegative()
+    {
+        // Manual-queue failure counter — exposed so the /Queue endpoint and UI
+        // can distinguish a failed transcription from a successful one (#70).
+        var queue = SubtitleQueueService.Instance;
+        Assert.True(queue.FailedCount >= 0);
+    }
+
+    [Fact]
+    public void LastError_IsExposed()
+    {
+        // Property must exist for the UI to surface a failure reason.
+        // It is null until a manual-queue item fails.
+        var queue = SubtitleQueueService.Instance;
+        _ = queue.LastError; // no throw; may be null or a prior error
+        Assert.True(true);
+    }
 }
 
 public class QueueEntryTests

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.18.1.0</Version>
+    <Version>3.18.2.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
Fixes #70 — two distinct bugs.

## 1. `libgomp.so.1` not found at transcribe time
The CPU `whisper-cli` binary dynamically linked the GNU OpenMP runtime, which isn't present in minimal TrueNAS Scale / TrueCharts containers, causing exit 127 mid-transcription. The `*-noavx` variants already avoided this via `-DGGML_OPENMP=OFF` — now applied to the `cpu`, `cpu-arm64`, `cuda12`, `vulkan` and `rocm` builds too. ggml falls back to its own pthread threadpool (still honors `-t N`), so multi-thread speed is preserved; only the small OpenMP delta is lost.

Cache keys bumped (`v9→v10`, rocm `v2→v3`) so the flag change actually rebuilds the binaries.

## 2. UI reported success when transcription failed
The per-language loop swallowed the whisper exception and the queue counted the item as "processed", so the progress card showed a green "Finished". Now:
- `SubtitleManager` reports a per-attempt outcome (Succeeded / Skipped / Failed) and throws when **every** attempted language fails with no output (per-language isolation preserved — one language failing still lets others proceed).
- `SubtitleQueueService` tracks a manual-queue `FailedCount` + `LastError`, surfaced via `/Queue`.
- The progress card shows a red error state ("Failed" / "Finished with errors") with the error text instead of a green checkmark.
- `whisper-cli` exit 127 now produces a clear "missing `<lib>`" message.

README updated: the CPU binary no longer requires `libgomp1`.

## Test plan
- [x] `dotnet build` (Release) clean
- [x] `dotnet test` — 341 passed
- [ ] CI builds all binary variants; `ldd whisper-cli` should no longer list `libgomp.so.1`
- [ ] Manual transcription failure shows red error card, not green success

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Queue UI shows failure state, success indicator, truncated last-error text, and extended banner visibility.

* **Bug Fixes**
  * Corrected queue failure counting to include all failure sources.
  * Improved runtime error reporting with actionable guidance for missing libraries.

* **Documentation**
  * Updated container/library guidance: CPU binary v3.18.2.0 built without OpenMP (libgomp1 not required).

* **Tests**
  * Added tests to validate exposed FailedCount and LastError behavior.

* **Chores**
  * CI/build workflow and release artifact cache keys updated; project version bumped to v3.18.2.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->