### PR TITLE
feat: generate-from-page button (#94) + fix AVX2 detection crash (#95)

### DIFF
--- a/Api/SubtitleController.cs
+++ b/Api/SubtitleController.cs
@@ -211,6 +211,14 @@ namespace WhisperSubs.Api
                     return NotFound(new { error = "Item not found" });
                 }
 
+                // Guard against enqueuing an entire library: only specific media or season/series containers.
+                if (parent is MediaBrowser.Controller.Entities.CollectionFolder
+                    || parent is MediaBrowser.Controller.Entities.UserView
+                    || parent is MediaBrowser.Controller.Entities.AggregateFolder)
+                {
+                    return BadRequest(new { error = "Select a specific movie, episode, season, or series." });
+                }
+
                 var config = Plugin.Instance.Configuration;
                 var targetLanguage = language ?? config.DefaultLanguage;
 
@@ -236,18 +244,20 @@ namespace WhisperSubs.Api
                 }
 
                 var queue = SubtitleQueueService.Instance;
+                int queued = 0, skipped = 0;
                 foreach (var child in children)
                 {
                     // Bulk "Generate all" deliberately does NOT force: it respects the
                     // SkipIfSubtitleExists toggle and the original-language / translation toggles so a
                     // library-wide request fills only the gaps the user actually wants (unlike
                     // single-item Generate, which forces a specific item). See #82/#83.
-                    queue.Enqueue(child, targetLanguage);
+                    if (queue.Enqueue(child, targetLanguage)) queued++;
+                    else skipped++;
                 }
 
                 _logger.LogInformation(
-                    "Queued {Count} items for subtitle generation under {ParentName} [{Language}]",
-                    children.Count, parent.Name, targetLanguage);
+                    "Queued {Queued} items ({Skipped} already queued or in progress) for subtitle generation under {ParentName} [{Language}]",
+                    queued, skipped, parent.Name, targetLanguage);
 
                 // Ensure the background drain worker is running
                 var manager = GetSubtitleManager();
@@ -256,9 +266,13 @@ namespace WhisperSubs.Api
 
                 return Accepted(new
                 {
-                    message = $"Queued {children.Count} item(s) for subtitle generation",
+                    message = skipped > 0
+                        ? $"Queued {queued} item(s) for subtitle generation ({skipped} already queued or in progress)"
+                        : $"Queued {queued} item(s) for subtitle generation",
                     parent = parent.Name,
                     count = children.Count,
+                    queued,
+                    skipped,
                     language = targetLanguage,
                     queueSize = queue.PriorityCount
                 });

--- a/Controller/SubtitleQueueService.cs
+++ b/Controller/SubtitleQueueService.cs
@@ -41,6 +41,7 @@ namespace WhisperSubs.Controller
         public static SubtitleQueueService Instance => _instance ??= new SubtitleQueueService();
 
         private readonly ConcurrentQueue<SubtitleWorkItem> _priorityQueue = new();
+        private readonly ConcurrentDictionary<string, byte> _inFlight = new();
         private int _isDraining;
         private string? _currentItemName;
         private int _processedCount;
@@ -137,6 +138,17 @@ namespace WhisperSubs.Controller
             Interlocked.Exchange(ref _taskIsRunning, 0);
         }
 
+        // De-dup key for a queued unit of work. Same item + language + force collapses to one entry,
+        // so double-clicks and overlapping season-bulk requests don't queue the same work twice.
+        internal static string DedupKey(Guid itemId, string language, bool force) =>
+            $"{itemId:N}|{(language ?? string.Empty).ToLowerInvariant()}|{(force ? "1" : "0")}";
+
+        // Reserve a key before enqueuing; returns false if an identical unit is already queued/in-flight.
+        internal bool TryReserve(string key) => _inFlight.TryAdd(key, 0);
+
+        // Release after processing (or on failure/cancel) so the same work can be requested again later.
+        internal void Release(string key) => _inFlight.TryRemove(key, out _);
+
         [ExcludeFromCodeCoverage(Justification = "Requires Plugin.Instance")]
         private static string QueueFilePath
         {
@@ -150,8 +162,10 @@ namespace WhisperSubs.Controller
         }
 
         [ExcludeFromCodeCoverage(Justification = "Requires BaseItem + Plugin.Instance for persistence")]
-        public void Enqueue(BaseItem item, string language, bool force = false)
+        public bool Enqueue(BaseItem item, string language, bool force = false)
         {
+            var key = DedupKey(item.Id, language, force);
+            if (!TryReserve(key)) return false; // identical work already queued / in flight
             _priorityQueue.Enqueue(new SubtitleWorkItem
             {
                 Item = item,
@@ -160,6 +174,7 @@ namespace WhisperSubs.Controller
                 Force = force
             });
             PersistQueue();
+            return true;
         }
 
         [ExcludeFromCodeCoverage(Justification = "Requires BaseItem + Plugin.Instance for persistence")]
@@ -206,6 +221,8 @@ namespace WhisperSubs.Controller
                     var item = libraryManager.GetItemById(guid);
                     if (item == null) continue;
 
+                    // Reserve the key so a startup re-scan won't double-queue this; restore is authoritative.
+                    TryReserve(DedupKey(item.Id, entry.Language, entry.Force));
                     _priorityQueue.Enqueue(new SubtitleWorkItem
                     {
                         Item = item,
@@ -333,6 +350,10 @@ namespace WhisperSubs.Controller
                     workItem.Completion?.TrySetException(ex);
                     logger.LogError(ex, "[Queue] Failed: {ItemName}", workItem.Item.Name);
                 }
+                finally
+                {
+                    Release(DedupKey(workItem.Item.Id, workItem.Language, workItem.Force));
+                }
             }
             logger.LogInformation("[Queue] Drain complete. Processed {Count} items total ({Failed} failed).",
                 _processedCount, _failedCount);
