### PR TITLE
fix: handle CPUs without AVX (detect, recommend noavx, fall back on SIGILL)

### DIFF
--- a/Providers/WhisperProvider.cs
+++ b/Providers/WhisperProvider.cs
@@ -199,6 +199,19 @@ namespace WhisperSubs.Providers
                             $"libgomp.so.1) or switch to a binary variant that doesn't need it. Raw error: {stderr.Trim()}");
                     }
 
+                    // Exit 132 = SIGILL (illegal instruction): the binary used a CPU instruction set
+                    // (e.g. AVX) this CPU doesn't support. The "noavx" (Compatibility) variant is built
+                    // for these CPUs. 134 = SIGABRT, 135 = SIGBUS are adjacent hardware/ABI crashes.
+                    if (process.ExitCode == 132 || process.ExitCode == 134 || process.ExitCode == 135)
+                    {
+                        throw new InvalidOperationException(
+                            "whisper-cli crashed on launch with an illegal-instruction error (exit " +
+                            $"{process.ExitCode}). This CPU likely lacks an instruction set (such as AVX) that " +
+                            "this binary was built for. Re-download the binary and choose the " +
+                            "\"CPU (Compatibility)\" / noavx variant on the plugin setup page, which is built " +
+                            $"for CPUs without AVX. Raw error: {stderr.Trim()}");
+                    }
+
                     throw new InvalidOperationException(
                         $"Whisper process failed with exit code {process.ExitCode}. Error: {stderr}");
                 }

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ The plugin's built-in binary downloader fetches pre-built whisper-cli binaries. 
 
 > **Minimal containers (TrueNAS Scale, slim Docker):** The default `cpu` build links `libgomp1` (OpenMP) for best performance. If that library is missing, **the plugin automatically falls back to the `noavx` build**, which is compiled with OpenMP off and has no such dependency — so transcription still works out of the box, just without the small OpenMP speed-up.
 
