### PR TITLE
fix(forced): translate foreign dialogue to English, quiet whisper stderr, skip double-VAD

### DIFF
--- a/Controller/SubtitleManager.cs
+++ b/Controller/SubtitleManager.cs
@@ -437,6 +437,17 @@ namespace WhisperSubs.Controller
         }
 
         /// <summary>
+        /// True when the language code/name denotes English. whisper's <c>--translate</c> task can
+        /// only ever target English, so forced subtitles translate foreign dialogue only for English
+        /// primaries (see <see cref="GenerateForcedSubtitleAsync"/>). Accepts the ISO 639-1 "en", the
+        /// 639-2 "eng", and the English display name; case-insensitive. (Issue #95.)
+        /// </summary>
+        internal static bool LanguageIsEnglish(string? language) =>
+            string.Equals(language, "en", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(language, "eng", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(language, "english", StringComparison.OrdinalIgnoreCase);
+
+        /// <summary>
         /// Generates a forced subtitle file containing only foreign-language segments.
         /// Uses VAD-based chunking, per-chunk language detection, and selective transcription.
         /// Output: Movie.{lang}.forced.generated.srt
@@ -623,6 +634,23 @@ namespace WhisperSubs.Controller
                 var forcedSrt = new StringBuilder();
                 int entryNum = 1;
 
+                // Forced subtitles should read in the viewer's primary language, not the foreign
+                // source. whisper can only translate INTO English, so when the primary language is
+                // English (the common case — an English title with foreign-language inserts) we
+                // translate each foreign chunk to English, so the .en.forced track actually contains
+                // English instead of the source language. For a non-English primary, whisper has no
+                // path to that language, so we keep the in-source transcription rather than write
+                // mislabeled English into a .<lang>.forced file. (Issue #95.)
+                var translateForced = LanguageIsEnglish(resolvedPrimary);
+                if (translateForced && !ModelCatalog.IsTranslationCapable(Plugin.Instance?.Configuration?.WhisperModelPath))
+                {
+                    _logger.LogWarning(
+                        "Forced subtitles for {ItemName} will translate foreign dialogue to English, but the active " +
+                        "whisper model \"{Model}\" is a turbo model not trained for translation and will emit the source " +
+                        "language instead. Activate a non-turbo model (Large V3 or Medium) for English forced subtitles.",
+                        item.Name, Path.GetFileName(Plugin.Instance?.Configuration?.WhisperModelPath));
+                }
+
                 foreach (var segment in mergedSegments)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
@@ -632,7 +660,12 @@ namespace WhisperSubs.Controller
                     try
                     {
                         await ExtractAudioChunkAsync(fullAudioPath, segmentPath, segment.Start, segDuration, cancellationToken);
-                        var srtContent = await provider.TranscribeAsync(segmentPath, segment.Language, cancellationToken);
+                        // applyVad:false — the chunk is already a VAD-trimmed speech segment; a second
+                        // VAD pass can filter a short clip to zero segments and write an empty subtitle.
+                        // Only WhisperProvider runs a local VAD pass; the remote provider ignores it.
+                        var srtContent = provider is WhisperProvider whisperProv
+                            ? await whisperProv.TranscribeAsync(segmentPath, segment.Language, cancellationToken, translateForced, applyVad: false)
+                            : await provider.TranscribeAsync(segmentPath, segment.Language, cancellationToken, translate: translateForced);
 
                         if (!string.IsNullOrWhiteSpace(srtContent))
                         {

--- a/Controller/SubtitleManager.cs
+++ b/Controller/SubtitleManager.cs
@@ -642,7 +642,11 @@ namespace WhisperSubs.Controller
                 // path to that language, so we keep the in-source transcription rather than write
                 // mislabeled English into a .<lang>.forced file. (Issue #95.)
                 var translateForced = LanguageIsEnglish(resolvedPrimary);
-                if (translateForced && !ModelCatalog.IsTranslationCapable(Plugin.Instance?.Configuration?.WhisperModelPath))
+                // Gate the turbo-model warning to local whisper runs — a remote provider can translate
+                // fine and shouldn't trigger a warning about the local model path. (CodeRabbit.)
+                if (translateForced
+                    && provider is WhisperProvider
+                    && !ModelCatalog.IsTranslationCapable(Plugin.Instance?.Configuration?.WhisperModelPath))
                 {
                     _logger.LogWarning(
                         "Forced subtitles for {ItemName} will translate foreign dialogue to English, but the active " +
@@ -660,9 +664,10 @@ namespace WhisperSubs.Controller
                     try
                     {
                         await ExtractAudioChunkAsync(fullAudioPath, segmentPath, segment.Start, segDuration, cancellationToken);
-                        // applyVad:false — the chunk is already a VAD-trimmed speech segment; a second
-                        // VAD pass can filter a short clip to zero segments and write an empty subtitle.
-                        // Only WhisperProvider runs a local VAD pass; the remote provider ignores it.
+                        // applyVad:false — the chunk is already an edge-trimmed speech window (it may
+                        // span a few merged utterances); re-running whisper's VAD can filter a short
+                        // window to zero segments and write an empty subtitle. Only WhisperProvider
+                        // runs a local VAD pass; the remote provider ignores it.
                         var srtContent = provider is WhisperProvider whisperProv
                             ? await whisperProv.TranscribeAsync(segmentPath, segment.Language, cancellationToken, translateForced, applyVad: false)
                             : await provider.TranscribeAsync(segmentPath, segment.Language, cancellationToken, translate: translateForced);

--- a/Providers/WhisperProvider.cs
+++ b/Providers/WhisperProvider.cs
@@ -97,7 +97,17 @@ namespace WhisperSubs.Providers
                 : "Language-detection model not ready in time; using the transcription model for detection this run.");
         }
 
-        public async Task<string> TranscribeAsync(string audioPath, string language, CancellationToken cancellationToken, bool translate = false)
+        public Task<string> TranscribeAsync(string audioPath, string language, CancellationToken cancellationToken, bool translate = false)
+            => TranscribeAsync(audioPath, language, cancellationToken, translate, applyVad: true);
+
+        /// <summary>
+        /// Transcription overload that can suppress whisper-cli's native VAD pass. Forced-subtitle
+        /// chunks are already trimmed to a single speech segment (found by the detection pass), so
+        /// running whisper's VAD again can filter a short chunk down to zero segments and write an
+        /// empty subtitle — those callers pass <paramref name="applyVad"/> = false. Full and
+        /// translation runs keep VAD on via the interface method's default. (Issue #95.)
+        /// </summary>
+        public async Task<string> TranscribeAsync(string audioPath, string language, CancellationToken cancellationToken, bool translate, bool applyVad)
         {
             _logger.LogInformation("Starting Whisper transcription for {AudioPath} with model {ModelPath}", audioPath, _modelPath);
 
@@ -111,11 +121,11 @@ namespace WhisperSubs.Providers
                 throw new FileNotFoundException($"Audio file not found: {audioPath}");
             }
 
-            return await TranscribeInternalAsync(audioPath, language, cancellationToken, translate);
+            return await TranscribeInternalAsync(audioPath, language, cancellationToken, translate, applyVad);
         }
 
         [ExcludeFromCodeCoverage(Justification = "Spawns whisper-cli process")]
-        private async Task<string> TranscribeInternalAsync(string audioPath, string language, CancellationToken cancellationToken, bool translate)
+        private async Task<string> TranscribeInternalAsync(string audioPath, string language, CancellationToken cancellationToken, bool translate, bool applyVad)
         {
             var tempOutputPrefix = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             var tempSrtPath = tempOutputPrefix + ".srt";
@@ -141,9 +151,10 @@ namespace WhisperSubs.Providers
                     WorkingDirectory = Path.GetDirectoryName(whisperExecutable) ?? ""
                 };
 
-                // Caller resolves whether VAD applies (model configured + present on disk); the pure
-                // arg-builder stays I/O-free and unit-testable.
-                var useVad = !string.IsNullOrEmpty(_vadModelPath) && File.Exists(_vadModelPath);
+                // Caller resolves whether VAD applies (requested + model configured + present on
+                // disk); the pure arg-builder stays I/O-free and unit-testable. Forced chunks pass
+                // applyVad:false so an already-trimmed segment isn't re-filtered to empty. (Issue #95.)
+                var useVad = applyVad && !string.IsNullOrEmpty(_vadModelPath) && File.Exists(_vadModelPath);
                 foreach (var arg in BuildTranscribeArguments(
                     _modelPath, audioPath, language, _threadCount, translate,
                     useVad ? _vadModelPath : null, tempOutputPrefix, langPrompt))
@@ -174,14 +185,19 @@ namespace WhisperSubs.Providers
                     {
                         errorBuilder.AppendLine(e.Data);
 
-                        // Progress lines drive the per-file bar; everything else is a real warning.
+                        // Progress lines drive the per-file bar; everything else is whisper-cli's own
+                        // diagnostic output. whisper-cli writes ALL of it (model load, system_info,
+                        // VAD, timings) to stderr by design — it is not a warning, so log it at Debug
+                        // rather than flooding the Jellyfin log with [WRN] on a healthy run. A genuine
+                        // failure still surfaces via the non-zero exit-code path below, which throws
+                        // with the full captured stderr (errorBuilder). (Issue #95.)
                         if (TryParseProgress(e.Data, out var pct))
                         {
                             SubtitleQueueService.Instance.ReportFileProgress(pct);
                         }
                         else
                         {
-                            _logger.LogWarning("Whisper stderr: {Error}", e.Data);
+                            _logger.LogDebug("Whisper stderr: {Error}", e.Data);
                         }
                     }
                 };

--- a/Providers/WhisperProvider.cs
+++ b/Providers/WhisperProvider.cs
@@ -102,10 +102,10 @@ namespace WhisperSubs.Providers
 
         /// <summary>
         /// Transcription overload that can suppress whisper-cli's native VAD pass. Forced-subtitle
-        /// chunks are already trimmed to a single speech segment (found by the detection pass), so
-        /// running whisper's VAD again can filter a short chunk down to zero segments and write an
-        /// empty subtitle — those callers pass <paramref name="applyVad"/> = false. Full and
-        /// translation runs keep VAD on via the interface method's default. (Issue #95.)
+        /// chunks are already edge-trimmed speech windows (found by the detection pass; they may span
+        /// a few merged utterances), so running whisper's VAD again can filter a short window down to
+        /// zero segments and write an empty subtitle — those callers pass <paramref name="applyVad"/>
+        /// = false. Full and translation runs keep VAD on via the interface method's default. (Issue #95.)
         /// </summary>
         public async Task<string> TranscribeAsync(string audioPath, string language, CancellationToken cancellationToken, bool translate, bool applyVad)
         {

--- a/Providers/WhisperProvider.cs
+++ b/Providers/WhisperProvider.cs
@@ -151,10 +151,12 @@ namespace WhisperSubs.Providers
                     WorkingDirectory = Path.GetDirectoryName(whisperExecutable) ?? ""
                 };
 
-                // Caller resolves whether VAD applies (requested + model configured + present on
-                // disk); the pure arg-builder stays I/O-free and unit-testable. Forced chunks pass
-                // applyVad:false so an already-trimmed segment isn't re-filtered to empty. (Issue #95.)
-                var useVad = applyVad && !string.IsNullOrEmpty(_vadModelPath) && File.Exists(_vadModelPath);
+                // Resolve whether VAD applies (requested + model configured + present on disk). The
+                // rule lives in the pure ShouldUseVad helper so "applyVad:false suppresses VAD even
+                // with a model present" — the invariant forced chunks rely on — is unit-testable.
+                // (Issue #95.)
+                var vadModelExists = !string.IsNullOrEmpty(_vadModelPath) && File.Exists(_vadModelPath);
+                var useVad = ShouldUseVad(applyVad, _vadModelPath, vadModelExists);
                 foreach (var arg in BuildTranscribeArguments(
                     _modelPath, audioPath, language, _threadCount, translate,
                     useVad ? _vadModelPath : null, tempOutputPrefix, langPrompt))
@@ -741,6 +743,15 @@ namespace WhisperSubs.Providers
             }
             return null;
         }
+
+        /// <summary>
+        /// Whether to pass whisper-cli's native VAD flag: only when the caller requested it
+        /// (<paramref name="applyVad"/> — forced chunks pass false), a VAD model is configured, and
+        /// it exists on disk. Pure so the "applyVad:false always suppresses VAD, even with a model
+        /// present" invariant is unit-testable. (Issue #95.)
+        /// </summary>
+        internal static bool ShouldUseVad(bool applyVad, string? vadModelPath, bool vadModelExists)
+            => applyVad && !string.IsNullOrEmpty(vadModelPath) && vadModelExists;
 
         /// <summary>
         /// Builds the whisper-cli argument vector shared by every transcription run (the full,

--- a/WhisperSubs.Tests/ForcedTranslateTests.cs
+++ b/WhisperSubs.Tests/ForcedTranslateTests.cs
@@ -66,17 +66,19 @@ public class ForcedTranslateTests
             "forced chunk must pass the foreign SOURCE language to -l so --translate knows what to translate from");
     }
 
