### PR TITLE
security: block fork PRs from running on the self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ concurrency:
 jobs:
   build:
     runs-on: [self-hosted, Linux, X64]
+    # Do not run untrusted fork PR code on the self-hosted runner.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
Adds a fork-guard `if:` so `pull_request`-triggered CI jobs run on the self-hosted runner **only for same-repo events**, never for PRs from forks.

## Why
On a public repo, a job that triggers on `pull_request` and runs on a self-hosted runner lets anyone's fork PR execute attacker-controlled code on the runner host. The guard keeps runs self-hosted for trusted events (push, schedule, workflow_dispatch, same-repo branch PRs) while skipping fork PRs. Same pattern already used in `tailscale-rs`.

```yaml
if: >-
  github.event_name != 'pull_request' ||
  github.event.pull_request.head.repo.full_name == github.repository
```

Files: ci.yml
