### PR TITLE
fix: reset per-file progress per run, anchor progress parse, test the --print-progress wiring (#86 follow-up)

### DIFF
--- a/Providers/WhisperProvider.cs
+++ b/Providers/WhisperProvider.cs
@@ -105,45 +105,14 @@ namespace WhisperSubs.Providers
                     WorkingDirectory = Path.GetDirectoryName(whisperExecutable) ?? ""
                 };
 
-                startInfo.ArgumentList.Add("-m");
-                startInfo.ArgumentList.Add(_modelPath);
-                startInfo.ArgumentList.Add("-f");
-                startInfo.ArgumentList.Add(audioPath);
-                startInfo.ArgumentList.Add("-l");
-                startInfo.ArgumentList.Add(language);
-                if (_threadCount > 0)
+                // Caller resolves whether VAD applies (model configured + present on disk); the pure
+                // arg-builder stays I/O-free and unit-testable.
+                var useVad = !string.IsNullOrEmpty(_vadModelPath) && File.Exists(_vadModelPath);
+                foreach (var arg in BuildTranscribeArguments(
+                    _modelPath, audioPath, language, _threadCount, translate,
+                    useVad ? _vadModelPath : null, tempOutputPrefix, langPrompt))
                 {
-                    startInfo.ArgumentList.Add("-t");
-                    startInfo.ArgumentList.Add(_threadCount.ToString());
-                }
-                startInfo.ArgumentList.Add("-mc");
-                startInfo.ArgumentList.Add("0");
-                startInfo.ArgumentList.Add("-sns");
-                // Make whisper-cli emit "progress = N%" lines to stderr so the
-                // ErrorDataReceived handler below can parse them and report per-file
-                // progress. Without this flag whisper-cli prints no progress at all, so
-                // the regex never matches and the UI progress bar never advances.
-                startInfo.ArgumentList.Add("--print-progress");
-                if (translate)
-                {
-                    startInfo.ArgumentList.Add("--translate");
-                }
-                // Native Silero VAD: makes whisper-cli emit subtitles that start at real speech
-                // onset instead of during the preceding silence (whisper.cpp otherwise chains
-                // segments gaplessly). Only when a VAD model is configured and present on disk.
-                if (!string.IsNullOrEmpty(_vadModelPath) && File.Exists(_vadModelPath))
-                {
-                    startInfo.ArgumentList.Add("--vad");
-                    startInfo.ArgumentList.Add("--vad-model");
-                    startInfo.ArgumentList.Add(_vadModelPath);
-                }
-                startInfo.ArgumentList.Add("-osrt");
-                startInfo.ArgumentList.Add("-of");
-                startInfo.ArgumentList.Add(tempOutputPrefix);
-                if (!string.IsNullOrEmpty(langPrompt))
-                {
-                    startInfo.ArgumentList.Add("--prompt");
-                    startInfo.ArgumentList.Add(langPrompt);
+                    startInfo.ArgumentList.Add(arg);
                 }
 
                 AppendCustomArgs(startInfo);
@@ -169,9 +138,8 @@ namespace WhisperSubs.Providers
                     {
                         errorBuilder.AppendLine(e.Data);
 
-                        // Parse whisper progress: "whisper_print_progress_callback: progress = 42%"
-                        var progressMatch = Regex.Match(e.Data, @"progress\s*=\s*(\d+)%");
-                        if (progressMatch.Success && int.TryParse(progressMatch.Groups[1].Value, out var pct))
+                        // Progress lines drive the per-file bar; everything else is a real warning.
+                        if (TryParseProgress(e.Data, out var pct))
                         {
                             SubtitleQueueService.Instance.ReportFileProgress(pct);
                         }
@@ -181,6 +149,13 @@ namespace WhisperSubs.Providers
                         }
                     }
                 };