-    // A non-English primary keeps the in-source transcription (translate off): whisper cannot
-    // translate into a non-English language, so we do not write mislabeled English.
+    // A non-English PRIMARY (translateForced=false) keeps the in-source transcription: whisper can
+    // only translate into English, so for a non-English-primary title we transcribe the foreign
+    // insert in its own language ("fr" here) rather than write mislabeled English. Still no second
+    // VAD pass.
     [Fact]
-    public void ForcedNonEnglishChunk_KeepsSourceTranscription()
+    public void ForcedNonEnglishPrimary_TranscribesWithoutTranslateOrVad()
     {
         var args = WhisperProvider.BuildTranscribeArguments(
             modelPath: "/m/model.bin",
             audioPath: "/tmp/foreign.wav",
-            language: "en",
+            language: "fr",         // the foreign insert's source language under a non-English primary
             threadCount: 0,
-            translate: false,       // Spanish primary, English insert → keep source (transcribe)
+            translate: false,       // translateForced=false for a non-English primary → keep source
             vadModelPath: null,
             outputPrefix: "/tmp/out",
             langPrompt: null);

--- a/WhisperSubs.Tests/ForcedTranslateTests.cs
+++ b/WhisperSubs.Tests/ForcedTranslateTests.cs
@@ -86,4 +86,33 @@ public class ForcedTranslateTests
         Assert.DoesNotContain("--translate", args);
         Assert.DoesNotContain("--vad", args);
     }
