### PR TITLE
fix: keep OpenMP for performance, auto-fall back to noavx if libgomp missing

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -31,7 +31,7 @@ jobs:
           - os: [self-hosted, Linux, X64]
             variant: cpu
             asset_name: whisper-cli-linux-x64
-            cmake_flags: "-DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON -DGGML_BMI2=ON -DGGML_OPENMP=OFF"
+            cmake_flags: "-DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON -DGGML_BMI2=ON"
             pre_install: ""
           - os: [self-hosted, Linux, X64]
             variant: cpu-noavx
@@ -41,7 +41,7 @@ jobs:
           - os: [self-hosted, Linux, X64]
             variant: cpu-arm64
             asset_name: whisper-cli-linux-arm64
-            cmake_flags: "-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DGGML_NATIVE=OFF -DGGML_OPENMP=OFF"
+            cmake_flags: "-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++ -DGGML_NATIVE=OFF"
             pre_install: "arm64"
           - os: [self-hosted, Linux, X64]
             variant: cpu-arm64-noavx
@@ -51,7 +51,7 @@ jobs:
           - os: [self-hosted, Linux, X64]
             variant: cuda12
             asset_name: whisper-cli-linux-x64-cuda12
-            cmake_flags: "-DGGML_CUDA=ON -DGGML_STATIC=ON -DCMAKE_CUDA_ARCHITECTURES='61;70;75;80;86;89;90' -DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON -DGGML_BMI2=ON -DGGML_OPENMP=OFF"
+            cmake_flags: "-DGGML_CUDA=ON -DGGML_STATIC=ON -DCMAKE_CUDA_ARCHITECTURES='61;70;75;80;86;89;90' -DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON -DGGML_BMI2=ON"
             pre_install: "cuda"
           - os: [self-hosted, Linux, X64]
             variant: cuda12-noavx
@@ -61,7 +61,7 @@ jobs:
           - os: [self-hosted, Linux, X64]
             variant: vulkan
             asset_name: whisper-cli-linux-x64-vulkan
-            cmake_flags: "-DGGML_VULKAN=ON -DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON -DGGML_BMI2=ON -DGGML_OPENMP=OFF"
+            cmake_flags: "-DGGML_VULKAN=ON -DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON -DGGML_BMI2=ON"
             pre_install: "vulkan"
           - os: [self-hosted, Linux, X64]
             variant: vulkan-noavx
@@ -75,7 +75,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/whisper-${{ matrix.variant }}/build/bin/whisper-cli
-          key: whisper-1.8.4-${{ matrix.asset_name }}-v10
+          key: whisper-1.8.4-${{ matrix.asset_name }}-v11
 
       - name: Install build dependencies
         if: steps.cache-whisper.outputs.cache-hit != 'true'
@@ -138,7 +138,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/rocm-output/whisper-cli
-          key: whisper-1.8.4-rocm-6.1.2-v3
+          key: whisper-1.8.4-rocm-6.1.2-v4
 
       - name: Build whisper-cli with ROCm
         if: steps.cache-whisper-rocm.outputs.cache-hit != 'true'
@@ -156,7 +156,6 @@ jobs:
                 -DBUILD_SHARED_LIBS=OFF \
                 -DCMAKE_EXE_LINKER_FLAGS="-static-libgcc -static-libstdc++" \
                 -DGGML_HIP=ON \
-                -DGGML_OPENMP=OFF \
                 -DCMAKE_C_COMPILER=hipcc \
                 -DCMAKE_CXX_COMPILER=hipcc &&
               cmake --build build --config Release -j$(nproc) &&

--- a/README.md
+++ b/README.md
@@ -125,14 +125,23 @@ Then configure the plugin with:
 
 #### <a id="container-setup"></a>Container Library Requirements
 
-The plugin's built-in binary downloader fetches pre-built whisper-cli binaries. As of **v3.18.2.0** the CPU binary is fully self-contained (OpenMP is compiled out, so `libgomp1` is no longer required). GPU variants still need their respective userspace driver libraries, which are **not included** in the default Jellyfin Docker image:
+The plugin's built-in binary downloader fetches pre-built whisper-cli binaries. These require runtime libraries that are **not included** in the default Jellyfin Docker image:
 
 | Variant | Required packages | Install command |
 |---------|-------------------|-----------------|
