### PR TITLE
Add --print-progress so the transcription progress bar advances

### DIFF
--- a/Providers/WhisperProvider.cs
+++ b/Providers/WhisperProvider.cs
@@ -119,6 +119,11 @@ namespace WhisperSubs.Providers
                 startInfo.ArgumentList.Add("-mc");
                 startInfo.ArgumentList.Add("0");
                 startInfo.ArgumentList.Add("-sns");
+                // Make whisper-cli emit "progress = N%" lines to stderr so the
+                // ErrorDataReceived handler below can parse them and report per-file
+                // progress. Without this flag whisper-cli prints no progress at all, so
+                // the regex never matches and the UI progress bar never advances.
+                startInfo.ArgumentList.Add("--print-progress");
                 if (translate)
                 {
                     startInfo.ArgumentList.Add("--translate");


### PR DESCRIPTION
## Problem

`WhisperProvider` already parses whisper-cli's stderr for `progress = N%` and forwards it to `SubtitleQueueService.ReportFileProgress`:

```csharp
// Parse whisper progress: "whisper_print_progress_callback: progress = 42%"
var progressMatch = Regex.Match(e.Data, @"progress\s*=\s*(\d+)%");
if (progressMatch.Success && int.TryParse(progressMatch.Groups[1].Value, out var pct))
{
    SubtitleQueueService.Instance.ReportFileProgress(pct);
}
```

But the main transcription invocation builds its argument list (`-m -f -l -mc 0 -sns -osrt -of …`) **without `--print-progress`**. whisper.cpp only emits those `progress = N%` lines when the flag is set, so the parser never receives anything: during a long transcription the per-file progress bar stays frozen and only the coarse phase labels ("Extracting audio" → "Transcribing") update, then it jumps to 100% at completion.

## Fix

Add `--print-progress` to the main transcription argument list so whisper-cli emits the progress lines the existing parser already expects.

- Touches only the main transcription invocation.
- The language-detection probe (`--no-gpu`, short-lived, one call per chunk) is intentionally left as-is.
- No new config; matched `progress = N%` lines are routed to `ReportFileProgress` and already excluded from the stderr-warning branch by the existing regex.

## Notes / testing

`--print-progress` (`-pp`) is a standard whisper-cli flag. I wasn't able to run a full `dotnet build` in my environment, so CI is the build check — the change is a single `ArgumentList.Add(...)` in the same style as the surrounding flags. The frozen-bar symptom was reproduced on a real ~2h CUDA transcription (GPU pegged at 100% in `nvidia-smi`, but the UI progress bar never moving); with the flag, the regex matches `whisper_print_progress_callback: progress = N%` and progress advances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where transcription progress was not being reported to users, enabling real-time progress tracking during processing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->