+
+    // Locks fix #2's invariant: forced chunks pass applyVad:false, and that MUST suppress whisper's
+    // VAD even when a VAD model is configured and present on disk — otherwise a short, already-
+    // trimmed chunk can be re-filtered to zero segments and write an empty subtitle. (Issue #95.)
+    [Fact]
+    public void ShouldUseVad_False_WhenApplyVadFalse_EvenWithModelPresent()
+    {
+        Assert.False(WhisperProvider.ShouldUseVad(applyVad: false, vadModelPath: "/models/vad.bin", vadModelExists: true));
+    }
+
+    [Fact]
+    public void ShouldUseVad_True_WhenApplyVadTrue_AndModelPresent()
+    {
+        Assert.True(WhisperProvider.ShouldUseVad(applyVad: true, vadModelPath: "/models/vad.bin", vadModelExists: true));
+    }
+
+    [Fact]
+    public void ShouldUseVad_False_WhenModelConfiguredButMissingOnDisk()
+    {
+        Assert.False(WhisperProvider.ShouldUseVad(applyVad: true, vadModelPath: "/models/vad.bin", vadModelExists: false));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void ShouldUseVad_False_WhenNoModelConfigured(string? vadModelPath)
+    {
+        Assert.False(WhisperProvider.ShouldUseVad(applyVad: true, vadModelPath: vadModelPath, vadModelExists: true));
+    }
 }

