### PR TITLE
ci: cap artifact retention at 1 day to stop storage billing

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -123,6 +123,9 @@ jobs:
         with:
           name: ${{ matrix.asset_name }}
           path: /tmp/whisper-${{ matrix.variant }}/build/bin/whisper-cli
+          # Transient hand-off to the release job; final binaries live in the
+          # GitHub Release. Short retention avoids paid Actions storage buildup.
+          retention-days: 1
 
   # ── Build whisper.cpp ROCm binary (needs full SDK container) ───────
   # NOTE: Cannot use `container:` with self-hosted runners — JavaScript actions
@@ -167,6 +170,9 @@ jobs:
         with:
           name: whisper-cli-linux-x64-rocm
           path: ${{ github.workspace }}/rocm-output/whisper-cli
+          # Transient hand-off to the release job; final binaries live in the
+          # GitHub Release. Short retention avoids paid Actions storage buildup.
+          retention-days: 1
 
   # ── Check if release already exists ─────────────────────────────────
   check-version:


### PR DESCRIPTION
## Summary
Caps CI artifact retention at **1 day** for the whisper-cli build binaries.

## Why
This repo was the source of a recurring **"GitHub Actions Usage"** charge (~\$8-10/month). The cause was **artifact storage**, not minutes: the build produces ~3GB of binaries per run (including two 727MB CUDA builds), and the default **90-day retention** let ~15GB (437 artifacts) accumulate.

These artifacts are **transient hand-offs** — the `build-whisper` jobs upload them, the `release` job downloads them and publishes the final binaries to the **GitHub Release** (where they live permanently). So 90-day artifact retention served no purpose. `retention-days: 1` keeps them just long enough for the release job to consume them.

## Effect
- Stops the storage accumulation that drives the bill.
- No functional change — releases still get all binaries.
- Existing old artifacts are being deleted separately.