### PR TITLE
fix: persist whisper binary variant + correct setup compatibility hint (#95)

### DIFF
--- a/Configuration/PluginConfiguration.cs
+++ b/Configuration/PluginConfiguration.cs
@@ -7,6 +7,15 @@ namespace WhisperSubs.Configuration
     {
         public string WhisperModelPath { get; set; } = "";
         public string WhisperBinaryPath { get; set; } = "";
+
+        /// <summary>
+        /// The whisper-cli binary variant that was actually downloaded and validated (e.g. "vulkan",
+        /// "vulkan-noavx", "cpu", "noavx"). Persisted so the setup page re-offers the installed variant
+        /// instead of silently re-defaulting the dropdown to the GPU recommendation on every load,
+        /// which could overwrite a deliberately-chosen compatibility build. (Issue #95 follow-up.)
+        /// </summary>
+        public string WhisperBinaryVariant { get; set; } = "";
+
         public bool EnableAutoGeneration { get; set; } = false;
 
         /// <summary>

--- a/Setup/WhisperSetupService.cs
+++ b/Setup/WhisperSetupService.cs
@@ -139,6 +139,7 @@ namespace WhisperSubs.Setup
                 ModelPath = configModelValid ? config.WhisperModelPath : autoModelPath,
                 Platform = GetPlatformIdentifier(),
                 SetupComplete = binaryOk && modelOk,
+                InstalledVariant = config.WhisperBinaryVariant,
                 Gpu = DetectGpu()
             };
         }
@@ -525,6 +526,9 @@ namespace WhisperSubs.Setup
                     {
                         var config = Plugin.Instance.Configuration;
                         config.WhisperBinaryPath = BinaryPath;
+                        // Persist the variant that actually validated (after any fallback walk) so the
+                        // setup page can re-offer it instead of re-defaulting to the recommendation.
+                        config.WhisperBinaryVariant = currentVariant;
                         Plugin.Instance.SaveConfiguration();
 
                         lock (_lock)
@@ -881,6 +885,7 @@ namespace WhisperSubs.Setup
         public string? ModelPath { get; set; }
         public string Platform { get; set; } = "";
         public bool SetupComplete { get; set; }
+        public string InstalledVariant { get; set; } = "";
         public GpuInfo Gpu { get; set; } = new();
     }
 

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -432,7 +432,7 @@
                         .then(function (s) {
                             WhisperSubsConfig._engineStatus = s;
                             WhisperSubsConfig.renderBinaryStatus(s);
-                            WhisperSubsConfig.loadEngineVariants(s.Gpu);
+                            WhisperSubsConfig.loadEngineVariants(s.Gpu, s.InstalledVariant);
                             // Load the catalog FIRST, then render the dropdown — the dropdown (and its
                             // description helptext) read _catalogModels, so rendering before the catalog
                             // resolves would leave both blank until the next interaction.
@@ -462,7 +462,7 @@
                     }
                 },
 
