### PR TITLE
ci(deps): bump deprecated GitHub Actions to current majors

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -280,7 +280,7 @@ jobs:
           fi
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ steps.version.outputs.version }}
           name: WhisperSubs v${{ steps.version.outputs.version }}
@@ -305,7 +305,7 @@ jobs:
           cp manifest.json _pages/
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v5
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           node-version: '20'
 
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed in 14 days if no further activity occurs.'
           close-issue-message: 'This issue was closed because it has been stale for 14 days with no activity.'


### PR DESCRIPTION
Mechanical major-version bumps for deprecated/old GitHub Actions.

- `actions/configure-pages: v4→v5`
- `actions/stale: v9→v10`
- `softprops/action-gh-release: v1→v2`

Auto-merge enabled; merges once CI is green.