### PR TITLE
feat: optional Lingarr webhook notification after subtitle generation

### DIFF
--- a/Configuration/PluginConfiguration.cs
+++ b/Configuration/PluginConfiguration.cs
@@ -146,6 +146,23 @@ namespace WhisperSubs.Configuration
 
         public List<string> EnabledLibraries { get; set; } = new List<string>();
 
+        /// <summary>
+        /// When enabled, fires an HTTP POST to the configured Lingarr URL after each subtitle
+        /// is generated, so Lingarr can auto-translate the new subtitle. Off by default.
+        /// </summary>
+        public bool EnableLingarrNotification { get; set; } = false;
+
+        /// <summary>
+        /// Base URL of the Lingarr instance to notify after subtitle generation.
+        /// Example: http://lingarr:8080
+        /// </summary>
+        public string LingarrUrl { get; set; } = "";
+
+        /// <summary>
+        /// API key sent as X-Api-Key header in the Lingarr webhook request.
+        /// </summary>
+        public string LingarrApiKey { get; set; } = "";
+
         public PluginConfiguration()
         {
         }

--- a/Controller/SubtitleManager.cs
+++ b/Controller/SubtitleManager.cs
@@ -123,7 +123,8 @@ namespace WhisperSubs.Controller
             }
 
             await item.RefreshMetadata(cancellationToken);
-            FireLingarrNotification(item);
+            if (attempted > 0 && failed < attempted)
+                FireLingarrNotification(item, mediaPath);
         }
 
         /// <summary>Outcome of a single subtitle generation attempt.</summary>
@@ -1687,26 +1688,30 @@ namespace WhisperSubs.Controller
             return SubtitleInventory.NormalizeLang(code) ?? (code ?? "").ToLowerInvariant();
         }
 
+        internal static string? ResolveLingarrMediaType(BaseItem item)
+        {
+            if (item is MediaBrowser.Controller.Entities.Movies.Movie) return "Movie";
+            if (item is MediaBrowser.Controller.Entities.TV.Episode) return "Episode";
+            return null;
+        }
+
         [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage(Justification = "Fire-and-forget HTTP call to external Lingarr service")]