-                loadEngineVariants: function (gpuInfo) {
+                loadEngineVariants: function (gpuInfo, installedVariant) {
                     WhisperSubsConfig.ajaxGet(ApiClient.getUrl('Plugins/WhisperSubs/Setup/BinaryVariants'))
                         .then(function (variants) {
                             var select = document.querySelector('#engineBinaryVariant');
@@ -488,7 +488,13 @@
                                 opt.textContent = v.DisplayName;
                                 select.appendChild(opt);
                             });
-                            if (gpuInfo && gpuInfo.RecommendedVariant) {
+                            // Prefer the variant the user actually installed (persisted) so re-opening
+                            // setup doesn't silently re-arm a different variant; fall back to the GPU
+                            // recommendation only when there's no valid persisted choice.
+                            var variantIds = variants.map(function (v) { return v.Id; });
+                            if (installedVariant && variantIds.indexOf(installedVariant) !== -1) {
+                                select.value = installedVariant;
+                            } else if (gpuInfo && gpuInfo.RecommendedVariant) {
                                 select.value = gpuInfo.RecommendedVariant;
                             }
                             // Store gpuInfo for variant change handler
@@ -837,6 +843,28 @@
                             hint.textContent = 'No GPU render device detected. This variant requires a GPU with Vulkan support.';
                             hint.style.color = '#CC7B19';
                         }
+                    } else if (variant === 'vulkan-noavx') {
+                        if (gpuInfo.HasRenderDevice && gpuInfo.HasVulkanLibrary) {
+                            hint.textContent = 'GPU compatibility build: Vulkan acceleration without AVX2. The right choice for an older CPU (no AVX2) with a Vulkan GPU.';
+                            hint.style.color = '#52B54B';
+                        } else if (gpuInfo.HasRenderDevice) {
+                            hint.textContent = 'GPU detected but Vulkan library not found. May need libvulkan1 installed.';
+                            hint.style.color = '#CC7B19';
+                        } else {
+                            hint.textContent = 'No GPU render device detected. This variant requires a GPU with Vulkan support.';
+                            hint.style.color = '#CC7B19';
+                        }
+                    } else if (variant === 'cuda12-noavx') {
+                        if (gpuInfo.HasNvidia && gpuInfo.HasCudaLibrary) {
+                            hint.textContent = 'GPU compatibility build: CUDA acceleration without AVX2. The right choice for an older CPU (no AVX2) with an NVIDIA GPU.';
+                            hint.style.color = '#52B54B';
+                        } else if (gpuInfo.HasNvidia) {
+                            hint.textContent = 'NVIDIA GPU detected but CUDA libraries not found.';
+                            hint.style.color = '#CC7B19';
+                        } else {
+                            hint.textContent = 'No NVIDIA GPU detected. This variant requires an NVIDIA GPU with CUDA support.';
+                            hint.style.color = '#CC7B19';
+                        }
                     } else if (variant === 'noavx') {
                         if (gpuInfo.HasAvx === false) {
                             hint.textContent = 'Compatibility variant \u2014 required: this CPU does not support AVX2. No AVX2 or OpenMP needed.';
@@ -848,7 +876,7 @@
                     } else {
                         // CPU
                         if (gpuInfo.HasAvx === false) {
-                            hint.textContent = 'This CPU does not support AVX2\u2014 the CPU variant will crash. Choose "CPU (Compatibility)" (noavx) instead.';
+                            hint.textContent = 'This CPU does not support AVX2 \u2014 the CPU variant will crash. Choose "CPU (Compatibility)" (noavx) instead.';
                             hint.style.color = '#CC3333';
                         } else if (gpuInfo.HasNvidia || gpuInfo.HasAmdGpu || gpuInfo.HasRenderDevice) {
                             hint.textContent = 'GPU detected \u2014 consider a GPU variant for faster transcription.';

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -844,9 +844,12 @@
                             hint.style.color = '#CC7B19';
                         }
                     } else if (variant === 'vulkan-noavx') {
-                        if (gpuInfo.HasRenderDevice && gpuInfo.HasVulkanLibrary) {
+                        if (gpuInfo.HasRenderDevice && gpuInfo.HasVulkanLibrary && gpuInfo.HasAvx === false) {
                             hint.textContent = 'GPU compatibility build: Vulkan acceleration without AVX2. The right choice for an older CPU (no AVX2) with a Vulkan GPU.';
                             hint.style.color = '#52B54B';
+                        } else if (gpuInfo.HasRenderDevice && gpuInfo.HasVulkanLibrary) {
+                            hint.textContent = 'Vulkan GPU detected, but this CPU supports AVX2 — the standard "Vulkan" variant is recommended over this compatibility build.';
+                            hint.style.color = '#CC7B19';
                         } else if (gpuInfo.HasRenderDevice) {
                             hint.textContent = 'GPU detected but Vulkan library not found. May need libvulkan1 installed.';
                             hint.style.color = '#CC7B19';
@@ -855,11 +858,14 @@
                             hint.style.color = '#CC7B19';
                         }
                     } else if (variant === 'cuda12-noavx') {
-                        if (gpuInfo.HasNvidia && gpuInfo.HasCudaLibrary) {
+                        if (gpuInfo.HasNvidia && gpuInfo.HasCudaLibrary && gpuInfo.HasAvx === false) {
                             hint.textContent = 'GPU compatibility build: CUDA acceleration without AVX2. The right choice for an older CPU (no AVX2) with an NVIDIA GPU.';
                             hint.style.color = '#52B54B';
+                        } else if (gpuInfo.HasNvidia && gpuInfo.HasCudaLibrary) {
+                            hint.textContent = 'NVIDIA GPU detected, but this CPU supports AVX2 — the standard "CUDA 12" variant is recommended over this compatibility build.';
+                            hint.style.color = '#CC7B19';
                         } else if (gpuInfo.HasNvidia) {
-                            hint.textContent = 'NVIDIA GPU detected but CUDA libraries not found.';
+                            hint.textContent = 'NVIDIA GPU detected but CUDA libraries not found. Install nvidia-cuda-toolkit or use the CPU (Compatibility) variant.';
                             hint.style.color = '#CC7B19';
                         } else {
                             hint.textContent = 'No NVIDIA GPU detected. This variant requires an NVIDIA GPU with CUDA support.';

--- a/WhisperSubs.Tests/ConfigurationTests.cs
+++ b/WhisperSubs.Tests/ConfigurationTests.cs
@@ -13,6 +13,7 @@ public class ConfigurationTests
 
         Assert.Equal("", config.WhisperModelPath);
         Assert.Equal("", config.WhisperBinaryPath);
+        Assert.Equal("", config.WhisperBinaryVariant);
         Assert.False(config.EnableAutoGeneration);
         Assert.Equal("auto", config.DefaultLanguage);
         Assert.Equal(SubtitleMode.Full, config.SubtitleMode);

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.21.0.0</Version>
+    <Version>3.21.1.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
Follow-up to #96 (v3.21.0.0), prompted by @eBellmer's reply on #95: he manually picked the Vulkan (Compatibility) build but "it reverted back to the AVX2 one automatically." A 5-angle investigation found the mechanism and two real residual gaps. v3.21.0.0 already makes the recommendation correct (`vulkan-noavx`) for his CPU; this PR closes the gaps so the choice is clear and sticks.

## Fix A — persist the installed binary variant

The plugin only ever persisted `WhisperBinaryPath` (a single fixed path, identical for every variant), never *which* variant was installed. The setup page re-defaulted the dropdown to `gpuInfo.RecommendedVariant` on **every** page load, so a subsequent "Download" could silently overwrite a deliberately-chosen compatibility build with the recommended one (pre-v3.21.0.0 that was the AVX2 `vulkan` for an AVX-but-no-AVX2 CPU).

- `PluginConfiguration.WhisperBinaryVariant` now stores the variant that **actually validated** (after any fallback walk), set in `DownloadBinaryAsync`.
- Surfaced via `Setup/Status` as `InstalledVariant`.
- `configPage.html` `loadEngineVariants` now **prefers the persisted installed variant** over the recommendation when it's still an available option, falling back to the recommendation otherwise. Backward-compatible: empty (existing installs) falls through to today's behavior.

## Fix B — correct the setup hint for compatibility GPU builds

`updateVariantHint` had no branch for `vulkan-noavx` / `cuda12-noavx`, so selecting the *correct* Compatibility build fell through to the CPU `else` branch and showed a misleading **red "this CPU does not support AVX2 — will crash"** warning. Added explicit green hints for both, and restored a missing space in the CPU-variant warning.

## Testing
- `dotnet build` — 0 warnings, 0 errors.
- `dotnet test` — 569 passed, 0 failed, 0 skipped (added a `WhisperBinaryVariant` default assertion).
- Embedded config-page JS — `node --check` clean.

Relates to #95.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The setup flow now remembers the previously installed Whisper binary variant and restores it when reopening configuration.
  * Variant guidance now covers additional compatibility options for certain GPU and CPU setups.

* **Bug Fixes**
  * The selected Whisper binary variant is now preserved after download and validation, reducing unexpected resets to default recommendations.
  * Setup status now shows the installed variant more accurately.

* **Chores**
  * Updated the application version to **3.21.1.0**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->