@@ -380,6 +401,10 @@ namespace WhisperSubs.Controller
                     _lastError = $"{workItem.Item.Name}: {ex.Message}";
                     workItem.Completion?.TrySetException(ex);
                     logger.LogError(ex, "[Priority] Failed: {ItemName}", workItem.Item.Name);
+                }
+                finally
+                {
+                    Release(DedupKey(workItem.Item.Id, workItem.Language, workItem.Force));
                 }
             }
             _currentItemName = null;

--- a/Controller/SubtitleQueueService.cs
+++ b/Controller/SubtitleQueueService.cs
@@ -181,6 +181,13 @@ namespace WhisperSubs.Controller
         public Task EnqueuePriorityAsync(BaseItem item, string language)
         {
             var tcs = new TaskCompletionSource<bool>();
+            // De-dup parity with Enqueue: priority items are non-forced. If identical work is already
+            // in flight, don't queue a duplicate — complete with false so an awaiter isn't left hanging.
+            if (!TryReserve(DedupKey(item.Id, language, false)))
+            {
+                tcs.SetResult(false);
+                return tcs.Task;
+            }
             _priorityQueue.Enqueue(new SubtitleWorkItem
             {
                 Item = item,
@@ -221,8 +228,9 @@ namespace WhisperSubs.Controller
                     var item = libraryManager.GetItemById(guid);
                     if (item == null) continue;
 
-                    // Reserve the key so a startup re-scan won't double-queue this; restore is authoritative.
-                    TryReserve(DedupKey(item.Id, entry.Language, entry.Force));
+                    // Skip duplicates: a queue.json containing the same (item, language, force) more
+                    // than once must not restore and re-run every copy — de-dup the restored set too.
+                    if (!TryReserve(DedupKey(item.Id, entry.Language, entry.Force))) continue;
                     _priorityQueue.Enqueue(new SubtitleWorkItem
                     {
                         Item = item,

--- a/Providers/WhisperProvider.cs
+++ b/Providers/WhisperProvider.cs
@@ -190,34 +190,9 @@ namespace WhisperSubs.Providers
                 if (process.ExitCode != 0)
                 {
                     var stderr = errorBuilder.ToString();
-
-                    // Exit 127 = dynamic linker couldn't load a shared library. Surface a clear,
-                    // actionable message instead of a raw dump (the binary itself is missing a runtime dep).
-                    if (process.ExitCode == 127)
-                    {
-                        var match = Regex.Match(stderr, @"error while loading shared libraries:\s*(\S+?):");
-                        var lib = match.Success ? match.Groups[1].Value : "a shared library";
-                        throw new InvalidOperationException(
-                            $"whisper-cli could not start: missing {lib}. The binary requires a system library " +
-                            $"that isn't present in this container. Install it (e.g. 'apt install libgomp1' for " +
-                            $"libgomp.so.1) or switch to a binary variant that doesn't need it. Raw error: {stderr.Trim()}");
-                    }
-
-                    // Exit 132 = SIGILL (illegal instruction): the binary used a CPU instruction set
-                    // (e.g. AVX) this CPU doesn't support. The "noavx" (Compatibility) variant is built
-                    // for these CPUs. 134 = SIGABRT, 135 = SIGBUS are adjacent hardware/ABI crashes.
-                    if (process.ExitCode == 132 || process.ExitCode == 134 || process.ExitCode == 135)
-                    {
-                        throw new InvalidOperationException(
-                            "whisper-cli crashed on launch with an illegal-instruction error (exit " +
-                            $"{process.ExitCode}). This CPU likely lacks an instruction set (such as AVX) that " +
-                            "this binary was built for. Re-download the binary and choose the " +
-                            "\"CPU (Compatibility)\" / noavx variant on the plugin setup page, which is built " +
-                            $"for CPUs without AVX. Raw error: {stderr.Trim()}");
-                    }
-
-                    throw new InvalidOperationException(
-                        $"Whisper process failed with exit code {process.ExitCode}. Error: {stderr}");
+                    var failure = DescribeWhisperExitFailure(process.ExitCode, stderr);
+                    if (failure != null) throw new InvalidOperationException(failure);
+                    throw new InvalidOperationException($"Whisper process failed with exit code {process.ExitCode}. Error: {stderr}");
                 }
 
                 if (File.Exists(tempSrtPath))
@@ -330,6 +305,12 @@ namespace WhisperSubs.Providers
 
             // Flush async stdout/stderr pipe buffers
             process.WaitForExit();
+
+            // A crash here (e.g. SIGILL/exit 132 on a non-AVX2 CPU running an AVX2 build) produces
+            // truncated output and would otherwise be misreported as "could not detect language".
+            // Surface the precise, actionable cause first — same diagnosis as the transcription path.
+            var exitFailure = DescribeWhisperExitFailure(process.ExitCode, errorBuilder.ToString());
+            if (exitFailure != null) throw new InvalidOperationException(exitFailure);
 
             var allOutput = outputBuilder.ToString() + "\n" + errorBuilder.ToString();
 
@@ -675,6 +656,30 @@ namespace WhisperSubs.Providers
             var ms = totalMs % 1000;
 
             return $"{h:D2}:{m:D2}:{s:D2},{ms:D3}";
+        }
+
+        // Maps a non-zero whisper-cli exit code to an actionable error message, or null if the code
+        // is not a known fatal-launch failure. Shared by transcription and language detection so both
+        // give the same precise diagnosis (e.g. a SIGILL on a non-AVX2 CPU) instead of a generic error.
+        internal static string? DescribeWhisperExitFailure(int exitCode, string stderr)
+        {
+            if (exitCode == 127)
+            {
+                var match = Regex.Match(stderr ?? string.Empty, @"error while loading shared libraries:\s*(\S+?):");
+                var lib = match.Success ? match.Groups[1].Value : "a shared library";
+                return $"whisper-cli could not start: missing {lib}. The binary requires a system library " +
+                       $"that isn't present in this container. Install it (e.g. 'apt install libgomp1' for " +
+                       $"libgomp.so.1) or switch to a binary variant that doesn't need it. Raw error: {(stderr ?? string.Empty).Trim()}";
+            }
+            if (exitCode == 132 || exitCode == 134 || exitCode == 135)
+            {
+                return "whisper-cli crashed on launch with an illegal-instruction error (exit " +
+                       $"{exitCode}). This CPU likely lacks an instruction set (such as AVX2) that " +
+                       "this binary was built for. Re-download the binary and choose the " +
+                       "\"CPU (Compatibility)\" / noavx variant on the plugin setup page, which is built " +
+                       $"for CPUs without AVX2. Raw error: {(stderr ?? string.Empty).Trim()}";
+            }
+            return null;
         }
 
         /// <summary>

--- a/Providers/WhisperProvider.cs
+++ b/Providers/WhisperProvider.cs
@@ -661,7 +661,7 @@ namespace WhisperSubs.Providers
         // Maps a non-zero whisper-cli exit code to an actionable error message, or null if the code
         // is not a known fatal-launch failure. Shared by transcription and language detection so both
         // give the same precise diagnosis (e.g. a SIGILL on a non-AVX2 CPU) instead of a generic error.
-        internal static string? DescribeWhisperExitFailure(int exitCode, string stderr)
+        internal static string? DescribeWhisperExitFailure(int exitCode, string? stderr)
         {
             if (exitCode == 127)
             {

--- a/Setup/WhisperSetupService.cs
+++ b/Setup/WhisperSetupService.cs
@@ -460,16 +460,18 @@ namespace WhisperSubs.Setup
             };
             info.HasOpenMP = Array.Exists(openmpPaths, File.Exists);
 
-            // CPU AVX support. Our x64 cpu/cuda12/vulkan binaries are compiled with AVX/AVX2;
+            // CPU AVX2 support. Our x64 cpu/cuda12/vulkan binaries are compiled with AVX2+FMA+F16C;
             // on a CPU that lacks those instructions they crash with SIGILL (illegal instruction,
             // exit 132). Only the *-noavx builds (SSE4.2) are safe there. ARM has no AVX concept,
-            // and its binaries are built without it, so treat ARM as "AVX not required" (HasAvx=true
-            // semantically means "the AVX-requiring builds are safe to run").
+            // and its binaries are built without it, so treat ARM as "AVX2 not required". The
+            // GpuInfo.HasAvx property name is the JSON/UI contract (read by Web/configPage.html);
+            // it semantically means "the AVX2-class instructions the prebuilt binaries require are
+            // present" (true also on ARM, where those builds are safe to run).
             info.HasAvx = RuntimeInformation.OSArchitecture == Architecture.Arm64
-                || DetectCpuHasAvx();
+                || DetectCpuHasAvx2();
 
             // Recommend variant based on detection — require both device AND userspace library.
-            // GPU binaries are also AVX-compiled, so a CPU without AVX must use a *-noavx variant.
+            // GPU binaries are also AVX2-compiled, so a CPU without AVX2 must use a *-noavx variant.
             if (info.HasNvidia && info.HasCudaLibrary) info.RecommendedVariant = info.HasAvx ? "cuda12" : "cuda12-noavx";
             else if (info.HasAmdGpu && info.HasRocmLibrary) info.RecommendedVariant = "rocm";
             else if (info.HasRenderDevice && info.HasVulkanLibrary) info.RecommendedVariant = info.HasAvx ? "vulkan" : "vulkan-noavx";
@@ -662,16 +664,16 @@ namespace WhisperSubs.Setup
         [ExcludeFromCodeCoverage(Justification = "Spawns binary process for validation")]
         private string? ValidateBinary(string binaryPath, string variant)
         {
-            // AVX gate: `--help` exits before any AVX instruction executes, so an AVX-compiled
-            // binary on a non-AVX CPU would *pass* the probe and only crash later during real
+            // AVX2 gate: `--help` exits before any AVX2 instruction executes, so an AVX2-compiled
+            // binary on a non-AVX2 CPU would *pass* the probe and only crash later during real
             // transcription (SIGILL / exit 132). Catch it here so the cpu->noavx fallback fires
             // at download time. ARM hosts have no AVX concept and their binaries don't use it.
-            if (VariantRequiresAvx(variant)
+            if (VariantRequiresAvx2(variant)
                 && RuntimeInformation.OSArchitecture != Architecture.Arm64
-                && !DetectCpuHasAvx())
+                && !DetectCpuHasAvx2())
             {
-                _logger.LogWarning("Variant '{Variant}' requires AVX but this CPU lacks it — will fall back", variant);
-                return "This CPU does not support AVX instructions, which this binary requires. "
+                _logger.LogWarning("Variant '{Variant}' requires AVX2 but this CPU lacks it — will fall back", variant);
+                return "This CPU does not support AVX2 instructions, which this binary requires. "
                      + "Falling back to the compatibility (noavx) build.";
             }
 
@@ -757,21 +759,24 @@ namespace WhisperSubs.Setup
         };
 
         /// <summary>
-        /// Whether the given variant's prebuilt binary was compiled with AVX/AVX2 instructions.
-        /// These crash with SIGILL (exit 132) on CPUs that lack AVX. The "*-noavx" builds use
+        /// Whether the given variant's prebuilt binary was compiled with AVX2 instructions.
+        /// These crash with SIGILL (exit 132) on CPUs that lack AVX2. The "*-noavx" builds use
         /// only SSE4.2 and are safe everywhere. ARM builds have no AVX and are always safe.
         /// </summary>
-        internal static bool VariantRequiresAvx(string variant) => variant switch
+        internal static bool VariantRequiresAvx2(string variant) => variant switch
         {
             "cpu" or "cuda12" or "vulkan" => true,
             _ => false   // noavx, cuda12-noavx, vulkan-noavx, rocm, unknown
         };
 
         /// <summary>
-        /// Parses Linux /proc/cpuinfo content and returns true if the CPU advertises AVX.
-        /// Pure/testable — the file read happens in <see cref="DetectCpuHasAvx"/>.
+        /// Parses Linux /proc/cpuinfo content and returns true if the CPU advertises AVX2.
+        /// The prebuilt cpu/cuda12/vulkan binaries are compiled with AVX2+FMA+F16C, and AVX2 is the
+        /// discriminator: every x86 CPU with AVX2 also has FMA and F16C, so checking AVX2 alone is
+        /// sufficient (and a CPU with plain AVX but no AVX2 — e.g. Ivy Bridge — must NOT pass).
+        /// Pure/testable — the file read happens in <see cref="DetectCpuHasAvx2"/>.
         /// </summary>
-        internal static bool CpuInfoHasAvx(string cpuInfoContent)
+        internal static bool CpuInfoHasAvx2(string cpuInfoContent)
         {
             if (string.IsNullOrEmpty(cpuInfoContent)) return false;
 
@@ -779,30 +784,31 @@ namespace WhisperSubs.Setup
             {
                 if (!line.StartsWith("flags", StringComparison.OrdinalIgnoreCase)) continue;
 
-                // flags are space-separated; match "avx" as a whole token (avoid matching "avx512..."
-                // substrings only — though those imply avx too, an exact-token check is clearest).
+                // flags are space-separated; match "avx2" as a whole token (an exact-token check
+                // avoids matching unrelated substrings such as "avx512..." that don't contain a
+                // bare "avx2" token).
                 var tokens = line.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
                 foreach (var token in tokens)
                 {
-                    if (string.Equals(token, "avx", StringComparison.OrdinalIgnoreCase)) return true;
+                    if (string.Equals(token, "avx2", StringComparison.OrdinalIgnoreCase)) return true;
                 }
             }
             return false;
         }
 
         /// <summary>
-        /// Reads /proc/cpuinfo and reports whether the host CPU supports AVX. Returns true on any
+        /// Reads /proc/cpuinfo and reports whether the host CPU supports AVX2. Returns true on any
         /// non-Linux platform or read failure (fail-open: don't wrongly steer users away from the
         /// faster build when we can't tell — the download-time validation still catches a real crash).
         /// </summary>
         [ExcludeFromCodeCoverage(Justification = "Reads host /proc/cpuinfo")]
-        private static bool DetectCpuHasAvx()
+        private static bool DetectCpuHasAvx2()
         {
             try
             {
                 if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) return true;
                 if (!File.Exists("/proc/cpuinfo")) return true;
-                return CpuInfoHasAvx(File.ReadAllText("/proc/cpuinfo"));
+                return CpuInfoHasAvx2(File.ReadAllText("/proc/cpuinfo"));
             }
             catch
             {
@@ -887,8 +893,11 @@ namespace WhisperSubs.Setup
         public bool HasRenderDevice { get; set; }
         public bool HasVulkanLibrary { get; set; }
         public bool HasOpenMP { get; set; }
-        /// <summary>True if the CPU supports AVX (or is ARM, where AVX is N/A). When false, only
-        /// the "*-noavx" binary variants will run — the others crash with SIGILL.</summary>
+        /// <summary>True if the CPU supports AVX2 (or is ARM, where AVX is N/A). When false, only
+        /// the "*-noavx" binary variants will run — the others (built with AVX2) crash with SIGILL.
+        /// The property name stays "HasAvx" because it is the JSON/UI contract read by
+        /// Web/configPage.html; it semantically means "the AVX2-class instructions the prebuilt
+        /// binaries require are present."</summary>
         public bool HasAvx { get; set; } = true;
         public string RecommendedVariant { get; set; } = "cpu";
     }

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -839,7 +839,7 @@
                         }
                     } else if (variant === 'noavx') {
                         if (gpuInfo.HasAvx === false) {
-                            hint.textContent = 'Compatibility variant \u2014 required: this CPU does not support AVX. No AVX or OpenMP needed.';
+                            hint.textContent = 'Compatibility variant \u2014 required: this CPU does not support AVX2. No AVX2 or OpenMP needed.';
                             hint.style.color = '#52B54B';
                         } else {
                             hint.textContent = 'Compatibility variant \u2014 no AVX or OpenMP required. Recommended for containers (TrueNAS Scale, minimal Docker).';
@@ -848,7 +848,7 @@
                     } else {
                         // CPU
                         if (gpuInfo.HasAvx === false) {
-                            hint.textContent = 'This CPU does not support AVX \u2014 the CPU variant will crash. Choose "CPU (Compatibility)" (noavx) instead.';
+                            hint.textContent = 'This CPU does not support AVX2\u2014 the CPU variant will crash. Choose "CPU (Compatibility)" (noavx) instead.';
                             hint.style.color = '#CC3333';
                         } else if (gpuInfo.HasNvidia || gpuInfo.HasAmdGpu || gpuInfo.HasRenderDevice) {
                             hint.textContent = 'GPU detected \u2014 consider a GPU variant for faster transcription.';

--- a/Web/whisperSubs.js
+++ b/Web/whisperSubs.js
@@ -58,7 +58,7 @@
             showToast('WhisperSubs: Queuing...');
             generateSubtitles(itemId).then(function (response) {
                 var data = typeof response === 'string' ? JSON.parse(response) : response;
-                var count = data.count || 1;
+                var count = data && data.queued != null ? data.queued : (data && data.count) || 1;
                 showToast('WhisperSubs: Queued ' + count + ' item(s) for subtitle generation');
             }).catch(function () {
                 showToast('WhisperSubs: Failed to queue generation');
@@ -197,7 +197,7 @@
                     showToast('WhisperSubs: Queuing...');
                     generateSubtitles(itemId).then(function (response) {
                         var data = typeof response === 'string' ? JSON.parse(response) : response;
-                        var n = (data && (data.queued != null ? data.queued : data.count)) || 1;
+                        var n = data && data.queued != null ? data.queued : (data && data.count) || 1;
                         showToast('WhisperSubs: Queued ' + n + ' item(s) for subtitle generation');
                     }).catch(function () {
                         showToast('WhisperSubs: Failed to queue generation');
@@ -217,6 +217,10 @@
     // Jellyfin rebuilds the detail DOM on each SPA navigation, so re-run on nav + render.
     var detailInjectTimer = null;
     function scheduleDetailInject() {
+        // Cheap early-exit: this fires on every DOM mutation via the body observer, so on non-detail
+        // pages (library grids, home, search) do almost nothing. A detail page always carries an item
+        // id in the hash; if there's none, skip without touching the timer.
+        if ((window.location.hash || '').indexOf('id=') === -1) return;
         if (detailInjectTimer) clearTimeout(detailInjectTimer);
         detailInjectTimer = setTimeout(injectDetailButton, 150);
     }

--- a/Web/whisperSubs.js
+++ b/Web/whisperSubs.js
@@ -128,27 +128,103 @@
 
     // Capture clicks on three-dot menu triggers everywhere
     document.addEventListener('click', function (e) {
-        var trigger = e.target.closest('.btnMoreCommands, [data-action="menu"]');
-        if (!trigger) return;
+        try {
+            if (!e.target || e.target.nodeType !== 1) return;
+            var trigger = e.target.closest('.btnMoreCommands, [data-action="menu"]');
+            if (!trigger) return;
 
-        // Try to get item ID from the nearest card/item element
-        var card = trigger.closest('[data-id]');
-        if (card) {
-            pendingItemId = card.getAttribute('data-id');
-        } else {
-            // Detail page fallback: extract from URL hash
-            var hash = window.location.hash || '';
-            var q = hash.indexOf('?');
-            if (q !== -1) {
-                var params = new URLSearchParams(hash.substring(q + 1));
-                pendingItemId = params.get('id');
+            // Try to get item ID from the nearest card/item element
+            var card = trigger.closest('[data-id]');
+            if (card) {
+                pendingItemId = card.getAttribute('data-id');
+            } else {
+                // Detail page fallback: extract from URL hash
+                var hash = window.location.hash || '';
+                var q = hash.indexOf('?');
+                if (q !== -1) {
+                    var params = new URLSearchParams(hash.substring(q + 1));
+                    pendingItemId = params.get('id');
+                }
             }
-        }
 
-        if (pendingItemId) {
-            watchForActionSheet();
+            if (pendingItemId) {
+                watchForActionSheet();
+            }
+        } catch (err) {
+            return;
         }
     }, true); // capture phase to run before Jellyfin's handler
+
+    // Inject a visible "Generate Subtitles" button onto the item detail page (issue #94),
+    // in addition to the three-dot context-menu item above. Fail-silent: never throw into the host page.
+    function injectDetailButton() {
+        try {
+            var page = document.querySelector('.libraryPage:not(.hide), .itemDetailPage:not(.hide), .detailPage:not(.hide)');
+            if (!page) return;
+
+            // Read the item id from the URL hash at this moment into a LOCAL var
+            // (deliberately NOT the module-global pendingItemId, which tracks the ⋮ menu target).
+            var hash = window.location.hash || '';
+            var m = hash.match(/[?&]id=([^&]+)/);
+            if (!m) return;
+            var itemId = decodeURIComponent(m[1]);
+
+            // Different Jellyfin versions use different button-row classes.
+            var row = page.querySelector('.mainDetailButtons, .detailButtons, .itemActionsBottom, .detailButtonsContainer');
+            if (!row) return;
+
+            if (row.querySelector('.btnWhisperSubsDetail')) return;
+
+            checkAdmin().then(function (admin) {
+                if (!admin) return;
+                if (row.querySelector('.btnWhisperSubsDetail')) return; // re-check after async
+
+                var btn = document.createElement('button');
+                btn.setAttribute('is', 'emby-button');
+                btn.type = 'button';
+                btn.className = 'button-flat detailButton emby-button btnWhisperSubsDetail';
+                btn.title = 'Generate subtitles';
+                btn.innerHTML =
+                    '<div class="detailButton-content">' +
+                        '<span class="material-icons detailButton-icon subtitles" aria-hidden="true"></span>' +
+                        '<span class="detailButton-icon-text">Subtitles</span>' +
+                    '</div>';
+
+                btn.addEventListener('click', function (e) {
+                    e.preventDefault();
+                    if (btn.disabled) return;
+                    btn.disabled = true;
+                    showToast('WhisperSubs: Queuing...');
+                    generateSubtitles(itemId).then(function (response) {
+                        var data = typeof response === 'string' ? JSON.parse(response) : response;
+                        var n = (data && (data.queued != null ? data.queued : data.count)) || 1;
+                        showToast('WhisperSubs: Queued ' + n + ' item(s) for subtitle generation');
+                    }).catch(function () {
+                        showToast('WhisperSubs: Failed to queue generation');
+                    }).then(function () {
+                        setTimeout(function () { btn.disabled = false; }, 3000); // debounce double-clicks
+                    });
+                });
+
+                row.appendChild(btn);
+            });
+        } catch (err) {
+            console.debug('[WhisperSubs] injectDetailButton error', err);
+            return;
+        }
+    }
+
+    // Jellyfin rebuilds the detail DOM on each SPA navigation, so re-run on nav + render.
+    var detailInjectTimer = null;
+    function scheduleDetailInject() {
+        if (detailInjectTimer) clearTimeout(detailInjectTimer);
+        detailInjectTimer = setTimeout(injectDetailButton, 150);
+    }
+    window.addEventListener('hashchange', scheduleDetailInject);
+    window.addEventListener('popstate', scheduleDetailInject);
+    var detailObserver = new MutationObserver(scheduleDetailInject);
+    detailObserver.observe(document.body, { childList: true, subtree: true });
+    scheduleDetailInject(); // initial attempt
 
     console.debug('[WhisperSubs] Context menu integration loaded');
 })();

--- a/WhisperSubs.Tests/SetupServiceTests.cs
+++ b/WhisperSubs.Tests/SetupServiceTests.cs
@@ -228,6 +228,15 @@ public class SetupServiceTests
     }
 
     [Fact]
+    public void CpuInfoHasAvx2_Avx2AsSubstringOfLongerToken_ReturnsFalse()
+    {
+        // Pins exact-token matching: a longer token that merely contains "avx2" (with no bare
+        // "avx2" token present) must NOT match. Guards against a regression to Contains("avx2").
+        var noBareToken = "flags\t\t: fpu sse2 avx2vnni avx512f\n";
+        Assert.False(WhisperSetupService.CpuInfoHasAvx2(noBareToken));
+    }
+
+    [Fact]
     public void Constructor_SetsDataPath()
     {
         var logger = new Microsoft.Extensions.Logging.Abstractions.NullLogger<WhisperSetupService>();

--- a/WhisperSubs.Tests/SetupServiceTests.cs
+++ b/WhisperSubs.Tests/SetupServiceTests.cs
@@ -180,42 +180,51 @@ public class SetupServiceTests
     [InlineData("vulkan-noavx", false)]
     [InlineData("rocm", false)]
     [InlineData("unknown", false)]
-    public void VariantRequiresAvx_OnlyNonNoavxBuilds(string variant, bool requiresAvx)
+    public void VariantRequiresAvx2_OnlyNonNoavxBuilds(string variant, bool requiresAvx)
     {
-        Assert.Equal(requiresAvx, WhisperSetupService.VariantRequiresAvx(variant));
+        Assert.Equal(requiresAvx, WhisperSetupService.VariantRequiresAvx2(variant));
     }
 
     [Fact]
-    public void CpuInfoHasAvx_DetectsAvxFlag()
+    public void CpuInfoHasAvx2_DetectsAvx2Flag()
     {
-        // Real /proc/cpuinfo "flags" line containing avx
-        var withAvx = "processor\t: 0\nflags\t\t: fpu vme de pse tsc msr pae mce cx8 sse sse2 avx avx2 fma\n";
-        Assert.True(WhisperSetupService.CpuInfoHasAvx(withAvx));
+        // Real /proc/cpuinfo "flags" line containing avx2
+        var withAvx2 = "processor\t: 0\nflags\t\t: fpu vme de pse tsc msr pae mce cx8 sse sse2 avx avx2 fma f16c\n";
+        Assert.True(WhisperSetupService.CpuInfoHasAvx2(withAvx2));
     }
 
     [Fact]
-    public void CpuInfoHasAvx_NoAvxFlag_ReturnsFalse()
+    public void CpuInfoHasAvx2_NoAvx2Flag_ReturnsFalse()
     {
-        // A CPU that lacks AVX (e.g. older Atom/Celeron common in NAS boxes)
+        // A CPU that lacks AVX2 (e.g. older Atom/Celeron common in NAS boxes) — has neither avx nor avx2
         var noAvx = "processor\t: 0\nflags\t\t: fpu vme de pse tsc msr pae mce cx8 sse sse2 sse4_1 sse4_2\n";
-        Assert.False(WhisperSetupService.CpuInfoHasAvx(noAvx));
+        Assert.False(WhisperSetupService.CpuInfoHasAvx2(noAvx));
     }
 
     [Fact]
-    public void CpuInfoHasAvx_DoesNotMatchAvxSubstrings()
+    public void CpuInfoHasAvx2_DoesNotMatchSubstrings()
     {
-        // Must match the whole "avx" token, not "avx512vl" alone implying nothing about plain avx.
-        // A line with only avx512 tokens (no bare "avx") should NOT report avx.
+        // Must match the whole "avx2" token. A line with only avx512 tokens (no bare "avx2")
+        // should NOT report avx2.
         var only512 = "flags\t\t: fpu sse2 avx512f avx512dq avx512bw\n";
-        Assert.False(WhisperSetupService.CpuInfoHasAvx(only512));
+        Assert.False(WhisperSetupService.CpuInfoHasAvx2(only512));
     }
 
     [Theory]
     [InlineData("")]
     [InlineData("processor : 0\nmodel name : Some CPU\n")]  // no flags line at all
-    public void CpuInfoHasAvx_EmptyOrNoFlags_ReturnsFalse(string content)
+    public void CpuInfoHasAvx2_EmptyOrNoFlags_ReturnsFalse(string content)
     {
-        Assert.False(WhisperSetupService.CpuInfoHasAvx(content));
+        Assert.False(WhisperSetupService.CpuInfoHasAvx2(content));
+    }
+
+    [Fact]
+    public void CpuInfoHasAvx2_AvxWithoutAvx2_ReturnsFalse()
+    {
+        // Issue #95: Intel Xeon E5-2687W v2 (Ivy Bridge-EP) has AVX but NOT AVX2.
+        // It must be classified as NOT AVX2-capable so it is steered to a *-noavx build.
+        var ivyBridge = "processor\t: 0\nflags\t\t: fpu vme de pse tsc msr sse sse2 ssse3 sse4_1 sse4_2 avx f16c rdrand\n";
+        Assert.False(WhisperSetupService.CpuInfoHasAvx2(ivyBridge));
     }
 
     [Fact]

--- a/WhisperSubs.Tests/SubtitleQueueServiceTests.cs
+++ b/WhisperSubs.Tests/SubtitleQueueServiceTests.cs
@@ -133,6 +133,53 @@ public class SubtitleQueueServiceTests
         _ = queue.LastError; // no throw; may be null or a prior error
         Assert.True(true);
     }
+
+    // ── Enqueue de-dup (#94): same item + language + force collapses to one queued entry ──
+
+    [Fact]
+    public void DedupKey_SameInputs_AreEqual_AndCaseInsensitiveLanguage()
+    {
+        // Language is normalized to lowercase so "EN" and "en" map to the same unit of work.
+        var id = Guid.NewGuid();
+        Assert.Equal(
+            SubtitleQueueService.DedupKey(id, "EN", false),
+            SubtitleQueueService.DedupKey(id, "en", false));
+    }
+
+    [Fact]
+    public void DedupKey_DiffersByForce()
+    {
+        // A forced (manual) request is a distinct unit from a non-forced one.
+        var id = Guid.NewGuid();
+        Assert.NotEqual(
+            SubtitleQueueService.DedupKey(id, "en", true),
+            SubtitleQueueService.DedupKey(id, "en", false));
+    }
+
+    [Fact]
+    public void DedupKey_DiffersByItem()
+    {
+        // Different items never collapse onto each other.
+        Assert.NotEqual(
+            SubtitleQueueService.DedupKey(Guid.NewGuid(), "en", false),
+            SubtitleQueueService.DedupKey(Guid.NewGuid(), "en", false));
+    }
+
+    [Fact]
+    public void TryReserve_SecondCallSameKey_ReturnsFalse_ThenReleaseAllowsReserve()
+    {
+        // Reserve once, the duplicate is rejected; after Release the key is requestable again.
+        // Unique GUID keeps this isolated from the shared singleton's other in-flight keys.
+        var queue = SubtitleQueueService.Instance;
+        var k = SubtitleQueueService.DedupKey(Guid.NewGuid(), "en", false);
+
+        Assert.True(queue.TryReserve(k));
+        Assert.False(queue.TryReserve(k));
+        queue.Release(k);
+        Assert.True(queue.TryReserve(k));
+
+        queue.Release(k); // clean up so we don't leak the key into other tests
+    }
 }
 
 public class QueueEntryTests

--- a/WhisperSubs.Tests/WhisperExitFailureTests.cs
+++ b/WhisperSubs.Tests/WhisperExitFailureTests.cs
@@ -1,0 +1,47 @@
+using WhisperSubs.Providers;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+public class WhisperExitFailureTests
+{
+    [Theory]
+    [InlineData(132)]
+    [InlineData(134)]
+    [InlineData(135)]
+    public void DescribeWhisperExitFailure_IllegalInstruction_SuggestsNoavx(int exitCode)
+    {
+        // SIGILL-class crashes (132/134/135) mean the AVX2 build hit a CPU without AVX2 — the
+        // diagnosis must point the user at the noavx (Compatibility) build, not a generic error.
+        var result = WhisperProvider.DescribeWhisperExitFailure(exitCode, "whatever stderr");
+
+        Assert.NotNull(result);
+        Assert.Contains("illegal", result!, System.StringComparison.OrdinalIgnoreCase);
+        Assert.True(
+            result.Contains("noavx", System.StringComparison.OrdinalIgnoreCase)
+            || result.Contains("Compatibility", System.StringComparison.OrdinalIgnoreCase),
+            $"Expected the message to mention the noavx/Compatibility build, got: {result}");
+    }
+
+    [Fact]
+    public void DescribeWhisperExitFailure_Exit127_NamesMissingLibrary()
+    {
+        var stderr = "whisper-cli: error while loading shared libraries: libvulkan.so.1: cannot open shared object file: No such file or directory";
+        var result = WhisperProvider.DescribeWhisperExitFailure(127, stderr);
+
+        Assert.NotNull(result);
+        Assert.Contains("libvulkan.so.1", result!);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(139)]
+    public void DescribeWhisperExitFailure_NonSpecialCodes_ReturnsNull(int exitCode)
+    {
+        // Only 127 and the SIGILL-class 132/134/135 codes get a tailored message; everything
+        // else (including a clean exit 0 and a generic exit 1) falls through to null so the
+        // caller emits its own generic error.
+        Assert.Null(WhisperProvider.DescribeWhisperExitFailure(exitCode, "some stderr"));
+    }
+}

--- a/WhisperSubs.Tests/WhisperExitFailureTests.cs
+++ b/WhisperSubs.Tests/WhisperExitFailureTests.cs
@@ -44,4 +44,15 @@ public class WhisperExitFailureTests
         // caller emits its own generic error.
         Assert.Null(WhisperProvider.DescribeWhisperExitFailure(exitCode, "some stderr"));
     }
+
+    [Theory]
+    [InlineData(127)]
+    [InlineData(132)]
+    public void DescribeWhisperExitFailure_NullStderr_DoesNotThrow(int exitCode)
+    {
+        // The shared helper must tolerate a null stderr (the parameter is string?); both special
+        // branches null-coalesce, so a future caller passing null cannot crash.
+        var result = WhisperProvider.DescribeWhisperExitFailure(exitCode, null);
+        Assert.NotNull(result);
+    }
 }

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.20.0.0</Version>
+    <Version>3.21.0.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
Implements **#94** and fixes **#95** in one release (v3.21.0.0). Two cleanly separated, independently-revertible commit groups.

## Fix #95 — language detection crashes on AVX-but-not-AVX2 CPUs

**Root cause.** The `cpu`/`cuda12`/`vulkan` binaries are compiled with **AVX2+FMA+F16C**, but the CPU-capability detector only matched the `avx` flag. A CPU with AVX1 but **not** AVX2 (the reporter's Xeon E5-2687W v2 / Ivy Bridge-EP) was therefore steered to an AVX2 binary. Language detection forces `--no-gpu`, so it runs the AVX2 CPU kernels → **SIGILL (exit 132)** → output truncated right after the Vulkan banner → misreported as the generic *"Could not detect language."* (Confirmed against whisper.cpp v1.8.4 source and the near-identical Handy #91 report for an E5-2670.)

**Changes**
- AVX detection now requires the `avx2` flag, so AVX1-only CPUs are correctly steered to the `*-noavx` variant by both `RecommendedVariant` and the download-time validation gate. (`CpuInfoHasAvx`→`CpuInfoHasAvx2`, `DetectCpuHasAvx`→`DetectCpuHasAvx2`, `VariantRequiresAvx`→`VariantRequiresAvx2`; the `GpuInfo.HasAvx` JSON/UI field name is preserved.)
- `DetectLanguageInternalAsync` now checks the process exit code (it never did) and surfaces the precise *"switch to the Compatibility/noavx variant"* message — via a shared `DescribeWhisperExitFailure` helper reused by the transcription path, so both give the same diagnosis.

**Deliberately not done** (and why): enabling GPU for detection (a benchmarked decision — ~21s vs ~15s/chunk — and it wouldn't fix the AVX2 host-code crash); silently defaulting a language (would emit wrong forced subtitles). Auto-re-download for already-installed users is deferred — the accurate error message is the migration path.

## Feature #94 — generate subtitles from the movie/episode page

The plugin already injected a "Generate Subtitles" item into the three-dot (⋮) context menu (which recurses Series→Season→Episode via `GenerateAll`), but it was hidden in the overflow menu with no de-dup.

**Changes**
- **Visible "Generate Subtitles" button** on movie/episode/season/series detail pages (in addition to the ⋮ item): admin-gated, idempotent, fail-silent, debounced, reading the item id from the URL hash into a local (fixes the shared-global race). Calls the same `GenerateAll` endpoint for consistent semantics.
- **Enqueue-time de-duplication** keyed on `(item, language, force)` — double-clicks and overlapping season requests no longer double-queue the same work. Keys are reserved in `Enqueue`/`RestoreQueue` and released in both drain loops. `GenerateAll` now reports `queued` vs `skipped`.
- **Library-root guard**: `GenerateAll` rejects a `CollectionFolder`/`UserView`/`AggregateFolder` id so a click can't enqueue an entire library.

Auth stays **admin-only** (`RequiresElevation`). The edit-subtitles-dialog hook and a per-language picker are deferred.

## Testing
- `dotnet build` — **0 warnings, 0 errors**.
- `dotnet test` — **566 passed**, 0 failed, 0 skipped (+12 new: AVX2 regression incl. the AVX-without-AVX2 case, exit-code mapping, and queue de-dup).

Closes #94. Fixes #95.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin-only “Generate subtitles” button on item pages for faster subtitle generation.
  * Bulk subtitle generation now reports how many items were queued and skipped.

* **Bug Fixes**
  * Prevented subtitle generation from being started on broad container views; a specific item must be selected.
  * Improved queue handling to avoid duplicate subtitle jobs.
  * Added clearer error messages when Whisper fails to launch or the device binary is incompatible.

* **Chores**
  * Updated version to 3.21.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->