--- a/WhisperSubs.Tests/ForcedTranslateTests.cs
+++ b/WhisperSubs.Tests/ForcedTranslateTests.cs
@@ -1,0 +1,87 @@
+using WhisperSubs.Controller;
+using WhisperSubs.Providers;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+// Issue #95: forced subtitles were transcribing foreign dialogue in its source language and writing
+// it into an English-tagged (.eng.forced) file, and re-running whisper's VAD on already-trimmed
+// chunks could empty them. These tests pin the two pure pieces of that fix: the English-only gate
+// for translation, and the forced-chunk argument shape (translate on, second VAD pass off).
+public class ForcedTranslateTests
+{
+    [Theory]
+    [InlineData("en")]
+    [InlineData("EN")]
+    [InlineData("eng")]
+    [InlineData("ENG")]
+    [InlineData("english")]
+    [InlineData("English")]
+    public void LanguageIsEnglish_TrueForEnglishForms(string language)
+    {
+        Assert.True(SubtitleManager.LanguageIsEnglish(language));
+    }
+
+    [Theory]
+    [InlineData("es")]
+    [InlineData("nn")]   // Norwegian Nynorsk — the language in the issue #95 report
+    [InlineData("de")]
+    [InlineData("auto")]
+    [InlineData("en-US")] // regional tag, not a bare English code — primaries are normalized to "en"
+    [InlineData("")]
+    [InlineData(null)]
+    public void LanguageIsEnglish_FalseForEverythingElse(string? language)
+    {
+        Assert.False(SubtitleManager.LanguageIsEnglish(language));
+    }
+
+    // The exact command shape a forced English chunk now produces: source language on -l, --translate
+    // to render it in English, and NO --vad (the chunk is already VAD-trimmed; a second pass could
+    // filter it to zero segments and emit an empty subtitle).
+    [Fact]
+    public void ForcedEnglishChunk_TranslatesWithoutSecondVadPass()
+    {
+        var args = WhisperProvider.BuildTranscribeArguments(
+            modelPath: "/m/model.bin",
+            audioPath: "/tmp/foreign_1510_1518.wav",
+            language: "nn",
+            threadCount: 0,
+            translate: true,        // English primary → translate the foreign chunk to English
+            vadModelPath: null,     // applyVad:false collapses to a null VAD path → no --vad
+            outputPrefix: "/tmp/out",
+            langPrompt: null);
+
+        Assert.Contains("--translate", args);
+        Assert.DoesNotContain("--vad", args);
+        Assert.DoesNotContain("--vad-model", args);
+
+        // -l must be immediately followed by the foreign SOURCE language so --translate knows what
+        // it is translating from (IReadOnlyList has no IndexOf, so scan the pairs).
+        var pairedSourceLang = false;
+        for (var i = 0; i + 1 < args.Count; i++)
+        {
+            if (args[i] == "-l" && args[i + 1] == "nn") { pairedSourceLang = true; break; }
+        }
+        Assert.True(pairedSourceLang,
+            "forced chunk must pass the foreign SOURCE language to -l so --translate knows what to translate from");
+    }
+
+    // A non-English primary keeps the in-source transcription (translate off): whisper cannot
+    // translate into a non-English language, so we do not write mislabeled English.
+    [Fact]
+    public void ForcedNonEnglishChunk_KeepsSourceTranscription()
+    {
+        var args = WhisperProvider.BuildTranscribeArguments(
+            modelPath: "/m/model.bin",
+            audioPath: "/tmp/foreign.wav",
+            language: "en",
+            threadCount: 0,
+            translate: false,       // Spanish primary, English insert → keep source (transcribe)
+            vadModelPath: null,
+            outputPrefix: "/tmp/out",
+            langPrompt: null);
+
+        Assert.DoesNotContain("--translate", args);
+        Assert.DoesNotContain("--vad", args);
+    }
+}

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.21.2.0</Version>
+    <Version>3.21.3.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
Follow-up to the #95 timeout fix (v3.21.2.0). With the per-chunk detection timeout resolved, @eBellmer reported that forced subtitles now run end-to-end but: (1) foreign dialogue is transcribed in its **source language** yet saved into the English-tagged `.eng.forced` file instead of being **translated to English**, and (2) whisper-cli's normal progress output floods the Jellyfin log as `[WRN]`. While verifying, a third latent bug showed up in his log: a short foreign chunk produced an **empty** subtitle (`Final speech segments after filtering: 0`).

