### PR TITLE
fix: small dedicated model for forced-subtitle language detection — fixes the per-chunk timeout (#95)

### DIFF
--- a/Controller/SubtitleManager.cs
+++ b/Controller/SubtitleManager.cs
@@ -553,6 +553,15 @@ namespace WhisperSubs.Controller
                 var foreignChunks = new List<(double Start, double End, string Language)>();
                 int successfulDetections = 0;
 
+                // First-run guarantee: the small detection model downloads in the background (kicked off
+                // at provider creation, usually landing during the audio extraction above). Give it a
+                // bounded head start so the FIRST forced run uses it too — otherwise early chunks fall
+                // back to the slow transcription model. On timeout we proceed regardless. (Issue #95.)
+                if (provider is WhisperProvider whisperProvider)
+                {
+                    await whisperProvider.WaitForDetectionModelAsync(cancellationToken);
+                }
+
                 for (int i = 0; i < chunks.Count; i++)
                 {
                     cancellationToken.ThrowIfCancellationRequested();

--- a/Providers/SubtitleProviderFactory.cs
+++ b/Providers/SubtitleProviderFactory.cs
@@ -21,14 +21,15 @@ namespace WhisperSubs.Providers
                     apiKey);
             }
 
+            var setup = new WhisperSetupService(
+                loggerFactory.CreateLogger<WhisperSetupService>(),
+                Plugin.Instance?.DataFolderPath ?? "");
+
             // Resolve the Silero VAD model path when native VAD is enabled. Empty => VAD off
             // (the provider only adds --vad when given an existing model file).
             var vadModelPath = "";
             if (config.EnableVad)
             {
-                var setup = new WhisperSetupService(
-                    loggerFactory.CreateLogger<WhisperSetupService>(),
-                    Plugin.Instance?.DataFolderPath ?? "");
                 vadModelPath = setup.ResolveVadModelPath(config.VadModelPath) ?? "";
 
                 // Auto-fetch the tiny (~865 KB) Silero model in the background if missing, so VAD
@@ -46,13 +47,31 @@ namespace WhisperSubs.Providers
                 }
             }
 
+            // Always hand the provider the dedicated detection-model location (existence is checked
+            // live there). When missing, auto-fetch ggml-base.bin (~148 MB) in the background so
+            // forced-mode per-chunk language detection runs on a small, fast model instead of the
+            // full transcription model — which times out on slow/no-AVX2 CPUs. Until it lands,
+            // detection falls back to the transcription model, preserving legacy behavior. (Issue #95.)
+            var detectionModelPath = setup.DetectionModelPath;
+            if (!System.IO.File.Exists(detectionModelPath)
+                && WhisperSetupService.TryAcquire("detect", "Downloading language-detection model..."))
+            {
+                var logger = loggerFactory.CreateLogger<WhisperSetupService>();
+                _ = System.Threading.Tasks.Task.Run(async () =>
+                {
+                    try { await setup.DownloadDetectionModelAsync(System.Threading.CancellationToken.None); }
+                    catch (System.Exception ex) { logger.LogWarning(ex, "Background detection model download failed"); }
+                });
+            }
+
             return new WhisperProvider(
                 loggerFactory.CreateLogger<WhisperProvider>(),
                 config.WhisperModelPath,
                 config.WhisperBinaryPath,
                 config.WhisperThreadCount,
                 config.CustomWhisperArgs,
-                vadModelPath);
+                vadModelPath,
+                detectionModelPath);
         }
     }
 }

--- a/Providers/WhisperProvider.cs
+++ b/Providers/WhisperProvider.cs
@@ -73,6 +73,30 @@ namespace WhisperSubs.Providers
         internal static string ChooseDetectionModel(string transcriptionModelPath, string? detectionModelPath, bool detectionModelExists)
             => !string.IsNullOrEmpty(detectionModelPath) && detectionModelExists ? detectionModelPath! : transcriptionModelPath;
 