-| **CPU** | none (self-contained) | — |
-| **Vulkan** | `libvulkan1`, `mesa-vulkan-drivers` | `apt install libvulkan1 mesa-vulkan-drivers` |
-| **CUDA 12** | NVIDIA Container Toolkit on host | See [CUDA section](#cuda-nvidia) |
-| **ROCm** | ROCm runtime | See [ROCm docs](https://rocm.docs.amd.com/) |
+| **CPU** | `libgomp1` | `apt install libgomp1` |
+| **CPU (Compatibility / noavx)** | none (self-contained) | — |
+| **Vulkan** | `libgomp1`, `libvulkan1`, `mesa-vulkan-drivers` | `apt install libgomp1 libvulkan1 mesa-vulkan-drivers` |
+| **CUDA 12** | `libgomp1` + NVIDIA Container Toolkit on host | See [CUDA section](#cuda-nvidia) |
+| **ROCm** | `libgomp1` + ROCm runtime | See [ROCm docs](https://rocm.docs.amd.com/) |
+
+> **Minimal containers (TrueNAS Scale, slim Docker):** The default `cpu` build links `libgomp1` (OpenMP) for best performance. If that library is missing, **the plugin automatically falls back to the `noavx` build**, which is compiled with OpenMP off and has no such dependency — so transcription still works out of the box, just without the small OpenMP speed-up. Install `libgomp1` if you want the faster build.
+
+To install `libgomp1` persistently, add to your container's entrypoint or Dockerfile:
+
+```bash
+apt-get update -qq && apt-get install -y -qq --no-install-recommends libgomp1 && rm -rf /var/lib/apt/lists/*
+```
 
 The plugin's setup page will detect missing libraries and warn you before downloading.
 
@@ -187,9 +196,10 @@ The Vulkan binary requires these libraries at runtime:
 |---|---|
 | `libvulkan1` | Vulkan loader |
 | `mesa-vulkan-drivers` | Intel (ANV) and AMD (RADV) Vulkan ICDs |
+| `libgomp1` | OpenMP threading |
 
 ```bash
-apt-get install -y libvulkan1 mesa-vulkan-drivers
+apt-get install -y libvulkan1 mesa-vulkan-drivers libgomp1
 ```
 
 #### Docker: GPU Passthrough for Vulkan
@@ -216,7 +226,7 @@ The container also needs the Vulkan runtime libraries. If using the official Jel
         dpkg -s libvulkan1 > /dev/null 2>&1 || \
           (apt-get update -qq && \
            apt-get install -y -qq --no-install-recommends \
-             libvulkan1 mesa-vulkan-drivers > /dev/null 2>&1 && \
+             libvulkan1 mesa-vulkan-drivers libgomp1 > /dev/null 2>&1 && \
            rm -rf /var/lib/apt/lists/*)
         exec /jellyfin/jellyfin
 ```

--- a/Setup/WhisperSetupService.cs
+++ b/Setup/WhisperSetupService.cs
@@ -339,9 +339,9 @@ namespace WhisperSubs.Setup
             };
             info.HasVulkanLibrary = Array.Exists(vulkanPaths, File.Exists);
 
-            // OpenMP runtime detection (informational only). As of v3.18.2.0 the distributed
-            // binaries are built with -DGGML_OPENMP=OFF and no longer link libgomp, so a missing
-            // libgomp.so.1 is NOT a blocker. Kept for diagnostics and older/self-built binaries.
+            // OpenMP runtime detection. The cpu/cuda12/vulkan/rocm binaries link libgomp for
+            // performance; if it's missing the plugin auto-falls back to the self-contained
+            // noavx build (compiled with -DGGML_OPENMP=OFF), so this is informational, not a blocker.
             var openmpPaths = new[]
             {
                 "/lib/x86_64-linux-gnu/libgomp.so.1",
@@ -445,15 +445,16 @@ namespace WhisperSubs.Setup
                 {
                     _logger.LogWarning("Binary validation warning: {Error}", validationError);
 
-                    // Auto-fallback: if a GPU variant fails, try the CPU equivalent
+                    // Auto-fallback: a GPU variant falls back to CPU; the OpenMP-linked CPU
+                    // variant falls back to the self-contained noavx build.
                     var fallbackVariant = GetCpuFallbackVariant(variant);
                     if (fallbackVariant != null)
                     {
-                        _logger.LogInformation("GPU binary failed validation — auto-downloading CPU fallback ({Fallback})", fallbackVariant);
+                        _logger.LogInformation("Binary '{Variant}' failed validation — auto-downloading fallback ({Fallback})", variant, fallbackVariant);
                         lock (_lock)
                         {
                             _progress = 50;
-                            _progressMessage = $"GPU binary failed ({validationError}). Downloading CPU fallback...";
+                            _progressMessage = $"'{variant}' binary failed ({validationError}). Downloading {fallbackVariant} fallback...";
                             _error = null;
                         }
                         await DownloadBinaryAsync(fallbackVariant, cancellationToken);
@@ -567,10 +568,15 @@ namespace WhisperSubs.Setup
         /// Maps GPU variants to their CPU fallback for auto-recovery.
         /// Returns null for CPU variants (no further fallback).
         /// </summary>
-        private static string? GetCpuFallbackVariant(string variant) => variant switch
+        internal static string? GetCpuFallbackVariant(string variant) => variant switch
         {
             "cuda12" or "vulkan" => "cpu",
             "cuda12-noavx" or "vulkan-noavx" or "rocm" => "noavx",
+            // The cpu build (x64 and arm64) links libgomp (OpenMP) for performance. If that
+            // library is missing (minimal containers), fall back to the self-contained noavx
+            // build, compiled with -DGGML_OPENMP=OFF, which has no such dependency. The arm64
+            // asset is resolved by platform, so "noavx" covers both architectures.
+            "cpu" => "noavx",
             _ => null
         };
 

--- a/WhisperSubs.Tests/SetupServiceTests.cs
+++ b/WhisperSubs.Tests/SetupServiceTests.cs
@@ -111,6 +111,19 @@ public class SetupServiceTests
         Assert.Contains("apt install", result);
     }
 
+    [Theory]
+    [InlineData("cuda12", "cpu")]
+    [InlineData("vulkan", "cpu")]
+    [InlineData("cuda12-noavx", "noavx")]
+    [InlineData("vulkan-noavx", "noavx")]
+    [InlineData("rocm", "noavx")]
+    [InlineData("cpu", "noavx")]        // #70: OpenMP-linked cpu build falls back to self-contained noavx
+    [InlineData("noavx", null)]         // already the most-compatible build — no further fallback
+    public void GetCpuFallbackVariant_MapsToExpectedFallback(string variant, string? expected)
+    {
+        Assert.Equal(expected, WhisperSetupService.GetCpuFallbackVariant(variant));
+    }
+
     [Fact]
     public void DetectGpu_ReturnsValidInfo()
     {

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.18.2.0</Version>
+    <Version>3.18.3.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
Follow-up to #71 / v3.18.2.0.

## Why
v3.18.2.0 fixed the `libgomp.so.1` failure (#70) by disabling OpenMP on **all** variants. That was the wrong trade-off: it slowed CPU transcription for **every** user — the majority who have `libgomp1` and work fine — just to rescue a minority on minimal containers, and it still didn't auto-route the affected user to a working binary.

## What
Restore the fast, OpenMP-linked builds and instead make the affected user land on the already-self-contained `noavx` build **automatically**:

- **Revert `-DGGML_OPENMP=OFF`** on `cpu`, `cpu-arm64`, `cuda12`, `vulkan` and the ROCm build — they keep OpenMP (and the `libgomp1` dependency) for full performance. The `*-noavx` variants stay OpenMP-off (self-contained).
- **`GetCpuFallbackVariant`: `cpu → noavx`.** The plugin already validates a downloaded binary by running `--help` and catching exit 127 (missing shared lib). Previously `cpu` had no fallback (dead end). Now a `cpu` binary that can't launch for lack of `libgomp` auto-downloads `noavx`, which has no such dependency. (arm64's asset is resolved by platform, so `noavx` covers both architectures.)
- **Cache keys bumped** (`v10→v11`, rocm `v3→v4`) so the OpenMP-on binaries actually rebuild.
- **README** restored: `libgomp1` required for cpu/gpu again, with a note that the plugin auto-falls back to `noavx` if it's missing.

Net effect: current users keep full speed; minimal-container users get a binary that just works, without having to know what OpenMP or `libgomp` is.

## Test plan
- [x] `dotnet build` (Release) clean
- [x] `dotnet test` — 348 passed (incl. 7 new `GetCpuFallbackVariant` cases)
- [ ] CI: `ldd whisper-cli-linux-x64` lists `libgomp.so.1` again; `whisper-cli-linux-x64-noavx` does not
- [ ] Container without libgomp: setup auto-downloads cpu, validation fails, noavx fetched and applied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated container setup instructions with OpenMP runtime requirements and automatic fallback behavior when OpenMP is unavailable

* **Chores**
  * Version bumped to 3.18.3.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->