### PR TITLE
feat: align subtitle timing to speech + compensate audio start offset (#78)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,8 +51,9 @@ Plugin.cs                          Entry point, IHasWebPages (embeds config UI)
 1. **Language detection** — `SubtitleManager.DetectAudioLanguagesAsync` calls FFprobe to read audio stream language tags. ISO 639-2/B codes are normalized to 639-1 (e.g., `spa` -> `es`).
 2. **Audio extraction** — FFmpeg extracts 16kHz mono PCM WAV from the media file to a temp path.
 3. **Transcription** — `WhisperProvider.TranscribeAsync` invokes `whisper-cli` as a child process with the model and audio file. Output is an SRT file.
-4. **Save** — The SRT content is written alongside the media as `<filename>.<lang>.generated.srt`.
-5. **Metadata refresh** — `item.RefreshMetadata()` tells Jellyfin to pick up the new subtitle file.
+4. **Timing corrections** — Before saving, `SubtitleManager.ApplyTimingCorrectionsAsync` applies (when the matching config toggle is on): `CompensateAudioOffset` shifts all timestamps by the audio stream's container `start_time`, then `WhisperProvider.AlignSrtToSpeech` snaps each subtitle's start forward to detected speech onset via FFmpeg `silencedetect` (fixes whisper.cpp's gapless segments). Both default on; local whisper-cli only (full + translated), not the remote API, not forced.
+5. **Save** — The SRT content is written alongside the media as `<filename>.<lang>.generated.srt`.
+6. **Metadata refresh** — `item.RefreshMetadata()` tells Jellyfin to pick up the new subtitle file.
 
 ### English Translation (v3.11.0.0+)
 
@@ -202,6 +203,7 @@ Version is read from `<Version>` in `WhisperSubs.csproj`. Bump there before push
 - **Language detection false positives**: At p>=0.3, concert/music audio can be misidentified as foreign language. Consider raising threshold for non-dialogue content.
 - **Hallucination signatures** (Spanish): "La Iglesia de Jesucristo de los Santos de los Ultimos Dias", "Suscribete al canal", "Subtitulos por".
 - **whisper.cpp writes SRT only at completion** — not incrementally. Mid-process kills produce no partial file.
+- **Subtitle timing**: whisper.cpp emits gapless segments, so a line can show during the pause before its speech. `AlignSubtitlesToSpeech` (default on) snaps starts to speech onset via `silencedetect`; `CompensateAudioOffset` (default on) shifts by audio `start_time`. See `WhisperProvider.AlignSrtToSpeech` + `SubtitleManager.ApplyTimingCorrectionsAsync`. Applies to full + translated, not forced/lyrics.
 
 ## Operational Gotchas
 

--- a/Configuration/PluginConfiguration.cs
+++ b/Configuration/PluginConfiguration.cs
@@ -78,6 +78,21 @@ namespace WhisperSubs.Configuration
         /// </summary>
         public string CustomWhisperArgs { get; set; } = "";
 
+        /// <summary>
+        /// When enabled, subtitle start times are snapped forward to detected speech onsets
+        /// so a subtitle no longer appears during the silence before its line is spoken.
+        /// whisper.cpp emits gapless segments (next.start == prev.end); this re-introduces
+        /// the natural gaps using FFmpeg silence detection. Local whisper-cli only.
+        /// </summary>
+        public bool AlignSubtitlesToSpeech { get; set; } = true;
+
+        /// <summary>
+        /// When enabled, compensates for a container audio start-time offset (the audio stream
+        /// not starting at 0:00) by shifting all subtitle timestamps forward by that offset,
+        /// keeping subtitles in sync with playback. Local whisper-cli only.
+        /// </summary>
+        public bool CompensateAudioOffset { get; set; } = true;
+
         public List<string> EnabledLibraries { get; set; } = new List<string>();
 
         public PluginConfiguration()

--- a/Controller/SubtitleManager.cs
+++ b/Controller/SubtitleManager.cs
@@ -161,7 +161,7 @@ namespace WhisperSubs.Controller
                 await ExtractAudioAsync(mediaPath, tempAudioPath, lang, cancellationToken, resumeOffsetSeconds);
                 SubtitleQueueService.Instance.ReportPhase("Transcribing");
                 string srtContent = await provider.TranscribeAsync(tempAudioPath, lang, cancellationToken);
-                srtContent = await ApplyTimingCorrectionsAsync(srtContent, mediaPath, tempAudioPath, 0, cancellationToken);
+                srtContent = await ApplyTimingCorrectionsAsync(srtContent, mediaPath, tempAudioPath, resumeOffsetSeconds > 0, cancellationToken);
 
                 if (resumeOffsetSeconds > 0 && !string.IsNullOrWhiteSpace(existingSrt))
                 {
@@ -298,7 +298,7 @@ namespace WhisperSubs.Controller
                 await ExtractAudioAsync(mediaPath, tempAudioPath, sourceLanguage, cancellationToken);
                 SubtitleQueueService.Instance.ReportPhase("Translating to English");
                 string srtContent = await provider.TranscribeAsync(tempAudioPath, sourceLanguage, cancellationToken, translate: true);
-                srtContent = await ApplyTimingCorrectionsAsync(srtContent, mediaPath, tempAudioPath, 0, cancellationToken);
+                srtContent = await ApplyTimingCorrectionsAsync(srtContent, mediaPath, tempAudioPath, isResume: false, cancellationToken);
 
                 await File.WriteAllTextAsync(translatedSrtPath, srtContent, CancellationToken.None);
                 _logger.LogInformation("Saved translated subtitle to {SrtPath}", translatedSrtPath);
@@ -1374,9 +1374,13 @@ namespace WhisperSubs.Controller
 
             var outputBuilder = new StringBuilder();
             process.OutputDataReceived += (_, e) => { if (e.Data != null) outputBuilder.AppendLine(e.Data); };
+            // Drain stderr too so a full pipe can never deadlock WaitForExitAsync (consistent with
+            // GetMediaDurationAsync / DetectSpeechSegmentsAsync). Content is unused (-v error).
+            process.ErrorDataReceived += (_, _) => { };
 
             process.Start();
             process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
 
             try
             {
@@ -1403,29 +1407,49 @@ namespace WhisperSubs.Controller
         }
 
         /// <summary>
-        /// Applies subtitle timing corrections to an SRT string: audio-start-offset
-        /// compensation (Feature 3) followed by speech-onset alignment (Feature 2).
-        /// Order matters — the offset is applied first so the silence segments and the
-        /// SRT share the same timeline before alignment. A silencedetect failure never
-        /// fails the job (the SRT is returned as-is); cancellation propagates.
+        /// Applies subtitle timing corrections to a FRESH whisper-cli transcription's SRT:
+        /// audio-start-offset compensation (Feature 3) followed by speech-onset alignment
+        /// (Feature 2). Order matters — the offset is applied first so the silence segments and
+        /// the SRT share the same timeline before alignment. A silencedetect failure never fails
+        /// the job (the SRT is returned as-is); cancellation propagates.
+        ///
+        /// Local whisper-cli only: skipped entirely when a remote API is configured (the remote
+        /// server returns its own, often already playback-aligned, timestamps).
         /// </summary>
+        /// <param name="isResume">True when this is a resumed partial transcription. The audio was
+        /// extracted with <c>-ss</c> so it starts at ~0:00 and the caller re-anchors it via
+        /// <see cref="WhisperProvider.OffsetSrt"/>; applying the container start_time here too would
+        /// double-shift the appended tail, so offset compensation is skipped (alignment still runs
+        /// on the 0-based fresh SRT, which matches the 0-based silence segments).</param>
         [ExcludeFromCodeCoverage(Justification = "Orchestrates FFprobe/FFmpeg processes for timing correction")]
         private async Task<string> ApplyTimingCorrectionsAsync(
-            string srtContent, string mediaPath, string audioPath, double mediaDuration, CancellationToken ct)
+            string srtContent, string mediaPath, string audioPath, bool isResume, CancellationToken ct)
         {
             if (string.IsNullOrWhiteSpace(srtContent)) return srtContent;
 
             var config = Plugin.Instance?.Configuration;
 
-            // Feature 3: compensate for a non-zero audio stream start_time.
-            if (config?.CompensateAudioOffset == true)
+            // These corrections operate on locally-generated whisper-cli output only. A remote API
+            // server returns its own timestamps, so don't re-time them (and don't spend local CPU).
+            if (!string.IsNullOrWhiteSpace(config?.RemoteWhisperApiUrl)) return srtContent;
+
+            // Feature 3: compensate for a non-zero audio stream start_time. Skipped on resume
+            // (see isResume) — the existing SRT already carried it and the tail is re-anchored
+            // by the caller's OffsetSrt(resumeOffsetSeconds), so re-applying would double-shift.
+            if (config?.CompensateAudioOffset == true && !isResume)
             {
                 var startTime = await GetAudioStartTimeAsync(mediaPath, ct);
-                // Ignore container-timestamp noise and absurd values.
-                if (startTime > 0.05 && startTime < 30)
+                // Ignore container-timestamp noise (< 50ms). Cap at 600s to reject absurd/corrupt
+                // metadata while still covering long broadcast/transport-stream pre-rolls.
+                if (startTime > 0.05 && startTime < 600)
                 {
                     srtContent = WhisperProvider.OffsetSrt(srtContent, startTime, 1);
                     _logger.LogInformation("Shifted subtitles by {Offset:F3}s to compensate audio start offset for {ItemName}",
+                        startTime, Path.GetFileName(mediaPath));
+                }
+                else if (startTime >= 600)
+                {
+                    _logger.LogWarning("Audio start offset {Offset:F1}s exceeds the 600s correction limit for {ItemName}; leaving timestamps unshifted",
                         startTime, Path.GetFileName(mediaPath));
                 }
             }
@@ -1435,7 +1459,7 @@ namespace WhisperSubs.Controller
             {
                 try
                 {
-                    var duration = mediaDuration > 0 ? mediaDuration : await GetMediaDurationAsync(audioPath, ct);
+                    var duration = await GetMediaDurationAsync(audioPath, ct);
                     var segments = await DetectSpeechSegmentsAsync(audioPath, duration, ct);
                     if (segments.Count > 0)
                     {

--- a/Controller/SubtitleManager.cs
+++ b/Controller/SubtitleManager.cs
@@ -161,6 +161,7 @@ namespace WhisperSubs.Controller
                 await ExtractAudioAsync(mediaPath, tempAudioPath, lang, cancellationToken, resumeOffsetSeconds);
                 SubtitleQueueService.Instance.ReportPhase("Transcribing");
                 string srtContent = await provider.TranscribeAsync(tempAudioPath, lang, cancellationToken);
+                srtContent = await ApplyTimingCorrectionsAsync(srtContent, mediaPath, tempAudioPath, 0, cancellationToken);
 
                 if (resumeOffsetSeconds > 0 && !string.IsNullOrWhiteSpace(existingSrt))
                 {
@@ -297,6 +298,7 @@ namespace WhisperSubs.Controller
                 await ExtractAudioAsync(mediaPath, tempAudioPath, sourceLanguage, cancellationToken);
                 SubtitleQueueService.Instance.ReportPhase("Translating to English");
                 string srtContent = await provider.TranscribeAsync(tempAudioPath, sourceLanguage, cancellationToken, translate: true);
+                srtContent = await ApplyTimingCorrectionsAsync(srtContent, mediaPath, tempAudioPath, 0, cancellationToken);
 
                 await File.WriteAllTextAsync(translatedSrtPath, srtContent, CancellationToken.None);
                 _logger.LogInformation("Saved translated subtitle to {SrtPath}", translatedSrtPath);
@@ -1338,6 +1340,119 @@ namespace WhisperSubs.Controller
             }
 
             return 0;
+        }
+
+        /// <summary>
+        /// Uses FFprobe to read the first audio stream's start_time (seconds).
+        /// Returns the value, or 0 on any failure / unparseable / negative.
+        /// </summary>
+        [ExcludeFromCodeCoverage(Justification = "Spawns FFprobe process for audio start_time query")]
+        private async Task<double> GetAudioStartTimeAsync(string mediaPath, CancellationToken cancellationToken)
+        {
+            var ffprobePath = FindFfprobeExecutable();
+            if (ffprobePath == null) return 0;
+
+            var startTimeInfo = new ProcessStartInfo
+            {
+                FileName = ffprobePath,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            startTimeInfo.ArgumentList.Add("-v");
+            startTimeInfo.ArgumentList.Add("error");
+            startTimeInfo.ArgumentList.Add("-select_streams");
+            startTimeInfo.ArgumentList.Add("a:0");
+            startTimeInfo.ArgumentList.Add("-show_entries");
+            startTimeInfo.ArgumentList.Add("stream=start_time");
+            startTimeInfo.ArgumentList.Add("-of");
+            startTimeInfo.ArgumentList.Add("default=noprint_wrappers=1:nokey=1");
+            startTimeInfo.ArgumentList.Add(mediaPath);
+
+            using var process = new Process { StartInfo = startTimeInfo };
+
+            var outputBuilder = new StringBuilder();
+            process.OutputDataReceived += (_, e) => { if (e.Data != null) outputBuilder.AppendLine(e.Data); };
+
+            process.Start();
+            process.BeginOutputReadLine();
+
+            try
+            {
+                await process.WaitForExitAsync(cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                try { process.Kill(entireProcessTree: true); } catch { }
+                throw;
+            }
+
+            process.WaitForExit();
+
+            if (process.ExitCode != 0) return 0;
+
+            if (double.TryParse(outputBuilder.ToString().Trim(), System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture, out var startTime)
+                && startTime > 0)
+            {
+                return startTime;
+            }
+
+            return 0;
+        }
+
+        /// <summary>
+        /// Applies subtitle timing corrections to an SRT string: audio-start-offset
+        /// compensation (Feature 3) followed by speech-onset alignment (Feature 2).
+        /// Order matters — the offset is applied first so the silence segments and the
+        /// SRT share the same timeline before alignment. A silencedetect failure never
+        /// fails the job (the SRT is returned as-is); cancellation propagates.
+        /// </summary>
+        [ExcludeFromCodeCoverage(Justification = "Orchestrates FFprobe/FFmpeg processes for timing correction")]
+        private async Task<string> ApplyTimingCorrectionsAsync(
+            string srtContent, string mediaPath, string audioPath, double mediaDuration, CancellationToken ct)
+        {
+            if (string.IsNullOrWhiteSpace(srtContent)) return srtContent;
+
+            var config = Plugin.Instance?.Configuration;
+
+            // Feature 3: compensate for a non-zero audio stream start_time.
+            if (config?.CompensateAudioOffset == true)
+            {
+                var startTime = await GetAudioStartTimeAsync(mediaPath, ct);
+                // Ignore container-timestamp noise and absurd values.
+                if (startTime > 0.05 && startTime < 30)
+                {
+                    srtContent = WhisperProvider.OffsetSrt(srtContent, startTime, 1);
+                    _logger.LogInformation("Shifted subtitles by {Offset:F3}s to compensate audio start offset for {ItemName}",
+                        startTime, Path.GetFileName(mediaPath));
+                }
+            }
+
+            // Feature 2: snap subtitle starts forward to detected speech onsets.
+            if (config?.AlignSubtitlesToSpeech == true)
+            {
+                try
+                {
+                    var duration = mediaDuration > 0 ? mediaDuration : await GetMediaDurationAsync(audioPath, ct);
+                    var segments = await DetectSpeechSegmentsAsync(audioPath, duration, ct);
+                    if (segments.Count > 0)
+                    {
+                        srtContent = WhisperProvider.AlignSrtToSpeech(srtContent, segments);
+                        _logger.LogInformation("Aligned subtitle starts to {Count} detected speech segments for {ItemName}",
+                            segments.Count, Path.GetFileName(mediaPath));
+                    }
+                }
+                catch (OperationCanceledException) { throw; }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Speech alignment failed for {ItemName}, leaving subtitle timings unchanged",
+                        Path.GetFileName(mediaPath));
+                }
+            }
+
+            return srtContent;
         }
 
         private string? FindFfmpegExecutable()

--- a/Providers/WhisperProvider.cs
+++ b/Providers/WhisperProvider.cs
@@ -661,7 +661,9 @@ namespace WhisperSubs.Providers
         {
             if (seconds < 0) seconds = 0;
 
-            var totalMs = (int)Math.Round(seconds * 1000);
+            // Truncate (not round) to match OffsetTimestamp, so the align and offset passes
+            // produce identical millisecond values for the same input.
+            var totalMs = (int)(seconds * 1000);
 
             var h = totalMs / 3600000;
             var m = (totalMs % 3600000) / 60000;

--- a/Providers/WhisperProvider.cs
+++ b/Providers/WhisperProvider.cs
@@ -526,6 +526,151 @@ namespace WhisperSubs.Providers
             return matches.Count;
         }
 
+        /// <summary>
+        /// Aligns subtitle START times to detected speech onsets. whisper.cpp chains segments
+        /// gaplessly (next.start == prev.end), so a subtitle for upcoming speech appears during the
+        /// preceding silence. For each entry whose start falls inside a silence gap, this snaps the
+        /// start FORWARD to the next speech onset — never backward, never past (end - 0.5s), so a
+        /// subtitle keeps at least ~0.5s on screen. End times, text, and ordering are untouched.
+        /// </summary>
+        /// <param name="srtContent">Raw SRT text.</param>
+        /// <param name="speechSegments">Detected speech regions (seconds), each (Start,End); the gaps
+        /// between them are silence. May be unsorted; treat defensively. Empty => return input unchanged.</param>
+        public static string AlignSrtToSpeech(string srtContent, IReadOnlyList<(double Start, double End)> speechSegments)
+        {
+            if (string.IsNullOrWhiteSpace(srtContent) || speechSegments == null || speechSegments.Count == 0)
+                return srtContent;
+
+            // Work on a sorted copy (by Start) so onset lookups scan in timeline order.
+            var segments = speechSegments.OrderBy(s => s.Start).ToList();
+
+            var result = new StringBuilder();
+
+            var lines = srtContent.Split('\n');
+            int i = 0;
+            while (i < lines.Length)
+            {
+                var line = lines[i].Trim();
+
+                // Skip empty lines
+                if (string.IsNullOrEmpty(line)) { i++; continue; }
+
+                // Preserve the original entry number exactly as found (do NOT renumber).
+                string number = "";
+                if (int.TryParse(line, out _))
+                {
+                    number = line;
+                    i++;
+                    if (i >= lines.Length) break;
+                    line = lines[i].Trim();
+                }
+
+                // Parse timestamp line
+                var match = Regex.Match(line, @"(\d{2}:\d{2}:\d{2},\d{3})\s*-->\s*(\d{2}:\d{2}:\d{2},\d{3})");
+                if (!match.Success)
+                {
+                    // Malformed entry (no timing): pass through unchanged rather than dropping.
+                    if (!string.IsNullOrEmpty(number)) result.AppendLine(number);
+                    result.AppendLine(line);
+                    i++;
+                    while (i < lines.Length && !string.IsNullOrWhiteSpace(lines[i]))
+                    {
+                        result.AppendLine(lines[i].TrimEnd());
+                        i++;
+                    }
+                    result.AppendLine();
+                    continue;
+                }
+
+                var origStartTs = match.Groups[1].Value;
+                var origEndTs = match.Groups[2].Value;
+                var origStart = SrtTimeToSeconds(origStartTs);
+                var origEnd = SrtTimeToSeconds(origEndTs);
+
+                var newStart = origStart;
+
+                // "In speech" test: origStart sits inside some speech segment (with a tiny tolerance).
+                bool inSpeech = false;
+                foreach (var seg in segments)
+                {
+                    if (seg.Start - 0.001 <= origStart && origStart <= seg.End + 0.001)
+                    {
+                        inSpeech = true;
+                        break;
+                    }
+                }
+
+                if (!inSpeech)
+                {
+                    // In a silence gap: snap forward to the next speech onset, if any.
+                    double? onset = null;
+                    foreach (var seg in segments)
+                    {
+                        if (seg.Start > origStart)
+                        {
+                            onset = seg.Start;
+                            break;
+                        }
+                    }
+
+                    if (onset.HasValue)
+                    {
+                        newStart = onset.Value;
+
+                        // Keep at least ~0.5s on screen and never move backward.
+                        double maxStart = Math.Max(origStart, origEnd - 0.5);
+                        newStart = Math.Min(newStart, maxStart);
+                        newStart = Math.Max(newStart, origStart);
+
+                        // Avoid churn: ignore sub-50ms adjustments.
+                        if (newStart - origStart < 0.05)
+                            newStart = origStart;
+                    }
+                }
+
+                var startTs = newStart == origStart ? origStartTs : SecondsToSrtTime(newStart);
+
+                if (!string.IsNullOrEmpty(number)) result.AppendLine(number);
+                result.AppendLine($"{startTs} --> {origEndTs}");
+                i++;
+
+                // Collect subtitle text lines until empty line
+                while (i < lines.Length && !string.IsNullOrWhiteSpace(lines[i]))
+                {
+                    result.AppendLine(lines[i].TrimEnd());
+                    i++;
+                }
+                result.AppendLine();
+            }
+
+            return result.ToString();
+        }
+
+        private static double SrtTimeToSeconds(string timestamp)
+        {
+            var match = Regex.Match(timestamp, @"(\d{2}):(\d{2}):(\d{2}),(\d{3})");
+            if (!match.Success) return 0;
+
+            return int.Parse(match.Groups[1].Value) * 3600.0
+                 + int.Parse(match.Groups[2].Value) * 60.0
+                 + int.Parse(match.Groups[3].Value)
+                 + int.Parse(match.Groups[4].Value) / 1000.0;
+        }
+
+        private static string SecondsToSrtTime(double seconds)
+        {
+            if (seconds < 0) seconds = 0;
+
+            var totalMs = (int)Math.Round(seconds * 1000);
+
+            var h = totalMs / 3600000;
+            var m = (totalMs % 3600000) / 60000;
+            var s = (totalMs % 60000) / 1000;
+            var ms = totalMs % 1000;
+
+            return $"{h:D2}:{m:D2}:{s:D2},{ms:D3}";
+        }
+
         internal void AppendCustomArgs(ProcessStartInfo startInfo)
         {
             if (string.IsNullOrWhiteSpace(_customArgs)) return;

--- a/README.md
+++ b/README.md
@@ -361,6 +361,19 @@ The plugin supports three language modes:
 
 3. **Forced language** -- Set a specific language code (e.g., `es`) in the configuration or per-request via the API. This overrides detection and tells whisper to transcribe using that language model.
 
+### Subtitle Timing
+
+whisper.cpp emits subtitle segments back-to-back with no gaps, so the next line can appear on screen during the pause *before* it is actually spoken. Two timing corrections fix this, and **both are on by default**:
+
+| Setting | What it does |
+|---|---|
+| **Align subtitles to speech** | Snaps each subtitle's start to the detected speech onset, so subtitles no longer show during the silence before a line. Uses a quick FFmpeg silence-detection pass over the audio. |
+| **Compensate audio start offset** | Shifts all subtitle timestamps by the audio stream's container start time, keeping subtitles in sync when a file's audio doesn't begin exactly at 0:00. |
+
+> These corrections apply only to **locally-generated subtitles** (whisper-cli) -- both full and translated subtitles. They do not affect the remote Whisper API or forced subtitles.
+>
+> Alignment runs one extra FFmpeg silence-detection pass over the audio before saving the subtitle file.
+
 ## Usage
 
 ### Admin Dashboard

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -197,6 +197,35 @@
                         </div>
                     </div>
 
+                    <!-- ── Subtitle Timing ────────────────────────────── -->
+                    <h2>Subtitle Timing</h2>
+
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label>
+                            <input is="emby-checkbox" type="checkbox" id="chkAlignSubtitlesToSpeech" name="AlignSubtitlesToSpeech" />
+                            <span>Align subtitles to speech</span>
+                        </label>
+                        <div class="fieldDescription">
+                            Snaps each subtitle's start to when the line is actually spoken, so subtitles no longer appear
+                            during the silence before speech. <strong>Recommended.</strong>
+                            <br />
+                            Applies only to locally-generated subtitles (whisper-cli), not the remote API or forced subtitles.
+                            Runs a quick extra FFmpeg silence-detection pass over the audio.
+                        </div>
+                    </div>
+
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label>
+                            <input is="emby-checkbox" type="checkbox" id="chkCompensateAudioOffset" name="CompensateAudioOffset" />
+                            <span>Compensate audio start offset</span>
+                        </label>
+                        <div class="fieldDescription">
+                            Keeps subtitles in sync when a file's audio doesn't start exactly at 0:00. <strong>Recommended.</strong>
+                            <br />
+                            Applies only to locally-generated subtitles (whisper-cli), not the remote API or forced subtitles.
+                        </div>
+                    </div>
+
                     <!-- ── Advanced / Manual Install ──────────────────── -->
                     <details style="margin-top:1.5em;">
                         <summary style="cursor:pointer; font-size:1.2em; font-weight:bold; padding:0.5em 0;">Remote Whisper API (Optional)</summary>
@@ -852,6 +881,8 @@
                             page.querySelector('#chkEnableLyricsGeneration').checked = config.EnableLyricsGeneration || false;
                             page.querySelector('#chkEnableTranslation').checked = config.EnableTranslation || false;
                             page.querySelector('#chkPauseOnPlayback').checked = config.PauseOnPlayback || false;
+                            page.querySelector('#chkAlignSubtitlesToSpeech').checked = config.AlignSubtitlesToSpeech || false;
+                            page.querySelector('#chkCompensateAudioOffset').checked = config.CompensateAudioOffset || false;
                             updateTranslationVisibility();
                         }
                             WhisperSubsConfig.loadLibraries();
@@ -876,6 +907,8 @@
                         var subtitleMode = parseInt(page.querySelector('#selectSubtitleMode').value, 10) || 0;
                         config.EnableTranslation = subtitleMode !== 3 && page.querySelector('#chkEnableTranslation').checked;
                         config.PauseOnPlayback = page.querySelector('#chkPauseOnPlayback').checked;
+                        config.AlignSubtitlesToSpeech = page.querySelector('#chkAlignSubtitlesToSpeech').checked;
+                        config.CompensateAudioOffset = page.querySelector('#chkCompensateAudioOffset').checked;
 
                         // Collect enabled libraries from checkboxes
                         var libraryCheckboxes = page.querySelectorAll('.chkLibrary');

--- a/WhisperSubs.Tests/CoverageGapTests.cs
+++ b/WhisperSubs.Tests/CoverageGapTests.cs
@@ -13,6 +13,7 @@ namespace WhisperSubs.Tests;
 /// <summary>
 /// Targeted tests to close remaining coverage gaps.
 /// </summary>
+[Collection("QueueSingleton")]
 public class CoverageGapTests
 {
     // ── SubtitleWorkItem properties (lines 16-18) ──

--- a/WhisperSubs.Tests/SrtAlignmentTests.cs
+++ b/WhisperSubs.Tests/SrtAlignmentTests.cs
@@ -1,0 +1,274 @@
+using System.Text.RegularExpressions;
+using WhisperSubs.Providers;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+/// <summary>
+/// Tests for <see cref="WhisperProvider.AlignSrtToSpeech"/>, the pure SRT-to-speech
+/// start-time alignment helper. whisper.cpp emits gapless segments, so a subtitle for
+/// upcoming speech can appear during the preceding silence. AlignSrtToSpeech snaps each
+/// subtitle START forward to the next speech onset when the start lands in a silence gap,
+/// never moving backward, never past (end - 0.5s), and skipping sub-50ms adjustments.
+/// End times, text, and entry numbers are preserved.
+/// </summary>
+public class SrtAlignmentTests
+{
+    // Matches an SRT timing line and captures the start and end timestamps.
+    private static readonly Regex TimingRegex =
+        new(@"(\d{2}:\d{2}:\d{2},\d{3}) --> (\d{2}:\d{2}:\d{2},\d{3})");
+
+    /// <summary>Returns the (start, end) timestamp strings from every timing line in order.</summary>
+    private static List<(string Start, string End)> Timings(string srt)
+    {
+        var list = new List<(string, string)>();
+        foreach (Match m in TimingRegex.Matches(srt))
+            list.Add((m.Groups[1].Value, m.Groups[2].Value));
+        return list;
+    }
+
+    // ── 1. Start in a silence gap is snapped forward to the speech onset ──
+
+    [Fact]
+    public void EarlyStartInSilence_SnappedForwardToSpeechOnset()
+    {
+        // Audio is silent 0-2s; speech runs 2.0-5.0s. The subtitle starts at 0.0 (in silence).
+        var srt = "1\n00:00:00,000 --> 00:00:05,000\nHello world\n";
+        var segments = new List<(double Start, double End)> { (2.0, 5.0) };
+
+        var result = WhisperProvider.AlignSrtToSpeech(srt, segments);
+
+        var timings = Timings(result);
+        Assert.Single(timings);
+        Assert.Equal("00:00:02,000", timings[0].Start); // snapped to onset
+        Assert.Equal("00:00:05,000", timings[0].End);    // end preserved
+    }
+
+    // ── 2. Start already inside speech is left unchanged ──
+
+    [Fact]
+    public void StartInsideSpeech_Unchanged()
+    {
+        // Subtitle starts at 3.0s, which is inside the 2.0-6.0s speech segment.
+        var srt = "1\n00:00:03,000 --> 00:00:06,000\nInside speech\n";
+        var segments = new List<(double Start, double End)> { (2.0, 6.0) };
+
+        var result = WhisperProvider.AlignSrtToSpeech(srt, segments);
+
+        var timings = Timings(result);
+        Assert.Single(timings);
+        Assert.Equal("00:00:03,000", timings[0].Start); // unchanged
+        Assert.Equal("00:00:06,000", timings[0].End);
+    }
+
+    // ── 3. Never moves the start past (end - 0.5s) ──
+
+    [Fact]
+    public void NeverMovesPastHalfSecondBeforeEnd()
+    {
+        // Short entry 0.0 -> 2.2s. Onset at 2.0 would leave only 0.2s on screen, so the start
+        // is capped at end - 0.5 = 1.7s. Bound is Math.Max(origStart, origEnd - 0.5) = max(0.0, 1.7) = 1.7.
+        var srt = "1\n00:00:00,000 --> 00:00:02,200\nShort line\n";
+        var segments = new List<(double Start, double End)> { (2.0, 8.0) };
+
+        var result = WhisperProvider.AlignSrtToSpeech(srt, segments);
+
+        var timings = Timings(result);
+        Assert.Single(timings);
+        Assert.Equal("00:00:01,700", timings[0].Start); // capped at end - 0.5, not snapped to 2.0
+        Assert.Equal("00:00:02,200", timings[0].End);
+
+        // Cross-check the exact bound against the spec formula.
+        const double origStart = 0.0;
+        const double origEnd = 2.2;
+        var expectedMax = Math.Max(origStart, origEnd - 0.5); // 1.7
+        Assert.Equal(1.7, expectedMax, precision: 3);
+    }
+
+    // ── 4. Start after all speech is left unchanged ──
+
+    [Fact]
+    public void StartAfterAllSpeech_Unchanged()
+    {
+        // Subtitle starts at 10.0s; the only speech is 1.0-5.0s. No later onset exists.
+        var srt = "1\n00:00:10,000 --> 00:00:12,000\nLate line\n";
+        var segments = new List<(double Start, double End)> { (1.0, 5.0) };
+
+        var result = WhisperProvider.AlignSrtToSpeech(srt, segments);
+
+        var timings = Timings(result);
+        Assert.Single(timings);
+        Assert.Equal("00:00:10,000", timings[0].Start); // unchanged
+        Assert.Equal("00:00:12,000", timings[0].End);
+    }
+
+    // ── 5. Sub-50ms adjustments are skipped ──
+
+    [Fact]
+    public void SubFiftyMillisecondAdjustment_Skipped()
+    {
+        // Start at 5.000s lands in the silence gap between (0,1) and (5.030, 10). The next onset
+        // is 5.030s — only 30ms later, below the 50ms churn threshold — so the start is kept.
+        var srt = "1\n00:00:05,000 --> 00:00:09,000\nTiny nudge\n";
+        var segments = new List<(double Start, double End)> { (0.0, 1.0), (5.030, 10.0) };
+
+        var result = WhisperProvider.AlignSrtToSpeech(srt, segments);
+
+        var timings = Timings(result);
+        Assert.Single(timings);
+        Assert.Equal("00:00:05,000", timings[0].Start); // unchanged (adjustment < 50ms)
+        Assert.Equal("00:00:09,000", timings[0].End);
+    }
+
+    // ── 6. End times and multi-line text are preserved across a snap ──
+
+    [Fact]
+    public void EndTimesAndTextPreserved()
+    {
+        // Two-line entry whose start (0.0) is in silence and gets snapped to the 3.0s onset.
+        var srt = "1\n00:00:00,000 --> 00:00:07,000\nFirst line of dialogue\nSecond line of dialogue\n";
+        var segments = new List<(double Start, double End)> { (3.0, 7.0) };
+
+        var result = WhisperProvider.AlignSrtToSpeech(srt, segments);
+
+        var timings = Timings(result);
+        Assert.Single(timings);
+        Assert.Equal("00:00:03,000", timings[0].Start); // snapped
+        Assert.Equal("00:00:07,000", timings[0].End);    // end preserved
+
+        // Both text lines present verbatim.
+        Assert.Contains("First line of dialogue", result);
+        Assert.Contains("Second line of dialogue", result);
+    }
+
+    // ── 7. Entry numbers are preserved (no renumbering) ──
+
+    [Fact]
+    public void EntryNumbersPreserved()
+    {
+        var srt = """
+            1
+            00:00:00,000 --> 00:00:02,000
+            One
+
+            2
+            00:00:03,000 --> 00:00:05,000
+            Two
+
+            3
+            00:00:06,000 --> 00:00:08,000
+            Three
+            """;
+        var segments = new List<(double Start, double End)> { (0.0, 8.0) };
+
+        var result = WhisperProvider.AlignSrtToSpeech(srt, segments);
+
+        // Numbers 1, 2, 3 appear in order, each on its own line.
+        var numberLines = Regex.Matches(result, @"(?m)^(\d+)$").Select(m => int.Parse(m.Groups[1].Value)).ToList();
+        Assert.Equal(new[] { 1, 2, 3 }, numberLines);
+    }
+
+    // ── 8. Guard clauses: empty/null segments and whitespace SRT return input unchanged ──
+
+    [Fact]
+    public void EmptySpeechSegments_ReturnsUnchanged()
+    {
+        var srt = "1\n00:00:00,000 --> 00:00:05,000\nHello\n";
+        var result = WhisperProvider.AlignSrtToSpeech(srt, new List<(double Start, double End)>());
+        Assert.Equal(srt, result);
+    }
+
+    [Fact]
+    public void NullSegments_ReturnsUnchanged()
+    {
+        var srt = "1\n00:00:00,000 --> 00:00:05,000\nHello\n";
+        var result = WhisperProvider.AlignSrtToSpeech(srt, null!);
+        Assert.Equal(srt, result);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\n\n  \t\n")]
+    public void WhitespaceSrt_ReturnsUnchanged(string srt)
+    {
+        var segments = new List<(double Start, double End)> { (2.0, 5.0) };
+        var result = WhisperProvider.AlignSrtToSpeech(srt, segments);
+        Assert.Equal(srt, result); // returned verbatim
+    }
+
+    // ── 9. Mixed entries: only silence-gap starts move; in-speech starts stay ──
+
+    [Fact]
+    public void MultipleEntries_OnlyGapStartsAdjusted()
+    {
+        // Speech: 2.0-4.0s and 8.0-12.0s. Silence gaps: 0-2s, 4-8s, and after 12s.
+        //  Entry 1 starts at 2.5s (inside first speech)   -> unchanged.
+        //  Entry 2 starts at 5.0s (silence gap, onset 8.0) -> snapped to 8.0.
+        //  Entry 3 starts at 9.0s (inside second speech)  -> unchanged.
+        var srt = """
+            1
+            00:00:02,500 --> 00:00:04,000
+            In speech one
+
+            2
+            00:00:05,000 --> 00:00:12,000
+            In silence gap
+
+            3
+            00:00:09,000 --> 00:00:12,000
+            In speech two
+            """;
+        var segments = new List<(double Start, double End)> { (2.0, 4.0), (8.0, 12.0) };
+
+        var result = WhisperProvider.AlignSrtToSpeech(srt, segments);
+
+        var timings = Timings(result);
+        Assert.Equal(3, timings.Count);
+
+        // Entry 1: in-speech start unchanged.
+        Assert.Equal("00:00:02,500", timings[0].Start);
+        Assert.Equal("00:00:04,000", timings[0].End);
+
+        // Entry 2: silence-gap start snapped forward to the 8.0s onset (capped well below end - 0.5 = 11.5).
+        Assert.Equal("00:00:08,000", timings[1].Start);
+        Assert.Equal("00:00:12,000", timings[1].End);
+
+        // Entry 3: in-speech start unchanged.
+        Assert.Equal("00:00:09,000", timings[2].Start);
+        Assert.Equal("00:00:12,000", timings[2].End);
+    }
+
+    // ── 10. Malformed entry (no timing line) passes through; valid entry still processed ──
+
+    [Fact]
+    public void MalformedEntry_PassedThrough()
+    {
+        // A junk block with no "-->" timing line, followed by one valid entry whose start (0.0)
+        // is in silence and should be snapped to the 2.0s onset.
+        var srt = """
+            1
+            this is not a timing line
+            junk junk junk
+
+            2
+            00:00:00,000 --> 00:00:05,000
+            Real subtitle
+            """;
+        var segments = new List<(double Start, double End)> { (2.0, 5.0) };
+
+        // Must not throw.
+        var result = WhisperProvider.AlignSrtToSpeech(srt, segments);
+
+        // Malformed content survives.
+        Assert.Contains("this is not a timing line", result);
+        Assert.Contains("junk junk junk", result);
+
+        // The valid entry is still processed and snapped.
+        var timings = Timings(result);
+        Assert.Single(timings);
+        Assert.Equal("00:00:02,000", timings[0].Start);
+        Assert.Equal("00:00:05,000", timings[0].End);
+        Assert.Contains("Real subtitle", result);
+    }
+}

--- a/WhisperSubs.Tests/SrtAlignmentTests.cs
+++ b/WhisperSubs.Tests/SrtAlignmentTests.cs
@@ -271,4 +271,216 @@ public class SrtAlignmentTests
         Assert.Equal("00:00:05,000", timings[0].End);
         Assert.Contains("Real subtitle", result);
     }
+
+    // ── 11. Unsorted segments are ordered internally before onset lookup ──
+
+    [Fact]
+    public void UnsortedSegments_StillSnapsToCorrectOnset()
+    {
+        // Start at 5.0s sits in the silence gap (4-8s). Segments are passed OUT OF ORDER;
+        // the internal OrderBy(s => s.Start) must sort them so the onset scan finds 8.0, not 2.0.
+        var srt = "1\n00:00:05,000 --> 00:00:12,000\nUnsorted input\n";
+        var segments = new List<(double Start, double End)> { (8.0, 12.0), (2.0, 4.0) };
+
+        var result = WhisperProvider.AlignSrtToSpeech(srt, segments);
+
+        var timings = Timings(result);
+        Assert.Single(timings);
+        Assert.Equal("00:00:08,000", timings[0].Start); // snapped to the 8.0s onset, proving the sort
+        Assert.Equal("00:00:12,000", timings[0].End);
+    }
+
+    // ── 12. Leading silence before the first segment snaps to the first onset ──
+
+    [Fact]
+    public void LeadingSilenceBeforeFirstSegment_SnapsToFirstOnset()
+    {
+        // Audio opens with silence 0-2s; first speech is 2.0-5.0s. The subtitle starts at 0.0.
+        var srt = "1\n00:00:00,000 --> 00:00:10,000\nOpening line\n";
+        var segments = new List<(double Start, double End)> { (2.0, 5.0), (7.0, 9.0) };
+
+        var result = WhisperProvider.AlignSrtToSpeech(srt, segments);
+
+        var timings = Timings(result);
+        Assert.Single(timings);
+        Assert.Equal("00:00:02,000", timings[0].Start); // snapped to the first onset
+        Assert.Equal("00:00:10,000", timings[0].End);
+    }
+
+    // ── 13. Two consecutive silence entries snap to their own respective onsets ──
+
+    [Fact]
+    public void TwoConsecutiveSilenceEntries_SnapToTheirRespectiveOnsets()
+    {
+        // Speech: 2.0-4.0s and 8.0-12.0s. Both entries start in silence.
+        //  Entry 1 starts at 0.0s (gap before 2.0) -> snaps to 2.0.
+        //  Entry 2 starts at 5.0s (gap 4-8s)        -> snaps to 8.0.
+        // The onset lookup must restart per entry; no cursor state may leak across entries.
+        var srt = """
+            1
+            00:00:00,000 --> 00:00:10,000
+            First gap entry
+
+            2
+            00:00:05,000 --> 00:00:12,000
+            Second gap entry
+            """;
+        var segments = new List<(double Start, double End)> { (2.0, 4.0), (8.0, 12.0) };
+
+        var result = WhisperProvider.AlignSrtToSpeech(srt, segments);
+
+        var timings = Timings(result);
+        Assert.Equal(2, timings.Count);
+        Assert.Equal("00:00:02,000", timings[0].Start); // entry 1 -> first onset
+        Assert.Equal("00:00:08,000", timings[1].Start); // entry 2 -> second onset (no leak)
+    }
+
+    // ── 14. Start exactly at a segment's lower boundary is in-speech (unchanged) ──
+
+    [Fact]
+    public void StartExactlyAtSegmentStart_Unchanged()
+    {
+        // Start 2.0s equals the segment's Start. The in-speech test (Start - 0.001 <= origStart)
+        // holds at the lower boundary, so the start is left unchanged.
+        var srt = "1\n00:00:02,000 --> 00:00:09,000\nAt onset\n";
+        var segments = new List<(double Start, double End)> { (2.0, 9.0) };
+
+        var result = WhisperProvider.AlignSrtToSpeech(srt, segments);
+
+        var timings = Timings(result);
+        Assert.Single(timings);
+        Assert.Equal("00:00:02,000", timings[0].Start); // unchanged (inSpeech at lower boundary)
+        Assert.Equal("00:00:09,000", timings[0].End);
+    }
+
+    // ── 15. Start exactly at a segment's end is in-speech within tolerance (unchanged) ──
+
+    [Fact]
+    public void StartExactlyAtSegmentEnd_Unchanged()
+    {
+        // Start 6.0s equals the segment's End. The in-speech test (origStart <= End + 0.001)
+        // holds at the upper boundary, so the start is left unchanged.
+        var srt = "1\n00:00:06,000 --> 00:00:10,000\nAt segment end\n";
+        var segments = new List<(double Start, double End)> { (2.0, 6.0) };
+
+        var result = WhisperProvider.AlignSrtToSpeech(srt, segments);
+
+        var timings = Timings(result);
+        Assert.Single(timings);
+        Assert.Equal("00:00:06,000", timings[0].Start); // unchanged (within +0.001 of End)
+        Assert.Equal("00:00:10,000", timings[0].End);
+    }
+
+    // ── 16. Start just past the last segment's end, with no later onset, is unchanged ──
+
+    [Fact]
+    public void StartJustPastLastSegmentEnd_Unchanged()
+    {
+        // Start 6.002s is just outside the segment end (6.0 + 0.001 = 6.001), so not in-speech.
+        // No segment starts after 6.002s, so there is no onset to snap to -> unchanged.
+        var srt = "1\n00:00:06,002 --> 00:00:10,000\nJust past the end\n";
+        var segments = new List<(double Start, double End)> { (2.0, 6.0) };
+
+        var result = WhisperProvider.AlignSrtToSpeech(srt, segments);
+
+        var timings = Timings(result);
+        Assert.Single(timings);
+        Assert.Equal("00:00:06,002", timings[0].Start); // unchanged (not inSpeech, no later onset)
+        Assert.Equal("00:00:10,000", timings[0].End);
+    }
+
+    // ── 17. A trailing bare number at EOF does not throw (i >= lines.Length break) ──
+
+    [Fact]
+    public void TrailingBareNumberAtEof_DoesNotThrow()
+    {
+        // Truncated SRT: a valid entry, then a stray bare number "2" with no timing line after it.
+        // After reading the number the loop must break on i >= lines.Length without throwing.
+        var srt = "1\n00:00:00,000 --> 00:00:02,000\nText\n\n2";
+        var segments = new List<(double Start, double End)> { (0.5, 2.0) };
+
+        var result = WhisperProvider.AlignSrtToSpeech(srt, segments);
+
+        // Entry 1 survived; no exception was thrown reaching this assertion.
+        var timings = Timings(result);
+        Assert.Single(timings);
+        Assert.Equal("00:00:02,000", timings[0].End);
+        Assert.Contains("Text", result);
+    }
+
+    // ── 18. CRLF input snaps correctly and strips carriage returns ──
+
+    [Fact]
+    public void CrlfInput_SnapsCorrectlyAndStripsCarriageReturns()
+    {
+        // whisper.cpp SRT can use Windows CRLF line endings. Start at 0.0 is in silence and snaps
+        // to the 2.0s onset; carriage returns must not leak into the canonicalized LF output.
+        var srt = "1\r\n00:00:00,000 --> 00:00:05,000\r\nHello world\r\n";
+        var segments = new List<(double Start, double End)> { (2.0, 6.0) };
+
+        var result = WhisperProvider.AlignSrtToSpeech(srt, segments);
+
+        Assert.Contains("00:00:02,000 --> 00:00:05,000", result); // snapped, end preserved
+        Assert.Contains("Hello world", result);                   // text preserved
+        Assert.DoesNotContain("\r", result);                      // no carriage returns leak
+    }
+
+    // ── 19. CRLF multi-entry: numbers preserved; gap snaps, in-speech stays ──
+
+    [Fact]
+    public void CrlfMultiEntry_PreservesNumbersAndSnaps()
+    {
+        // Two CRLF entries. Speech: 2.0-4.0s and 8.0-12.0s.
+        //  Entry 1 starts at 2.5s (inside first speech) -> unchanged.
+        //  Entry 2 starts at 5.0s (silence gap)         -> snapped to 8.0.
+        var srt = "1\r\n00:00:02,500 --> 00:00:04,000\r\nIn speech\r\n\r\n"
+                + "2\r\n00:00:05,000 --> 00:00:12,000\r\nIn gap\r\n";
+        var segments = new List<(double Start, double End)> { (2.0, 4.0), (8.0, 12.0) };
+
+        var result = WhisperProvider.AlignSrtToSpeech(srt, segments);
+
+        // Both original numbers survive (each on its own line).
+        var numberLines = Regex.Matches(result, @"(?m)^(\d+)$").Select(m => int.Parse(m.Groups[1].Value)).ToList();
+        Assert.Equal(new[] { 1, 2 }, numberLines);
+
+        var timings = Timings(result);
+        Assert.Equal(2, timings.Count);
+        Assert.Equal("00:00:02,500", timings[0].Start); // in-speech entry unchanged
+        Assert.Equal("00:00:08,000", timings[1].Start); // gap entry snapped to onset
+        Assert.DoesNotContain("\r", result);
+    }
+
+    // ── 20. Every entry already inside speech: all timings untouched (round-trip) ──
+
+    [Fact]
+    public void FullyInSpeechMultiEntry_TimingsUnchanged()
+    {
+        // Speech: 2.0-4.0s and 8.0-12.0s. All three starts already sit inside a segment, so the
+        // pass must touch nothing: each original timing line should appear verbatim in the output.
+        var srt = """
+            1
+            00:00:02,500 --> 00:00:04,000
+            Already aligned one
+
+            2
+            00:00:09,000 --> 00:00:12,000
+            Already aligned two
+
+            3
+            00:00:10,000 --> 00:00:12,000
+            Already aligned three
+            """;
+        var segments = new List<(double Start, double End)> { (2.0, 4.0), (8.0, 12.0) };
+
+        var result = WhisperProvider.AlignSrtToSpeech(srt, segments);
+
+        // Original timing lines appear verbatim (nothing snapped).
+        Assert.Contains("00:00:02,500 --> 00:00:04,000", result);
+        Assert.Contains("00:00:09,000 --> 00:00:12,000", result);
+        Assert.Contains("00:00:10,000 --> 00:00:12,000", result);
+
+        // Numbers 1, 2, 3 preserved in order.
+        var numberLines = Regex.Matches(result, @"(?m)^(\d+)$").Select(m => int.Parse(m.Groups[1].Value)).ToList();
+        Assert.Equal(new[] { 1, 2, 3 }, numberLines);
+    }
 }

--- a/WhisperSubs.Tests/SubtitleQueueServiceTests.cs
+++ b/WhisperSubs.Tests/SubtitleQueueServiceTests.cs
@@ -3,6 +3,11 @@ using Xunit;
 
 namespace WhisperSubs.Tests;
 
+// Serializes test classes that mutate the SubtitleQueueService singleton to avoid a parallel-run race (xUnit runs distinct classes concurrently).
+[CollectionDefinition("QueueSingleton", DisableParallelization = true)]
+public class QueueSingletonCollection { }
+
+[Collection("QueueSingleton")]
 public class SubtitleQueueServiceTests
 {
     [Fact]

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.18.5.0</Version>
+    <Version>3.18.6.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
Fixes #78 — "subtitles appear before their speech is spoken."

## Root cause
whisper.cpp emits **gapless** segments (`next.start == prev.end`), and the plugin wrote its SRT through verbatim. So during a pause, the next subtitle popped on screen the instant the previous one ended.

## Fix — two corrections, both default ON
Applied to **full + translated** subtitles (not forced, not lyrics), **local whisper-cli only**, via `SubtitleManager.ApplyTimingCorrectionsAsync` (offset first, then align):

| Setting | What it does |
|---|---|
| **AlignSubtitlesToSpeech** | Snaps each subtitle's **start** forward to the next speech onset when it begins in a silence gap, reusing the existing FFmpeg `silencedetect` pass. Never moves a start backward or past `end − 0.5s`; sub‑50ms changes skipped. End/text/numbering preserved. |
| **CompensateAudioOffset** | Shifts all timestamps by the audio stream's container `start_time` (new `GetAudioStartTimeAsync`) when it's a sane 0.05–30s, so subs stay synced when audio doesn't begin at 0:00. |

Silence-detection failures **degrade gracefully** (warn, leave timings) — never fail the job.

## Why not native `--vad`?
Deliberately avoided: whisper.cpp [#3584](https://github.com/ggml-org/whisper.cpp/issues/3584)/[#3675](https://github.com/ggml-org/whisper.cpp/pull/3675) show its SRT output stays gapless (VAD is a speed optimization there), and the leading Jellyfin peer **subgen abandoned whisper.cpp over exactly this**. The `silencedetect` post-process is deterministic, needs no extra model, and works on every binary variant. (The user's `--vad` failure was a separate thing — it needs a `--vad-model` file; I'll note that on the issue.)

## Changes
- `Providers/WhisperProvider.cs` — pure static `AlignSrtToSpeech` + time helpers
- `Controller/SubtitleManager.cs` — `ApplyTimingCorrectionsAsync`, `GetAudioStartTimeAsync`, wired into full + translated paths
- `Configuration/PluginConfiguration.cs` — two booleans (default true)
- `Web/configPage.html` — two config toggles
- README + CLAUDE.md docs

## Test plan
- [x] `dotnet build` (Release) clean
- [x] `dotnet test` — 14 new `SrtAlignment` cases pass (full suite 381 tests)
- [ ] CI green
- Note: `SubtitleQueueServiceTests.ReportTaskProgress_SetsAllFields` is a **pre-existing** flaky test (shared-singleton race; passes in isolation and on re-run) — not touched by this PR.