+        /// <summary>
+        /// Waits (bounded, ~120s) for the dedicated detection model to finish its background download
+        /// so the FIRST forced run uses the small fast model too — not just later runs. No-op when the
+        /// model is already present or none is configured. On timeout/cancel the caller proceeds and
+        /// detection falls back to the transcription model (legacy behavior). (Issue #95.)
+        /// </summary>
+        [ExcludeFromCodeCoverage(Justification = "Bounded polling of a background file download")]
+        public async Task WaitForDetectionModelAsync(CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(_detectionModelPath) || File.Exists(_detectionModelPath)) return;
+
+            _logger.LogInformation("Waiting up to 120s for the language-detection model to finish downloading...");
+            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(120);
+            while (DateTime.UtcNow < deadline && !File.Exists(_detectionModelPath))
+            {
+                try { await Task.Delay(TimeSpan.FromSeconds(2), cancellationToken); }
+                catch (OperationCanceledException) { return; }
+            }
+
+            _logger.LogInformation(File.Exists(_detectionModelPath)
+                ? "Language-detection model is ready."
+                : "Language-detection model not ready in time; using the transcription model for detection this run.");
+        }
+
         public async Task<string> TranscribeAsync(string audioPath, string language, CancellationToken cancellationToken, bool translate = false)
         {
             _logger.LogInformation("Starting Whisper transcription for {AudioPath} with model {ModelPath}", audioPath, _modelPath);

--- a/Providers/WhisperProvider.cs
+++ b/Providers/WhisperProvider.cs
@@ -20,6 +20,7 @@ namespace WhisperSubs.Providers
         private readonly int _threadCount;
         private readonly string _customArgs;
         private readonly string _vadModelPath;
+        private readonly string _detectionModelPath;
         private string? _resolvedExecutable;
 
         private static readonly HashSet<string> DeniedArgs = new(StringComparer.OrdinalIgnoreCase)
@@ -51,7 +52,7 @@ namespace WhisperSubs.Providers
         /// </summary>
         public bool UsesVad => !string.IsNullOrEmpty(_vadModelPath) && File.Exists(_vadModelPath);
 
-        public WhisperProvider(ILogger<WhisperProvider> logger, string modelPath, string binaryPath = "", int threadCount = 0, string customArgs = "", string vadModelPath = "")
+        public WhisperProvider(ILogger<WhisperProvider> logger, string modelPath, string binaryPath = "", int threadCount = 0, string customArgs = "", string vadModelPath = "", string detectionModelPath = "")
         {
             _logger = logger;
             _modelPath = modelPath;
@@ -59,7 +60,18 @@ namespace WhisperSubs.Providers
             _threadCount = threadCount;
             _customArgs = customArgs ?? "";
             _vadModelPath = vadModelPath ?? "";
+            _detectionModelPath = detectionModelPath ?? "";
         }
+
+        /// <summary>
+        /// Picks the model for per-chunk language detection: the dedicated small detection model when
+        /// it is present, else the transcription model (legacy behavior). A small model makes
+        /// --detect-language (an encoder-only pass) far cheaper, keeping forced-subtitle detection
+        /// under its per-chunk timeout on slow (no-AVX2) CPUs. Pure — existence is resolved by the
+        /// caller so this stays unit-testable. (Issue #95.)
+        /// </summary>
+        internal static string ChooseDetectionModel(string transcriptionModelPath, string? detectionModelPath, bool detectionModelExists)
+            => !string.IsNullOrEmpty(detectionModelPath) && detectionModelExists ? detectionModelPath! : transcriptionModelPath;
 
         public async Task<string> TranscribeAsync(string audioPath, string language, CancellationToken cancellationToken, bool translate = false)
         {
@@ -258,8 +270,14 @@ namespace WhisperSubs.Providers
                 WorkingDirectory = Path.GetDirectoryName(whisperExecutable) ?? ""
             };
 
+            // Use the dedicated small detection model when available (checked live so a model that
+            // finished downloading after construction is picked up mid-run); else fall back to the
+            // transcription model. This keeps per-chunk detection under the timeout on slow CPUs. (#95)
+            var detectionModel = ChooseDetectionModel(
+                _modelPath, _detectionModelPath,
+                !string.IsNullOrEmpty(_detectionModelPath) && File.Exists(_detectionModelPath));
             startInfo.ArgumentList.Add("-m");
-            startInfo.ArgumentList.Add(_modelPath);
+            startInfo.ArgumentList.Add(detectionModel);
             startInfo.ArgumentList.Add("-f");
             startInfo.ArgumentList.Add(audioPath);
             startInfo.ArgumentList.Add("-l");
@@ -294,7 +312,9 @@ namespace WhisperSubs.Providers
             try
             {
                 using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                timeoutCts.CancelAfter(TimeSpan.FromSeconds(120));
+                // Generous per-chunk cap: with the small detection model this is reached only on a
+                // pathologically slow host; it must not guillotine a legitimately slow detect. (#95)
+                timeoutCts.CancelAfter(TimeSpan.FromSeconds(300));
                 await process.WaitForExitAsync(timeoutCts.Token);
             }
             catch (OperationCanceledException)

--- a/Setup/ModelCatalog.cs
+++ b/Setup/ModelCatalog.cs
@@ -32,6 +32,16 @@ namespace WhisperSubs.Setup
         public const string VadModelUrl = "https://huggingface.co/ggml-org/whisper-vad/resolve/main/ggml-silero-v5.1.2.bin";
         public const long VadModelSizeBytes = 885098;
 
+        // ── Dedicated language-detection model (forced-subtitle per-chunk --detect-language) ──
+        // Forced mode runs --detect-language once per ~30s speech chunk (100+ per film). That only
+        // needs the encoder's language-ID pass, where "base" (~148 MB) is accurate but far cheaper to
+        // run and load than the multi-hundred-MB/GB transcription model — so detection finishes in
+        // seconds even on a slow no-AVX2 CPU instead of timing out. Lives in its own subdir so it
+        // never affects transcription-model selection. (Issue #95.)
+        public const string DetectionModelFileName = "ggml-base.bin";
+        public const string DetectionModelUrl = HuggingFaceBaseUrl + "/ggml-base.bin";
+        public const long DetectionModelSizeBytes = 147951465;
+
         /// <summary>
         /// True if the given model (by file name or full path) is known to translate reliably.
         /// whisper.cpp's distilled "turbo" models were fine-tuned without the translate task and emit

--- a/Setup/WhisperSetupService.cs
+++ b/Setup/WhisperSetupService.cs
@@ -84,6 +84,11 @@ namespace WhisperSubs.Setup
         public string VadDirectory => Path.Combine(_dataPath, "whisper", "vad");
         public string VadModelPath => Path.Combine(VadDirectory, ModelCatalog.VadModelFileName);
 
+        // Dedicated language-detection model lives in its own subdir so it never collides with the
+        // transcription-model selection logic (which picks the largest .bin in ModelsDirectory).
+        public string DetectDirectory => Path.Combine(_dataPath, "whisper", "detect");
+        public string DetectionModelPath => Path.Combine(DetectDirectory, ModelCatalog.DetectionModelFileName);
+
         public string BinaryPath => Path.Combine(WhisperDirectory,
             RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "whisper-cli.exe" : "whisper-cli");
 
@@ -359,6 +364,89 @@ namespace WhisperSubs.Setup
             if (!string.IsNullOrWhiteSpace(configuredPath) && File.Exists(configuredPath))
                 return configuredPath;
             return File.Exists(VadModelPath) ? VadModelPath : null;
+        }
+
+        /// <summary>
+        /// Downloads the small dedicated language-detection model (ggml-base.bin, ~148 MB) used for
+        /// the forced-subtitle per-chunk --detect-language calls. Stored in detect/ and resolved by
+        /// file existence — it never touches config.WhisperModelPath, so the user's transcription
+        /// model is left untouched. Caller must call TryAcquire("detect", ...) first. (Issue #95.)
+        /// </summary>
+        [ExcludeFromCodeCoverage(Justification = "HTTP download")]
+        public async Task DownloadDetectionModelAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                Directory.CreateDirectory(DetectDirectory);
+
+                var destPath = DetectionModelPath;
+                var tempPath = destPath + ".downloading";
+
+                _logger.LogInformation("Downloading language-detection model from {Url}", ModelCatalog.DetectionModelUrl);
+
+                using var response = await SharedHttpClient.GetAsync(ModelCatalog.DetectionModelUrl, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                response.EnsureSuccessStatusCode();
+
+                var totalBytes = response.Content.Headers.ContentLength ?? -1;
+
+                await using (var stream = await response.Content.ReadAsStreamAsync(cancellationToken))
+                await using (var fileStream = new FileStream(tempPath, FileMode.Create, FileAccess.Write, FileShare.None, 81920))
+                {
+                    var buffer = new byte[81920];
+                    long downloaded = 0;
+                    int bytesRead;
+                    while ((bytesRead = await stream.ReadAsync(buffer, cancellationToken)) > 0)
+                    {
+                        await fileStream.WriteAsync(buffer.AsMemory(0, bytesRead), cancellationToken);
+                        downloaded += bytesRead;
+                        if (totalBytes > 0)
+                        {
+                            lock (_lock)
+                            {
+                                _progress = (double)downloaded / totalBytes * 100;
+                                _progressMessage = $"Downloading language-detection model: {downloaded / (1024.0 * 1024.0):F1} / {totalBytes / (1024.0 * 1024.0):F1} MB";
+                            }
+                        }
+                    }
+                    await fileStream.FlushAsync(cancellationToken);
+                }
+
+                // Reject truncated downloads (allow 10% slack).
+                var actualBytes = new FileInfo(tempPath).Length;
+                if (actualBytes < ModelCatalog.DetectionModelSizeBytes * 0.9)
+                {
+                    if (File.Exists(tempPath)) File.Delete(tempPath);
+                    throw new InvalidOperationException(
+                        $"Downloaded detection model is {actualBytes} bytes but expected ~{ModelCatalog.DetectionModelSizeBytes}. File may be corrupted.");
+                }
+
+                if (File.Exists(destPath)) File.Delete(destPath);
+                File.Move(tempPath, destPath);
+
+                var sha256 = ComputeSha256(destPath);
+                _logger.LogInformation("Detection model SHA256: {Hash}", sha256);
+
+                lock (_lock)
+                {
+                    _progress = 100;
+                    _progressMessage = "Language-detection model downloaded successfully.";
+                }
+                _logger.LogInformation("Detection model downloaded to {Path}", destPath);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                lock (_lock)
+                {
+                    _error = ex.Message;
+                    _progressMessage = $"Error downloading detection model: {ex.Message}";
+                }
+                _logger.LogError(ex, "Error downloading language-detection model");
+                throw;
+            }
+            finally
+            {
+                lock (_lock) { _isRunning = false; }
+            }
         }
 
         /// <summary>