-        private void FireLingarrNotification(BaseItem item)
+        private void FireLingarrNotification(BaseItem item, string mediaPath)
         {
             var config = Plugin.Instance?.Configuration;
             if (config?.EnableLingarrNotification != true) return;
-            var baseUrl = (config.LingarrUrl ?? "").TrimEnd('/');
-            if (string.IsNullOrWhiteSpace(baseUrl)) return;
-            if (string.IsNullOrWhiteSpace(item.Path)) return;
+            var rawUrl = (config.LingarrUrl ?? "").Trim();
+            if (string.IsNullOrWhiteSpace(rawUrl)) return;
+            if (!Uri.TryCreate(rawUrl.TrimEnd('/') + '/', UriKind.Absolute, out var baseUri)
+                || (baseUri.Scheme != Uri.UriSchemeHttp && baseUri.Scheme != Uri.UriSchemeHttps)) return;
+            if (string.IsNullOrWhiteSpace(mediaPath)) return;
 
-            string mediaType;
-            if (item is MediaBrowser.Controller.Entities.Movies.Movie)
-                mediaType = "Movie";
-            else if (item is MediaBrowser.Controller.Entities.TV.Episode)
-                mediaType = "Episode";
-            else
-                return;
+            var mediaType = ResolveLingarrMediaType(item);
+            if (mediaType is null) return;
 
-            var url = baseUrl + "/api/webhook/whispersubs";
+            var url = new Uri(baseUri, "api/webhook/whispersubs").ToString();
             var apiKey = config.LingarrApiKey ?? "";
-            var payload = System.Text.Json.JsonSerializer.Serialize(new { path = item.Path, mediaType });
+            var payload = System.Text.Json.JsonSerializer.Serialize(new { path = mediaPath, mediaType });
 
             _ = Task.Run(async () =>
             {

--- a/Controller/SubtitleManager.cs
+++ b/Controller/SubtitleManager.cs
@@ -1694,12 +1694,19 @@ namespace WhisperSubs.Controller
             if (config?.EnableLingarrNotification != true) return;
             var baseUrl = (config.LingarrUrl ?? "").TrimEnd('/');
             if (string.IsNullOrWhiteSpace(baseUrl)) return;
+            if (string.IsNullOrWhiteSpace(item.Path)) return;
 
-            var path = GetLingarrWebhookPath(item);
-            if (path == null) return;
+            string mediaType;
+            if (item is MediaBrowser.Controller.Entities.Movies.Movie)
+                mediaType = "Movie";
+            else if (item is MediaBrowser.Controller.Entities.TV.Episode)
+                mediaType = "Episode";
+            else
+                return;
 
-            var url = baseUrl + path;
+            var url = baseUrl + "/api/webhook/whispersubs";
             var apiKey = config.LingarrApiKey ?? "";
+            var payload = System.Text.Json.JsonSerializer.Serialize(new { path = item.Path, mediaType });
 
             _ = Task.Run(async () =>
             {
@@ -1708,30 +1715,16 @@ namespace WhisperSubs.Controller
                     using var request = new HttpRequestMessage(HttpMethod.Post, url);
                     if (!string.IsNullOrWhiteSpace(apiKey))
                         request.Headers.Add("X-Api-Key", apiKey);
-                    request.Content = new StringContent("{}", System.Text.Encoding.UTF8, "application/json");
+                    request.Content = new StringContent(payload, System.Text.Encoding.UTF8, "application/json");
                     using var response = await _httpClient.SendAsync(request).ConfigureAwait(false);
-                    _logger.LogInformation("Lingarr notified for {ItemName} via {Path}: HTTP {Status}",
-                        item.Name, path, (int)response.StatusCode);
+                    _logger.LogInformation("Lingarr notified for {ItemName} ({MediaType}): HTTP {Status}",
+                        item.Name, mediaType, (int)response.StatusCode);
                 }
                 catch (Exception ex)
                 {
                     _logger.LogWarning(ex, "Lingarr notification failed for {ItemName} — subtitle was still saved", item.Name);
                 }
             });
-        }
-
-        /// <summary>
-        /// Returns the Lingarr webhook path for the given item type, or null if the item
-        /// type has no corresponding Lingarr webhook (e.g. Audio).
-        /// Movies route to /api/webhook/radarr; Episodes to /api/webhook/sonarr.
-        /// </summary>
-        internal static string? GetLingarrWebhookPath(BaseItem item)
-        {
-            if (item is MediaBrowser.Controller.Entities.Movies.Movie)
-                return "/api/webhook/radarr";
-            if (item is MediaBrowser.Controller.Entities.TV.Episode)
-                return "/api/webhook/sonarr";
-            return null;
         }
     }
 }

--- a/Controller/SubtitleManager.cs
+++ b/Controller/SubtitleManager.cs
@@ -1717,8 +1717,12 @@ namespace WhisperSubs.Controller
                         request.Headers.Add("X-Api-Key", apiKey);
                     request.Content = new StringContent(payload, System.Text.Encoding.UTF8, "application/json");
                     using var response = await _httpClient.SendAsync(request).ConfigureAwait(false);