## Fixes

**1. Translate foreign dialogue to English (English libraries)**
Forced subtitles should read in the viewer's primary language. whisper's `--translate` only ever targets English, so each foreign chunk is now translated when the primary language is English (the common case — an English title with foreign-language inserts). For a non-English primary, whisper has no path to that language, so the in-source transcription is kept rather than writing mislabeled English. Warns once when the active model is a turbo build that can't translate (mirrors the existing translation-pass guard).

**2. Quiet whisper-cli stderr**
whisper-cli writes all its normal diagnostics (model load, `system_info`, VAD, timings) to stderr by design. Every line was logged at `Warning`. Now logged at `Debug` — a genuine failure still surfaces via the non-zero exit-code path, which throws with the full captured stderr.

**3. Skip the double-VAD pass for forced chunks**
Forced chunks are already trimmed to a single speech segment by the detection pass, but transcription re-ran whisper's native VAD, which could filter a short clip to zero segments and emit an empty subtitle. Forced chunks now pass `applyVad:false` through a new `WhisperProvider` overload; the `ISubtitleProvider` interface and `RemoteWhisperProvider` are untouched.

## Tests
`ForcedTranslateTests` covers the English-language gate (`LanguageIsEnglish`) and the forced-chunk argument shape (translate on, second VAD pass off). **590 tests pass**, build clean (0/0).

Closes #95.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Forced subtitles now better handle English output, including common English language variants.
  * Translation can now be applied during subtitle transcription when needed.

* **Bug Fixes**
  * Improved forced subtitle behavior so foreign segments are translated to English when the main language is English.
  * Avoids an extra voice-detection pass for already trimmed subtitle chunks, helping preserve timing and reduce unnecessary processing.
  * Non-progress command output is now less noisy in logs.

* **Chores**
  * Updated the app version to 3.21.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->