+
+                // Reset the per-file progress bar to 0 at the start of every whisper run. This is the
+                // single choke point all transcription paths funnel through (full / translation /
+                // forced-segment / lyrics / resume) and is reached by both the scheduled task and the
+                // manual Generate drain loop — so resetting here (rather than only in the scheduled
+                // task) stops the bar showing the previous run's stale 100% and running backwards.
+                SubtitleQueueService.Instance.ResetFileProgress();
 
                 process.Start();
                 process.BeginOutputReadLine();
@@ -699,6 +674,83 @@ namespace WhisperSubs.Providers
             var ms = totalMs % 1000;
 
             return $"{h:D2}:{m:D2}:{s:D2},{ms:D3}";
+        }
+
+        /// <summary>
+        /// Builds the whisper-cli argument vector shared by every transcription run (the full,
+        /// translation, forced-segment, lyrics and resume callers all funnel through one method, so
+        /// they emit the same flags). Pure and I/O-free so it is unit-testable — the caller resolves
+        /// filesystem-dependent state (VAD model presence, language prompt) and passes the results in.
+        /// </summary>
+        /// <param name="vadModelPath">Resolved Silero VAD model path, or null/empty to omit VAD.</param>
+        /// <param name="langPrompt">Resolved initial prompt, or null/empty to omit it.</param>
+        internal static IReadOnlyList<string> BuildTranscribeArguments(
+            string modelPath, string audioPath, string language, int threadCount, bool translate,
+            string? vadModelPath, string outputPrefix, string? langPrompt)
+        {
+            var args = new List<string>
+            {
+                "-m", modelPath,
+                "-f", audioPath,
+                "-l", language,
+            };
+            if (threadCount > 0)
+            {
+                args.Add("-t");
+                args.Add(threadCount.ToString(CultureInfo.InvariantCulture));
+            }
+            args.Add("-mc");
+            args.Add("0");
+            args.Add("-sns");
+            // Make whisper-cli emit "whisper_print_progress_callback: progress = N%" lines to stderr
+            // so the ErrorDataReceived handler can parse them and report per-file progress. The flag
+            // defaults OFF in whisper.cpp, so without it whisper-cli prints no progress at all, the
+            // regex never matches, and the UI progress bar never advances.
+            args.Add("--print-progress");
+            if (translate)
+            {
+                args.Add("--translate");
+            }
+            // Native Silero VAD: makes whisper-cli emit subtitles that start at real speech onset
+            // instead of during the preceding silence (whisper.cpp otherwise chains segments
+            // gaplessly). Only when a VAD model is configured and present on disk (resolved by caller).
+            if (!string.IsNullOrEmpty(vadModelPath))
+            {
+                args.Add("--vad");
+                args.Add("--vad-model");
+                args.Add(vadModelPath);
+            }
+            args.Add("-osrt");
+            args.Add("-of");
+            args.Add(outputPrefix);
+            if (!string.IsNullOrEmpty(langPrompt))
+            {
+                args.Add("--prompt");
+                args.Add(langPrompt);
+            }
+            return args;
+        }
+
+        // Anchored to whisper.cpp's own progress emitters so an unrelated stderr line that merely
+        // contains "progress = N%" can't be misread as progress (and thereby silently skipped from the
+        // warning log). Both the whisper_print_progress_callback and whisper_full_with_state forms seen
+        // across builds begin with a "whisper_" token, hence the family anchor.
+        private static readonly Regex ProgressRegex = new(
+            @"^\s*whisper_\S*:\s*progress\s*=\s*(\d+)\s*%",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+        /// <summary>
+        /// Parses a whisper-cli stderr line of the form
+        /// "whisper_print_progress_callback: progress =  42%" into its integer percentage.
+        /// Returns false (and pct = 0) for any non-progress line. Pure and unit-testable.
+        /// </summary>
+        internal static bool TryParseProgress(string? line, out int pct)
+        {
+            pct = 0;
+            if (string.IsNullOrEmpty(line)) return false;
+            var m = ProgressRegex.Match(line);
+            return m.Success
+                && int.TryParse(m.Groups[1].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out pct);
         }
 
         internal void AppendCustomArgs(ProcessStartInfo startInfo)

--- a/Providers/WhisperProvider.cs
+++ b/Providers/WhisperProvider.cs
@@ -153,8 +153,9 @@ namespace WhisperSubs.Providers
                 // Reset the per-file progress bar to 0 at the start of every whisper run. This is the
                 // single choke point all transcription paths funnel through (full / translation /
                 // forced-segment / lyrics / resume) and is reached by both the scheduled task and the
-                // manual Generate drain loop — so resetting here (rather than only in the scheduled
-                // task) stops the bar showing the previous run's stale 100% and running backwards.
+                // manual Generate drain loop — so the manual path (which has no item-level reset)
+                // no longer shows the previous run's stale 100% and runs backwards. The scheduled
+                // task also resets at item start (before audio extraction); that reset stays.
                 SubtitleQueueService.Instance.ResetFileProgress();
 
                 process.Start();
@@ -735,8 +736,10 @@ namespace WhisperSubs.Providers
         // contains "progress = N%" can't be misread as progress (and thereby silently skipped from the
         // warning log). Both the whisper_print_progress_callback and whisper_full_with_state forms seen
         // across builds begin with a "whisper_" token, hence the family anchor.
+        // Compiled (unlike the file's other inline regexes) because this one runs once per stderr
+        // line for the whole transcription — the only regex on that hot path.
         private static readonly Regex ProgressRegex = new(
-            @"^\s*whisper_\S*:\s*progress\s*=\s*(\d+)\s*%",
+            @"^\s*whisper_\S*:\s*progress\s*=\s*(\d+)%",
             RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
         /// <summary>

--- a/ScheduledTasks/SubtitleGenerationTask.cs
+++ b/ScheduledTasks/SubtitleGenerationTask.cs
@@ -304,6 +304,8 @@ namespace WhisperSubs.ScheduledTasks
                 {
                     _logger.LogInformation("[{Current}/{Total}] Processing {ItemName}",
                         completed + 1, allItems.Count, item.Name);
+                    // Reset at item start so the bar reads 0 during audio extraction (before whisper
+                    // runs). WhisperProvider also resets at each whisper run; both are idempotent.
                     queue.ResetFileProgress();
                     queue.ReportTaskProgress(item.Name, completed, allItems.Count, failed, itemType, libName);
 

--- a/WhisperSubs.Tests/WhisperProviderArgsTests.cs
+++ b/WhisperSubs.Tests/WhisperProviderArgsTests.cs
@@ -213,13 +213,36 @@ public class WhisperProviderArgsTests
         Assert.Equal(expected, pct);
     }
 
+    // The raw line has no leading whitespace — confirms the `^` anchor doesn't *require* it.
+    [Fact]
+    public void TryParseProgress_NoLeadingWhitespace_Parses()
+    {
+        var ok = WhisperProvider.TryParseProgress("whisper_print_progress_callback: progress = 42%", out var pct);
+        Assert.True(ok);
+        Assert.Equal(42, pct);
+    }
+
+    // Contract: the parser does NOT clamp — it returns whisper's raw percent. Clamping to 0-100 is
+    // the consumer's job (SubtitleQueueService.ReportFileProgress). Pin that so a future change that
+    // moves clamping into the parser is a deliberate, test-visible decision.
+    [Fact]
+    public void TryParseProgress_Above100_ReturnsRawUnclampedValue()
+    {
+        var ok = WhisperProvider.TryParseProgress("whisper_print_progress_callback: progress = 150%", out var pct);
+        Assert.True(ok);
+        Assert.Equal(150, pct);
+    }
+
     [Theory]
     [InlineData("whisper_init_state: loading model")]
     [InlineData("system_info: n_threads = 4 | AVX = 1")]
     [InlineData("main: processing 'a.wav' ... progress = 50% pending")] // anchor guard: has "progress = 50%" but no leading whisper_ token
     [InlineData("main: progress = 7%")]
+    [InlineData("progress = 50%")] // bare progress line, no whisper_ emitter token
+    [InlineData("   ")] // whitespace-only: not IsNullOrEmpty, so it reaches the regex and fails to match
     [InlineData("")]
-    public void TryParseProgress_NonProgressLines_ReturnsFalse(string line)
+    [InlineData(null)] // e.Data can be null on the stderr stream; the IsNullOrEmpty guard handles it
+    public void TryParseProgress_NonProgressLines_ReturnsFalse(string? line)
     {
         var ok = WhisperProvider.TryParseProgress(line, out var pct);
         Assert.False(ok);

--- a/WhisperSubs.Tests/WhisperProviderArgsTests.cs
+++ b/WhisperSubs.Tests/WhisperProviderArgsTests.cs
@@ -1,0 +1,228 @@
+using System.Collections.Generic;
+using WhisperSubs.Providers;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+public class WhisperProviderArgsTests
+{
+    // Builds the argument vector with sane defaults; the test under each [Fact] varies the one
+    // parameter it cares about. Keeps every call site short and the intent obvious.
+    private static IReadOnlyList<string> Build(
+        string modelPath = "/m/model.bin",
+        string audioPath = "/tmp/a.wav",
+        string language = "es",
+        int threadCount = 0,
+        bool translate = false,
+        string? vadModelPath = null,
+        string outputPrefix = "/tmp/out",
+        string? langPrompt = null)
+    {
+        return WhisperProvider.BuildTranscribeArguments(
+            modelPath, audioPath, language, threadCount, translate, vadModelPath, outputPrefix, langPrompt);
+    }
+
+    // Asserts that `flag` appears in the vector and is immediately followed by `expectedValue`.
+    private static void AssertFlagFollowedBy(IReadOnlyList<string> args, string flag, string expectedValue)
+    {
+        var idx = IndexOf(args, flag);
+        Assert.True(idx >= 0, $"expected flag '{flag}' to be present in: {string.Join(" ", args)}");
+        Assert.True(idx + 1 < args.Count, $"flag '{flag}' has no following value in: {string.Join(" ", args)}");
+        Assert.Equal(expectedValue, args[idx + 1]);
+    }
+
+    private static int IndexOf(IReadOnlyList<string> args, string value)
+    {
+        for (var i = 0; i < args.Count; i++)
+        {
+            if (args[i] == value)
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    // ── BuildTranscribeArguments ────────────────────────────────────────────
+
+    // THE lock: the entire reason this PR exists is to guarantee progress reporting is wired up.
+    [Fact]
+    public void BuildTranscribeArguments_IncludesPrintProgress()
+    {
+        var args = Build();
+        Assert.Contains("--print-progress", args);
+    }
+
+    [Fact]
+    public void BuildTranscribeArguments_IncludesCoreFlagsPaired()
+    {
+        var args = Build(
+            modelPath: "/m/model.bin",
+            audioPath: "/tmp/a.wav",
+            language: "es",
+            outputPrefix: "/tmp/out");
+
+        AssertFlagFollowedBy(args, "-m", "/m/model.bin");
+        AssertFlagFollowedBy(args, "-f", "/tmp/a.wav");
+        AssertFlagFollowedBy(args, "-l", "es");
+        Assert.Contains("-osrt", args);
+        AssertFlagFollowedBy(args, "-of", "/tmp/out");
+    }
+
+    [Fact]
+    public void BuildTranscribeArguments_AlwaysIncludesMcAndSns()
+    {
+        var args = Build();
+        AssertFlagFollowedBy(args, "-mc", "0");
+        Assert.Contains("-sns", args);
+    }
+
+    // Golden vector: pins the exact flag sequence for a fully-populated config (threads + translate
+    // + VAD + prompt). whisper-cli is order-insensitive, but this PR's contract is that extracting
+    // BuildTranscribeArguments left the emitted command line byte-identical — so lock the order too.
+    [Fact]
+    public void BuildTranscribeArguments_FullConfig_MatchesCanonicalOrder()
+    {
+        var args = Build(
+            modelPath: "/m/model.bin",
+            audioPath: "/tmp/a.wav",
+            language: "es",
+            threadCount: 8,
+            translate: true,
+            vadModelPath: "/models/vad.bin",
+            outputPrefix: "/tmp/out",
+            langPrompt: "hola");
+
+        var expected = new[]
+        {
+            "-m", "/m/model.bin",
+            "-f", "/tmp/a.wav",
+            "-l", "es",
+            "-t", "8",
+            "-mc", "0",
+            "-sns",
+            "--print-progress",
+            "--translate",
+            "--vad", "--vad-model", "/models/vad.bin",
+            "-osrt",
+            "-of", "/tmp/out",
+            "--prompt", "hola",
+        };
+        Assert.Equal(expected, args);
+    }
+
+    // Golden vector for the minimal config (no threads / translate / vad / prompt): the optional
+    // flags must be absent and the rest in canonical order.
+    [Fact]
+    public void BuildTranscribeArguments_MinimalConfig_MatchesCanonicalOrder()
+    {
+        var args = Build(
+            modelPath: "/m/model.bin",
+            audioPath: "/tmp/a.wav",
+            language: "es",
+            outputPrefix: "/tmp/out");
+
+        var expected = new[]
+        {
+            "-m", "/m/model.bin",
+            "-f", "/tmp/a.wav",
+            "-l", "es",
+            "-mc", "0",
+            "-sns",
+            "--print-progress",
+            "-osrt",
+            "-of", "/tmp/out",
+        };
+        Assert.Equal(expected, args);
+    }
+
+    [Fact]
+    public void BuildTranscribeArguments_ThreadCountZero_OmitsThreadFlag()
+    {
+        var args = Build(threadCount: 0);
+        Assert.DoesNotContain("-t", args);
+    }
+
+    [Fact]
+    public void BuildTranscribeArguments_ThreadCountPositive_AddsThreadFlagAndValue()
+    {
+        var args = Build(threadCount: 8);
+        AssertFlagFollowedBy(args, "-t", "8");
+    }
+
+    [Fact]
+    public void BuildTranscribeArguments_Translate_AddsTranslateFlag()
+    {
+        var args = Build(translate: true);
+        Assert.Contains("--translate", args);
+    }
+
+    [Fact]
+    public void BuildTranscribeArguments_NoTranslate_OmitsTranslateFlag()
+    {
+        var args = Build(translate: false);
+        Assert.DoesNotContain("--translate", args);
+    }
+
+    [Fact]
+    public void BuildTranscribeArguments_WithVadModel_AddsVadFlagsPaired()
+    {
+        var args = Build(vadModelPath: "/models/vad.bin");
+        Assert.Contains("--vad", args);
+        AssertFlagFollowedBy(args, "--vad-model", "/models/vad.bin");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void BuildTranscribeArguments_WithoutVadModel_OmitsVadFlags(string? vadModelPath)
+    {
+        var args = Build(vadModelPath: vadModelPath);
+        Assert.DoesNotContain("--vad", args);
+        Assert.DoesNotContain("--vad-model", args);
+    }
+
+    [Fact]
+    public void BuildTranscribeArguments_WithLangPrompt_AddsPromptPaired()
+    {
+        var args = Build(langPrompt: "hola");
+        AssertFlagFollowedBy(args, "--prompt", "hola");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void BuildTranscribeArguments_WithoutLangPrompt_OmitsPromptFlag(string? langPrompt)
+    {
+        var args = Build(langPrompt: langPrompt);
+        Assert.DoesNotContain("--prompt", args);
+    }
+
+    // ── TryParseProgress ────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("whisper_print_progress_callback: progress =  42%", 42)] // double space from %3d padding
+    [InlineData("whisper_print_progress_callback: progress = 0%", 0)]
+    [InlineData("whisper_print_progress_callback: progress = 100%", 100)]
+    [InlineData("whisper_full_with_state: progress = 33%", 33)]
+    public void TryParseProgress_ValidProgressLines_ParsesPercent(string line, int expected)
+    {
+        var ok = WhisperProvider.TryParseProgress(line, out var pct);
+        Assert.True(ok);
+        Assert.Equal(expected, pct);
+    }
+
+    [Theory]
+    [InlineData("whisper_init_state: loading model")]
+    [InlineData("system_info: n_threads = 4 | AVX = 1")]
+    [InlineData("main: processing 'a.wav' ... progress = 50% pending")] // anchor guard: has "progress = 50%" but no leading whisper_ token
+    [InlineData("main: progress = 7%")]
+    [InlineData("")]
+    public void TryParseProgress_NonProgressLines_ReturnsFalse(string line)
+    {
+        var ok = WhisperProvider.TryParseProgress(line, out var pct);
+        Assert.False(ok);
+        Assert.Equal(0, pct);
+    }
+}

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.19.0.0</Version>
+    <Version>3.19.1.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
Follow-up to #86 (thanks again @hrones). #86 added `--print-progress` so the per-file progress bar finally advances; a review pass surfaced a few adjacent issues in the surrounding code that the now-live bar **exposed** but that weren't @hrones's to own. This PR hardens them.

## Changes

### 1. Progress bar no longer runs backwards (HIGH)
`ResetFileProgress()` was only called by the scheduled task, so:
- on the **manual Generate queue**, item N+1 showed item N's stale **100%** then jumped *backward* to ~5%;
- a **multi-pass item** (full transcription → 100%, then the English translation pass → 0%) snapped back mid-item.

Fix: reset progress inside `TranscribeInternalAsync` immediately before `process.Start()` — the single choke point every transcription path (full / translation / forced-segment / lyrics / resume) and **both** drivers (scheduled task + manual drain loop) funnel through. The existing reset in the scheduled task becomes harmless/redundant and is left in place.

### 2. Anchored, testable progress parsing (MEDIUM)
The old `progress\s*=\s*(\d+)%` was unanchored, so any stderr line merely *containing* `progress = N%` (e.g. `main: processing … progress = 50%`) was misread as progress **and** silently skipped the warning-log branch. Extracted `TryParseProgress(...)` with a compiled regex anchored to whisper's own emitter family — `^\s*whisper_\S*:\s*progress = N%` — which matches both `whisper_print_progress_callback:` and `whisper_full_with_state:` forms while rejecting the false positives.

### 3. The `--print-progress` wiring is now under test (HIGH)
`TranscribeInternalAsync` is `[ExcludeFromCodeCoverage]` and built its args inline, so the flag's presence was untestable — a future refactor could silently drop it and re-freeze the bar with a green suite. Extracted a pure, I/O-free `internal static BuildTranscribeArguments(...)`; the emitted argument vector is **byte-identical** to before (verified element-by-element). `TranscribeInternalAsync` now calls it (resolving VAD presence in the caller to keep the builder I/O-free).

## Tests
New `WhisperProviderArgsTests` (xUnit): `--print-progress` presence; core-flag pairing; **golden-vector order** for full + minimal configs (locks the byte-identical contract); thread/translate/vad/prompt conditionals; and `TryParseProgress` cases incl. the anchor-guard false positive (`main: … progress = 50%` → no match). **533 tests pass** locally, 0 warnings/errors.

## Notes
- Touches only `Providers/WhisperProvider.cs` + the new test file; no behavior change to the emitted whisper-cli command line.
- Patch bump to **3.19.1.0** (bug fix) — this release ships both #86's flag and this hardening.