-                    _logger.LogInformation("Lingarr notified for {ItemName} ({MediaType}): HTTP {Status}",
-                        item.Name, mediaType, (int)response.StatusCode);
+                    if (response.IsSuccessStatusCode)
+                        _logger.LogInformation("Lingarr notified for {ItemName} ({MediaType}): HTTP {Status}",
+                            item.Name, mediaType, (int)response.StatusCode);
+                    else
+                        _logger.LogWarning("Lingarr notification rejected for {ItemName} ({MediaType}): HTTP {Status}",
+                            item.Name, mediaType, (int)response.StatusCode);
                 }
                 catch (Exception ex)
                 {

--- a/Controller/SubtitleManager.cs
+++ b/Controller/SubtitleManager.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
@@ -22,6 +23,7 @@ namespace WhisperSubs.Controller
     {
         private readonly ILibraryManager _libraryManager;
         private readonly ILogger<SubtitleManager> _logger;
+        private static readonly HttpClient _httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
 
         public SubtitleManager(ILibraryManager libraryManager, ILogger<SubtitleManager> logger)
         {
@@ -121,6 +123,7 @@ namespace WhisperSubs.Controller
             }
 
             await item.RefreshMetadata(cancellationToken);
+            FireLingarrNotification(item);
         }
 
         /// <summary>Outcome of a single subtitle generation attempt.</summary>
@@ -1682,6 +1685,53 @@ namespace WhisperSubs.Controller
             // preserves this method's non-null contract: callers expect a usable code back, and
             // placeholder tags ("auto"/"und", which NormalizeLang maps to null) round-trip unchanged.
             return SubtitleInventory.NormalizeLang(code) ?? (code ?? "").ToLowerInvariant();
+        }
+
+        [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage(Justification = "Fire-and-forget HTTP call to external Lingarr service")]
+        private void FireLingarrNotification(BaseItem item)
+        {
+            var config = Plugin.Instance?.Configuration;
+            if (config?.EnableLingarrNotification != true) return;
+            var baseUrl = (config.LingarrUrl ?? "").TrimEnd('/');
+            if (string.IsNullOrWhiteSpace(baseUrl)) return;
+
+            var path = GetLingarrWebhookPath(item);
+            if (path == null) return;
+
+            var url = baseUrl + path;
+            var apiKey = config.LingarrApiKey ?? "";
+
+            _ = Task.Run(async () =>
+            {
+                try
+                {
+                    using var request = new HttpRequestMessage(HttpMethod.Post, url);
+                    if (!string.IsNullOrWhiteSpace(apiKey))
+                        request.Headers.Add("X-Api-Key", apiKey);
+                    request.Content = new StringContent("{}", System.Text.Encoding.UTF8, "application/json");
+                    using var response = await _httpClient.SendAsync(request).ConfigureAwait(false);
+                    _logger.LogInformation("Lingarr notified for {ItemName} via {Path}: HTTP {Status}",
+                        item.Name, path, (int)response.StatusCode);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Lingarr notification failed for {ItemName} — subtitle was still saved", item.Name);
+                }
+            });
+        }
+
+        /// <summary>
+        /// Returns the Lingarr webhook path for the given item type, or null if the item
+        /// type has no corresponding Lingarr webhook (e.g. Audio).
+        /// Movies route to /api/webhook/radarr; Episodes to /api/webhook/sonarr.
+        /// </summary>
+        internal static string? GetLingarrWebhookPath(BaseItem item)
+        {
+            if (item is MediaBrowser.Controller.Entities.Movies.Movie)
+                return "/api/webhook/radarr";
+            if (item is MediaBrowser.Controller.Entities.TV.Episode)
+                return "/api/webhook/sonarr";
+            return null;
         }
     }
 }

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -342,6 +342,34 @@
                         </div>
                     </details>
 
+                    <details style="margin-top:1.5em;">
+                        <summary style="cursor:pointer; font-size:1.2em; font-weight:bold; padding:0.5em 0;">Lingarr Integration (Optional)</summary>
+
+                        <div class="checkboxContainer checkboxContainer-withDescription">
+                            <label>
+                                <input is="emby-checkbox" type="checkbox" id="chkEnableLingarrNotification" name="EnableLingarrNotification" />
+                                <span>Notify Lingarr after subtitle generation</span>
+                            </label>
+                            <div class="fieldDescription">
+                                When enabled, WhisperSubs sends a webhook to Lingarr after each subtitle file is written,
+                                so Lingarr can auto-translate it. Movies notify <code>/api/webhook/radarr</code>;
+                                episodes notify <code>/api/webhook/sonarr</code>. Off by default.
+                            </div>
+                        </div>
+
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="txtLingarrUrl">Lingarr URL</label>
+                            <input type="text" id="txtLingarrUrl" name="LingarrUrl" class="emby-input" placeholder="http://lingarr:8080" />
+                            <div class="fieldDescription">Base URL of your Lingarr instance. Must be reachable from the Jellyfin server container (e.g. an internal Docker hostname).</div>
+                        </div>
+
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="txtLingarrApiKey">Lingarr API Key</label>
+                            <input type="password" id="txtLingarrApiKey" name="LingarrApiKey" class="emby-input" autocomplete="new-password" maxlength="256" spellcheck="false" />
+                            <div class="fieldDescription">Sent as <code>X-Api-Key</code> on every webhook request. Find this in Lingarr's settings.</div>
+                        </div>
+                    </details>
+
                     <button is="emby-button" type="submit" class="raised button-submit block" style="margin-top:1.5em;">
                         <span>Save</span>
                     </button>