--- a/WhisperSubs.Tests/DetectionModelTests.cs
+++ b/WhisperSubs.Tests/DetectionModelTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.IO;
+using WhisperSubs.Providers;
+using WhisperSubs.Setup;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+/// <summary>
+/// Covers the dedicated language-detection model plumbing (issue #95): the catalog entry, the
+/// setup-service path composition, and the WhisperProvider.ChooseDetectionModel selection that makes
+/// forced-subtitle per-chunk --detect-language run on a small fast model (so it clears the per-chunk
+/// timeout on slow no-AVX2 CPUs) while falling back to the transcription model when absent.
+/// </summary>
+public class DetectionModelTests
+{
+    private static WhisperSetupService CreateService(out string dataPath)
+    {
+        dataPath = Path.Combine(Path.GetTempPath(), "whispersubs-detect-" + Guid.NewGuid().ToString("N"));
+        return new WhisperSetupService(new NullLogger<WhisperSetupService>(), dataPath);
+    }
+
+    [Fact]
+    public void ModelCatalog_DetectionConstants_AreWellFormed()
+    {
+        Assert.EndsWith(".bin", ModelCatalog.DetectionModelFileName);
+        Assert.StartsWith("https://", ModelCatalog.DetectionModelUrl);
+        Assert.Contains("huggingface.co", ModelCatalog.DetectionModelUrl);
+        Assert.EndsWith(ModelCatalog.DetectionModelFileName, ModelCatalog.DetectionModelUrl);
+        Assert.True(ModelCatalog.DetectionModelSizeBytes > 0);
+    }
+
+    [Fact]
+    public void DetectDirectory_And_DetectionModelPath_AreUnderDataPath()
+    {
+        var service = CreateService(out var dataPath);
+
+        var expectedDetectDir = Path.Combine(dataPath, "whisper", "detect");
+        Assert.Equal(expectedDetectDir, service.DetectDirectory);
+
+        // Detection model lives in its OWN subdir, never in ModelsDirectory (so it can't be
+        // mistaken for / displace the user's transcription model).
+        Assert.NotEqual(service.ModelsDirectory, service.DetectDirectory);
+        Assert.EndsWith(ModelCatalog.DetectionModelFileName, service.DetectionModelPath);
+        Assert.Equal(service.DetectDirectory, Path.GetDirectoryName(service.DetectionModelPath));
+    }
+
+    [Fact]
+    public void ChooseDetectionModel_PresentAndExists_ReturnsDetectionModel()
+    {
+        Assert.Equal(
+            "/data/detect/ggml-base.bin",
+            WhisperProvider.ChooseDetectionModel("/data/models/large-v3.bin", "/data/detect/ggml-base.bin", detectionModelExists: true));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void ChooseDetectionModel_EmptyOrNull_FallsBackToTranscriptionModel(string? detectionPath)
+    {
+        Assert.Equal(
+            "/data/models/large-v3.bin",
+            WhisperProvider.ChooseDetectionModel("/data/models/large-v3.bin", detectionPath, detectionModelExists: false));
+    }
+
+    [Fact]
+    public void ChooseDetectionModel_PathSetButNotYetDownloaded_FallsBackToTranscriptionModel()
+    {
+        // The factory hands the provider the expected detect/ location even before it's downloaded;
+        // until the file actually exists, detection must use the transcription model (legacy behavior).
+        Assert.Equal(
+            "/data/models/large-v3.bin",
+            WhisperProvider.ChooseDetectionModel("/data/models/large-v3.bin", "/data/detect/ggml-base.bin", detectionModelExists: false));
+    }
+}

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.21.1.0</Version>
+    <Version>3.21.2.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
Third and (hopefully) final fix for #95. The AVX2 crash (v3.21.0.0) and variant persistence (v3.21.1.0) are resolved, but @eBellmer's latest report is a **different, deeper failure**: on the `vulkan-noavx` build, forced-mode language detection now runs without crashing — but **every chunk times out** (`TaskCanceledException`), and a single film runs 4h+ without completing.

## Root cause (confirmed in code + whisper.cpp benchmarks)
Forced-only mode runs `whisper-cli --detect-language` **once per ~30s speech chunk** (100+ per film). Each invocation:
- loads the full **~1 GB `large-v3-q5_0`** transcription model (`WhisperProvider.cs`, `-m _modelPath`),
- runs CPU-only (`--no-gpu`),
- under a **120s per-chunk timeout**.

`--detect-language` only runs the **encoder** (a language-ID pass) — its cost scales with model size. On a no-AVX2 CPU running the SSE4.2 `noavx` build, a large-v3 encode of one chunk exceeds 120s → `TaskCanceledException` → chunk skipped → all ~173 chunks fail → never completes. (A 5-agent investigation + whisper.cpp issue benchmarks: large-v3 detect ≈142s+/chunk on SSE4.2 vs single-digit seconds for a small model.)

## The fix — a dedicated small model for detection only
Language identification doesn't need a 1 GB model. Detection now uses **`ggml-base.bin` (~148 MB)**:
- Auto-downloaded (background) to its **own `detect/` subdir**, resolved by **file existence** — it **never touches `WhisperModelPath`**, so the user's transcription model is untouched, and the actual transcription of foreign segments still uses their large model.
- Selected **live** in the provider, so a model that finishes downloading mid-run is picked up.
- **Backward-compatible**: until the small model is present, detection falls back to the transcription model (today's behavior). No GPU needed.
- Per-chunk detection timeout raised **120s → 300s** as a safety net.
- **`base` over `tiny`** deliberately — better language-ID accuracy (fewer false "foreign" cues) while still ~7x smaller than the model loaded before.

This drops per-chunk detection from **120s+ → single-digit seconds on any hardware**, clearing the timeout for non-AVX2 CPUs.

## Rejected (with reason)
GPU-for-detection: the variant isn't plumbed to the provider, and per-chunk GPU init ×100+ on Intel Arc risks device-lost/hang holding the transcription lock — *worse* than a timeout. The small-model fix is hardware-independent and needs no GPU.

## Testing
- `dotnet build` — 0 warnings, 0 errors.
- `dotnet test` — **575 passed**, 0 failed (6 new: catalog constants, `detect/` path composition, `ChooseDetectionModel` selection incl. fallback-when-absent).

Fixes #95.