+> **Older / low-power CPUs (no AVX):** The `cpu`, `vulkan` and `cuda12` builds are compiled with AVX/AVX2 instructions and will crash with an *illegal instruction* error (exit 132) on CPUs that lack them — common on budget NAS boxes, Atom/Celeron chips and some VMs. The plugin **detects missing AVX support and automatically uses the `noavx` (Compatibility) build** instead, both when recommending a variant and as a download-time fallback. You can also pick **"CPU (Compatibility)"** manually on the setup page.
+
 For the faster build, install `libgomp1` persistently via your container's entrypoint or Dockerfile:
 
 ```bash

--- a/Setup/WhisperSetupService.cs
+++ b/Setup/WhisperSetupService.cs
@@ -353,11 +353,20 @@ namespace WhisperSubs.Setup
             };
             info.HasOpenMP = Array.Exists(openmpPaths, File.Exists);
 
-            // Recommend variant based on detection — require both device AND userspace library
-            if (info.HasNvidia && info.HasCudaLibrary) info.RecommendedVariant = "cuda12";
+            // CPU AVX support. Our x64 cpu/cuda12/vulkan binaries are compiled with AVX/AVX2;
+            // on a CPU that lacks those instructions they crash with SIGILL (illegal instruction,
+            // exit 132). Only the *-noavx builds (SSE4.2) are safe there. ARM has no AVX concept,
+            // and its binaries are built without it, so treat ARM as "AVX not required" (HasAvx=true
+            // semantically means "the AVX-requiring builds are safe to run").
+            info.HasAvx = RuntimeInformation.OSArchitecture == Architecture.Arm64
+                || DetectCpuHasAvx();
+
+            // Recommend variant based on detection — require both device AND userspace library.
+            // GPU binaries are also AVX-compiled, so a CPU without AVX must use a *-noavx variant.
+            if (info.HasNvidia && info.HasCudaLibrary) info.RecommendedVariant = info.HasAvx ? "cuda12" : "cuda12-noavx";
             else if (info.HasAmdGpu && info.HasRocmLibrary) info.RecommendedVariant = "rocm";
-            else if (info.HasRenderDevice && info.HasVulkanLibrary) info.RecommendedVariant = "vulkan";
-            else info.RecommendedVariant = "cpu";
+            else if (info.HasRenderDevice && info.HasVulkanLibrary) info.RecommendedVariant = info.HasAvx ? "vulkan" : "vulkan-noavx";
+            else info.RecommendedVariant = info.HasAvx ? "cpu" : "noavx";
 
             return info;
         }
@@ -546,6 +555,19 @@ namespace WhisperSubs.Setup
         [ExcludeFromCodeCoverage(Justification = "Spawns binary process for validation")]
         private string? ValidateBinary(string binaryPath, string variant)
         {
+            // AVX gate: `--help` exits before any AVX instruction executes, so an AVX-compiled
+            // binary on a non-AVX CPU would *pass* the probe and only crash later during real
+            // transcription (SIGILL / exit 132). Catch it here so the cpu->noavx fallback fires
+            // at download time. ARM hosts have no AVX concept and their binaries don't use it.
+            if (VariantRequiresAvx(variant)
+                && RuntimeInformation.OSArchitecture != Architecture.Arm64
+                && !DetectCpuHasAvx())
+            {
+                _logger.LogWarning("Variant '{Variant}' requires AVX but this CPU lacks it — will fall back", variant);
+                return "This CPU does not support AVX instructions, which this binary requires. "
+                     + "Falling back to the compatibility (noavx) build.";
+            }
+
             try
             {
                 using var process = new System.Diagnostics.Process
@@ -589,6 +611,16 @@ namespace WhisperSubs.Setup
                     return $"Missing {lib}. {suggestion}";
                 }
 
+                // 128+N = killed by signal N. 132 = SIGILL (illegal instruction) — the binary used
+                // a CPU instruction (e.g. AVX) this CPU doesn't support. 134 = SIGABRT, 135 = SIGBUS.
+                // Treat these as a validation failure so the fallback chain steps to a safer build.
+                if (process.ExitCode == 132 || process.ExitCode == 134 || process.ExitCode == 135)
+                {
+                    return "The binary crashed on launch (illegal instruction) — this CPU likely "
+                         + "lacks an instruction set (e.g. AVX) the build requires. "
+                         + "Falling back to the compatibility (noavx) build.";
+                }
+
                 return null; // Any other exit code is fine (--help may return non-zero on some builds)
             }
             catch (Exception ex)
@@ -616,6 +648,60 @@ namespace WhisperSubs.Setup
             "cpu" => "noavx",
             _ => null
         };
+
+        /// <summary>
+        /// Whether the given variant's prebuilt binary was compiled with AVX/AVX2 instructions.
+        /// These crash with SIGILL (exit 132) on CPUs that lack AVX. The "*-noavx" builds use
+        /// only SSE4.2 and are safe everywhere. ARM builds have no AVX and are always safe.
+        /// </summary>
+        internal static bool VariantRequiresAvx(string variant) => variant switch
+        {
+            "cpu" or "cuda12" or "vulkan" => true,
+            _ => false   // noavx, cuda12-noavx, vulkan-noavx, rocm, unknown
+        };
+
+        /// <summary>
+        /// Parses Linux /proc/cpuinfo content and returns true if the CPU advertises AVX.
+        /// Pure/testable — the file read happens in <see cref="DetectCpuHasAvx"/>.
+        /// </summary>
+        internal static bool CpuInfoHasAvx(string cpuInfoContent)
+        {
+            if (string.IsNullOrEmpty(cpuInfoContent)) return false;
+
+            foreach (var line in cpuInfoContent.Split('\n'))
+            {
+                if (!line.StartsWith("flags", StringComparison.OrdinalIgnoreCase)) continue;
+
+                // flags are space-separated; match "avx" as a whole token (avoid matching "avx512..."
+                // substrings only — though those imply avx too, an exact-token check is clearest).
+                var tokens = line.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                foreach (var token in tokens)
+                {
+                    if (string.Equals(token, "avx", StringComparison.OrdinalIgnoreCase)) return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Reads /proc/cpuinfo and reports whether the host CPU supports AVX. Returns true on any
+        /// non-Linux platform or read failure (fail-open: don't wrongly steer users away from the
+        /// faster build when we can't tell — the download-time validation still catches a real crash).
+        /// </summary>
+        [ExcludeFromCodeCoverage(Justification = "Reads host /proc/cpuinfo")]
+        private static bool DetectCpuHasAvx()
+        {
+            try
+            {
+                if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) return true;
+                if (!File.Exists("/proc/cpuinfo")) return true;
+                return CpuInfoHasAvx(File.ReadAllText("/proc/cpuinfo"));
+            }
+            catch
+            {
+                return true; // can't determine — don't block the default recommendation
+            }
+        }
 
         /// <summary>
         /// Returns an apt-install hint for a missing shared library.
@@ -694,6 +780,9 @@ namespace WhisperSubs.Setup
         public bool HasRenderDevice { get; set; }
         public bool HasVulkanLibrary { get; set; }
         public bool HasOpenMP { get; set; }
+        /// <summary>True if the CPU supports AVX (or is ARM, where AVX is N/A). When false, only
+        /// the "*-noavx" binary variants will run — the others crash with SIGILL.</summary>
+        public bool HasAvx { get; set; } = true;
         public string RecommendedVariant { get; set; } = "cpu";
     }
 

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -726,11 +726,19 @@
                             hint.style.color = '#CC7B19';
                         }
                     } else if (variant === 'noavx') {
-                        hint.textContent = 'Compatibility variant \u2014 no AVX or OpenMP required. Recommended for containers (TrueNAS Scale, minimal Docker).';
-                        hint.style.color = '';
+                        if (gpuInfo.HasAvx === false) {
+                            hint.textContent = 'Compatibility variant \u2014 required: this CPU does not support AVX. No AVX or OpenMP needed.';
+                            hint.style.color = '#52B54B';
+                        } else {
+                            hint.textContent = 'Compatibility variant \u2014 no AVX or OpenMP required. Recommended for containers (TrueNAS Scale, minimal Docker).';
+                            hint.style.color = '';
+                        }
                     } else {
                         // CPU
-                        if (gpuInfo.HasNvidia || gpuInfo.HasAmdGpu || gpuInfo.HasRenderDevice) {
+                        if (gpuInfo.HasAvx === false) {
+                            hint.textContent = 'This CPU does not support AVX \u2014 the CPU variant will crash. Choose "CPU (Compatibility)" (noavx) instead.';
+                            hint.style.color = '#CC3333';
+                        } else if (gpuInfo.HasNvidia || gpuInfo.HasAmdGpu || gpuInfo.HasRenderDevice) {
                             hint.textContent = 'GPU detected \u2014 consider a GPU variant for faster transcription.';
                             hint.style.color = '#CC7B19';
                         } else {

--- a/WhisperSubs.Tests/SetupServiceTests.cs
+++ b/WhisperSubs.Tests/SetupServiceTests.cs
@@ -165,9 +165,57 @@ public class SetupServiceTests
         var gpu = WhisperSetupService.DetectGpu();
         Assert.NotNull(gpu);
         Assert.False(string.IsNullOrEmpty(gpu.RecommendedVariant));
-        // On macOS (test environment), no GPU devices expected
-        var validVariants = new[] { "cpu", "cuda12", "vulkan", "rocm" };
+        // Recommendation must be a real catalog variant. Includes *-noavx because a host
+        // without AVX (or our detection) is steered to the compatibility builds.
+        var validVariants = new[] { "cpu", "noavx", "cuda12", "cuda12-noavx", "vulkan", "vulkan-noavx", "rocm" };
         Assert.Contains(gpu.RecommendedVariant, validVariants);
+    }
+
+    [Theory]
+    [InlineData("cpu", true)]
+    [InlineData("cuda12", true)]
+    [InlineData("vulkan", true)]
+    [InlineData("noavx", false)]
+    [InlineData("cuda12-noavx", false)]
+    [InlineData("vulkan-noavx", false)]
+    [InlineData("rocm", false)]
+    [InlineData("unknown", false)]
+    public void VariantRequiresAvx_OnlyNonNoavxBuilds(string variant, bool requiresAvx)
+    {
+        Assert.Equal(requiresAvx, WhisperSetupService.VariantRequiresAvx(variant));
+    }
+
+    [Fact]
+    public void CpuInfoHasAvx_DetectsAvxFlag()
+    {
+        // Real /proc/cpuinfo "flags" line containing avx
+        var withAvx = "processor\t: 0\nflags\t\t: fpu vme de pse tsc msr pae mce cx8 sse sse2 avx avx2 fma\n";
+        Assert.True(WhisperSetupService.CpuInfoHasAvx(withAvx));
+    }
+
+    [Fact]
+    public void CpuInfoHasAvx_NoAvxFlag_ReturnsFalse()
+    {
+        // A CPU that lacks AVX (e.g. older Atom/Celeron common in NAS boxes)
+        var noAvx = "processor\t: 0\nflags\t\t: fpu vme de pse tsc msr pae mce cx8 sse sse2 sse4_1 sse4_2\n";
+        Assert.False(WhisperSetupService.CpuInfoHasAvx(noAvx));
+    }
+
+    [Fact]
+    public void CpuInfoHasAvx_DoesNotMatchAvxSubstrings()
+    {
+        // Must match the whole "avx" token, not "avx512vl" alone implying nothing about plain avx.
+        // A line with only avx512 tokens (no bare "avx") should NOT report avx.
+        var only512 = "flags\t\t: fpu sse2 avx512f avx512dq avx512bw\n";
+        Assert.False(WhisperSetupService.CpuInfoHasAvx(only512));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("processor : 0\nmodel name : Some CPU\n")]  // no flags line at all
+    public void CpuInfoHasAvx_EmptyOrNoFlags_ReturnsFalse(string content)
+    {
+        Assert.False(WhisperSetupService.CpuInfoHasAvx(content));
     }
 
     [Fact]

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.18.4.0</Version>
+    <Version>3.18.5.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
Follow-up to #70. The reporter confirmed the libgomp + UI fixes work, but transcription then failed with **exit 132 (SIGILL)** — their TrueNAS CPU lacks AVX, and our `cpu`/`cuda12`/`vulkan` binaries are compiled with AVX/AVX2, so they crash on launch.

## Why the existing auto-fallback didn't save them
1. **Validation runs `whisper-cli --help`**, which exits *before* any AVX instruction executes — so the AVX-incompatible binary **passed** validation and got written to config.
2. We only treated **exit 127** (missing shared lib) as a failure, not **132** (SIGILL).

## Fix — defense in depth, so any AVX-less CPU lands on `noavx` automatically
- **Up-front detection**: `DetectGpu` reads `/proc/cpuinfo` and recommends a `*-noavx` variant when AVX is absent (`cpu→noavx`, `cuda12→cuda12-noavx`, `vulkan→vulkan-noavx`). Fixes the first-time download.
- **Download-time gate**: `ValidateBinary` fails AVX-requiring variants on a non-AVX host, so the existing `cpu→noavx` fallback fires without needing to run compute. Also treats exit `132/134/135` (SIGILL/SIGABRT/SIGBUS) as failures.
- **Runtime message**: `WhisperProvider` gives a clear "illegal instruction — re-download and pick CPU (Compatibility)/noavx" error on exit 132 for already-installed binaries.
- **UI**: config page shows a red warning when `cpu` is selected on a non-AVX CPU.

AVX detection **fails open** (assume AVX present) when it can't read cpuinfo or runs off-Linux, so AVX-capable users are never wrongly downgraded; the runtime SIGILL handler is the backstop.

## Test plan
- [x] `dotnet build` (Release) clean
- [x] `dotnet test` — 367 passed (+13: `CpuInfoHasAvx` parser cases, `VariantRequiresAvx` mapping)
- [ ] CI green
- [ ] Reporter confirms transcription works on their non-AVX TrueNAS box