@@ -971,6 +999,9 @@
                             page.querySelector('#chkEnableVad').checked = config.EnableVad !== false;
                             page.querySelector('#chkAlignSubtitlesToSpeech').checked = config.AlignSubtitlesToSpeech !== false;
                             page.querySelector('#chkCompensateAudioOffset').checked = config.CompensateAudioOffset !== false;
+                            page.querySelector('#chkEnableLingarrNotification').checked = config.EnableLingarrNotification === true;
+                            page.querySelector('#txtLingarrUrl').value = config.LingarrUrl || '';
+                            page.querySelector('#txtLingarrApiKey').value = config.LingarrApiKey || '';
                             updateTranslationVisibility();
                         }
                             WhisperSubsConfig.loadLibraries();
@@ -1002,6 +1033,9 @@
                         config.EnableVad = page.querySelector('#chkEnableVad').checked;
                         config.AlignSubtitlesToSpeech = page.querySelector('#chkAlignSubtitlesToSpeech').checked;
                         config.CompensateAudioOffset = page.querySelector('#chkCompensateAudioOffset').checked;
+                        config.EnableLingarrNotification = page.querySelector('#chkEnableLingarrNotification').checked;
+                        config.LingarrUrl = (page.querySelector('#txtLingarrUrl').value || '').trim();
+                        config.LingarrApiKey = (page.querySelector('#txtLingarrApiKey').value || '').trim();
 
                         // Collect enabled libraries from checkboxes
                         var libraryCheckboxes = page.querySelectorAll('.chkLibrary');

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -352,8 +352,8 @@
                             </label>
                             <div class="fieldDescription">
                                 When enabled, WhisperSubs sends a webhook to Lingarr after each subtitle file is written,
-                                so Lingarr can auto-translate it. Movies notify <code>/api/webhook/radarr</code>;
-                                episodes notify <code>/api/webhook/sonarr</code>. Off by default.
+                                so Lingarr can auto-translate it. Posts to <code>/api/webhook/whispersubs</code>
+                                with the media path and type. Off by default.
                             </div>
                         </div>
 

--- a/WhisperSubs.Tests/LingarrNotificationTests.cs
+++ b/WhisperSubs.Tests/LingarrNotificationTests.cs
@@ -1,0 +1,42 @@
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Entities.TV;
+using WhisperSubs.Controller;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+public class LingarrNotificationTests
+{
+    [Fact]
+    public void GetLingarrWebhookPath_Movie_ReturnsRadarrPath()
+    {
+        var item = new Movie { Name = "Test Movie" };
+        var path = SubtitleManager.GetLingarrWebhookPath(item);
+        Assert.Equal("/api/webhook/radarr", path);
+    }
+
+    [Fact]
+    public void GetLingarrWebhookPath_Episode_ReturnsSonarrPath()
+    {
+        var item = new Episode { Name = "Test Episode" };
+        var path = SubtitleManager.GetLingarrWebhookPath(item);
+        Assert.Equal("/api/webhook/sonarr", path);
+    }
+
+    [Fact]
+    public void GetLingarrWebhookPath_Audio_ReturnsNull()
+    {
+        var item = new MediaBrowser.Controller.Entities.Audio.Audio { Name = "Test Track" };
+        var path = SubtitleManager.GetLingarrWebhookPath(item);
+        Assert.Null(path);
+    }
+
+    [Fact]
+    public void GetLingarrWebhookPath_Video_ReturnsNull()
+    {
+        var item = new Video { Name = "Test Video" };
+        var path = SubtitleManager.GetLingarrWebhookPath(item);
+        Assert.Null(path);
+    }
+}

--- a/WhisperSubs.Tests/LingarrNotificationTests.cs
+++ b/WhisperSubs.Tests/LingarrNotificationTests.cs
@@ -9,34 +9,30 @@ namespace WhisperSubs.Tests;
 public class LingarrNotificationTests
 {
     [Fact]
-    public void GetLingarrWebhookPath_Movie_ReturnsRadarrPath()
+    public void ResolveLingarrMediaType_Movie_ReturnsMovie()
     {
         var item = new Movie { Name = "Test Movie" };
-        var path = SubtitleManager.GetLingarrWebhookPath(item);
-        Assert.Equal("/api/webhook/radarr", path);
+        Assert.Equal("Movie", SubtitleManager.ResolveLingarrMediaType(item));
     }
 
     [Fact]
-    public void GetLingarrWebhookPath_Episode_ReturnsSonarrPath()
+    public void ResolveLingarrMediaType_Episode_ReturnsEpisode()
     {
         var item = new Episode { Name = "Test Episode" };
-        var path = SubtitleManager.GetLingarrWebhookPath(item);
-        Assert.Equal("/api/webhook/sonarr", path);
+        Assert.Equal("Episode", SubtitleManager.ResolveLingarrMediaType(item));
     }
 
     [Fact]
-    public void GetLingarrWebhookPath_Audio_ReturnsNull()
+    public void ResolveLingarrMediaType_Audio_ReturnsNull()
     {
         var item = new MediaBrowser.Controller.Entities.Audio.Audio { Name = "Test Track" };
-        var path = SubtitleManager.GetLingarrWebhookPath(item);
-        Assert.Null(path);
+        Assert.Null(SubtitleManager.ResolveLingarrMediaType(item));
     }
 
     [Fact]
-    public void GetLingarrWebhookPath_Video_ReturnsNull()
+    public void ResolveLingarrMediaType_Video_ReturnsNull()
     {
         var item = new Video { Name = "Test Video" };
-        var path = SubtitleManager.GetLingarrWebhookPath(item);
-        Assert.Null(path);
+        Assert.Null(SubtitleManager.ResolveLingarrMediaType(item));
     }
 }


### PR DESCRIPTION
## Summary

Adds optional integration with [Lingarr](https://github.com/lingarr-translate/lingarr), a self-hosted subtitle translation service. When enabled, WhisperSubs fires a `POST` to `/api/webhook/whispersubs` after successfully generating subtitles, allowing Lingarr to pick them up and translate automatically — no Sonarr/Radarr dependency required on the WhisperSubs side.

## Configuration

Three new optional fields added to the plugin config page under a collapsible **Lingarr Integration (Optional)** section:

| Field | Default | Description |
|-------|---------|-------------|
| Enable Lingarr notification | off | Master toggle |
| Lingarr URL | — | Base URL, e.g. `http://lingarr:7001` or `https://lingarr.example.com` |
| Lingarr API key | — | Sent as `X-Api-Key` header when set |

## Webhook details

**Endpoint:** `POST {LingarrUrl}/api/webhook/whispersubs`

**Headers:** `Content-Type: application/json`, optionally `X-Api-Key: <value>`

**Payload:**
```json
{ "path": "/media/movies/Film (2024)/Film.mkv", "mediaType": "Movie" }
```

`mediaType` is `"Movie"` for `Movie` items and `"Episode"` for `Episode` items. Items that don't resolve to either (audio tracks, generic `Video`) are silently skipped.

## Behaviour

- **Fire-and-forget:** runs in a background `Task.Run` — never blocks subtitle generation, never throws to the caller, and failures are logged at Warning level
- **Success-only:** notification fires only when at least one subtitle pass actually produced output (`attempted > 0 && failed < attempted`); runs where all passes were skipped (subtitle already exists, no foreign audio, etc.) do not notify
- **Correct path:** sends the Unicode-normalized `mediaPath` that was resolved at the start of `GenerateSubtitleAsync` — the path WhisperSubs actually wrote the subtitle next to — rather than the raw `item.Path`
- **URL safety:** base URL is `Trim()`-ed, scheme is validated as `http`/`https`, and the webhook path is appended via `Uri` composition to handle subpath installs correctly

## Tests

`LingarrNotificationTests` covers `ResolveLingarrMediaType` (extracted as `internal static` for testability):

- `Movie` → `"Movie"`
- `Episode` → `"Episode"`
- `Audio` → `null`
- `Video` (base class, not Movie/Episode) → `null`

The fire-and-forget HTTP dispatch method is `[ExcludeFromCodeCoverage]` — it requires a live HTTP endpoint and cannot be meaningfully unit tested without one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Lingarr webhook integration with configuration options for URL and API key.
  * Automatic notifications now sent to Lingarr after subtitle generation.
  * New configuration UI fields to enable/disable Lingarr notifications and specify webhook details.

* **Tests**
  * Added test coverage for notification type resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->