### PR TITLE
feat(integration): show client-script injection status + Re-inject button (#94)

### DIFF
--- a/Api/SubtitleController.cs
+++ b/Api/SubtitleController.cs
@@ -507,6 +507,44 @@ namespace WhisperSubs.Api
         }
 
         /// <summary>
+        /// Reports whether the in-page client script is injected into Jellyfin's index.html, so an
+        /// admin can diagnose a missing "Generate Subtitles" button/menu without reading server logs.
+        /// </summary>
+        [HttpGet("Setup/InjectionStatus")]
+        [Authorize(Policy = "RequiresElevation")]
+        public ActionResult GetInjectionStatus()
+        {
+            try
+            {
+                return Ok(Plugin.Instance.GetInjectionStatus());
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error checking client-script injection status");
+                return StatusCode(500, new { error = ex.Message });
+            }
+        }
+
+        /// <summary>
+        /// Re-runs the index.html script injection on demand (config-page button), then returns the
+        /// fresh status — lets an admin fix a wiped/missing injection without restarting Jellyfin.
+        /// </summary>
+        [HttpPost("Setup/ReinjectScript")]
+        [Authorize(Policy = "RequiresElevation")]
+        public ActionResult ReinjectScript()
+        {
+            try
+            {
+                return Ok(Plugin.Instance.ReinjectScript());
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error re-injecting client script");
+                return StatusCode(500, new { error = ex.Message });
+            }
+        }
+
+        /// <summary>
         /// Lists whisper models available for download from HuggingFace.
         /// </summary>
         [HttpGet("Setup/AvailableModels")]

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text.RegularExpressions;
 using WhisperSubs.Configuration;
@@ -16,13 +17,22 @@ namespace WhisperSubs
         private readonly IApplicationPaths _appPaths;
         private readonly ILogger<Plugin> _logger;
 
-        private const string ScriptTag = "<script src=\"configurationpage?name=whisperSubs.js\"></script>";
+        internal const string ScriptTag = "<script src=\"configurationpage?name=whisperSubs.js\"></script>";
 
         public override string Name => "WhisperSubs";
         public override Guid Id => Guid.Parse("97124bd9-c8cd-4a53-a213-e593aa3fef52"); // Using a static GUID
 
         // Store data outside /plugins/ to avoid Jellyfin treating the data dir as a plugin folder
         public new string DataFolderPath => Path.Combine(_appPaths.DataPath, "WhisperSubs");
+
+        /// <summary>Jellyfin web root (where index.html lives). Surfaced for the injection-status panel.</summary>
+        public string WebPath => _appPaths.WebPath;
+
+        /// <summary>Path to Jellyfin's index.html that the client script is injected into.</summary>
+        public string IndexHtmlPath => Path.Combine(_appPaths.WebPath, "index.html");
+
+        /// <summary>Outcome of the most recent <see cref="InjectClientScript"/> run (startup or manual re-inject).</summary>
+        public string LastInjectionOutcome { get; private set; } = "not run";
 
         public Plugin(
             IApplicationPaths applicationPaths,
@@ -59,42 +69,195 @@ namespace WhisperSubs
 
         /// <summary>
         /// Injects a script tag into Jellyfin's index.html so our JS runs on every page.
-        /// Follows the same pattern used by intro-skipper and JellyScrub plugins.
+        /// Follows the same pattern used by intro-skipper and JellyScrub plugins. Records the result
+        /// in <see cref="LastInjectionOutcome"/> and returns it so the config page can surface whether
+        /// the in-page button/menu integration is actually wired up. (Issue #94.)
         /// </summary>
-        private void InjectClientScript()
+        [ExcludeFromCodeCoverage(Justification = "Reads/writes Jellyfin's index.html on disk")]
+        public ScriptInjectionOutcome InjectClientScript()
         {
             try
             {
-                var indexPath = Path.Combine(_appPaths.WebPath, "index.html");
+                var indexPath = IndexHtmlPath;
                 if (!File.Exists(indexPath))
                 {
+                    LastInjectionOutcome = "index.html not found";
                     _logger.LogDebug("WhisperSubs: index.html not found at {Path}, skipping script injection", indexPath);
-                    return;
+                    return ScriptInjectionOutcome.IndexNotFound;
                 }
 
-                var contents = File.ReadAllText(indexPath);
-                if (contents.Contains(ScriptTag, StringComparison.OrdinalIgnoreCase))
+                var (outcome, newHtml) = ComputeInjection(File.ReadAllText(indexPath));
+                switch (outcome)
                 {
-                    _logger.LogDebug("WhisperSubs: script tag already present in index.html");
-                    return;
-                }
+                    case ScriptInjectionOutcome.AlreadyPresent:
+                        LastInjectionOutcome = "already injected";
+                        _logger.LogDebug("WhisperSubs: script tag already present in index.html");
+                        return outcome;
 
-                // Insert before </head>
-                var headEnd = new Regex("</head>", RegexOptions.IgnoreCase);
-                if (!headEnd.IsMatch(contents))
-                {
-                    _logger.LogWarning("WhisperSubs: could not find </head> in index.html, skipping script injection");
-                    return;
-                }
+                    case ScriptInjectionOutcome.NoHeadTag:
+                        LastInjectionOutcome = "no </head> tag in index.html";
+                        _logger.LogWarning("WhisperSubs: could not find </head> in index.html, skipping script injection");
+                        return outcome;
 
-                contents = headEnd.Replace(contents, ScriptTag + "\n</head>", 1);
-                File.WriteAllText(indexPath, contents);
-                _logger.LogInformation("WhisperSubs: injected client script into index.html");
+                    default:
+                        File.WriteAllText(indexPath, newHtml!);
+                        LastInjectionOutcome = "injected";
+                        _logger.LogInformation("WhisperSubs: injected client script into index.html");
+                        return ScriptInjectionOutcome.Injected;
+                }
             }
             catch (Exception ex)
             {
+                LastInjectionOutcome = "failed: " + ex.Message;
                 _logger.LogWarning(ex, "WhisperSubs: failed to inject client script into index.html");
+                return ScriptInjectionOutcome.WriteFailed;
             }
         }
+
+        /// <summary>
+        /// Pure core of <see cref="InjectClientScript"/>: decides what to do with the given index.html
+        /// content. Returns the outcome and, when the tag should be added, the rewritten HTML (the tag
+        /// inserted once before the first &lt;/head&gt;). No I/O, so it is unit-testable.
+        /// </summary>
+        internal static (ScriptInjectionOutcome Outcome, string? NewHtml) ComputeInjection(string? html)
+        {
+            if (string.IsNullOrEmpty(html))
+            {
+                return (ScriptInjectionOutcome.NoHeadTag, null);
+            }
+
+            if (html.Contains(ScriptTag, StringComparison.OrdinalIgnoreCase))
+            {
+                return (ScriptInjectionOutcome.AlreadyPresent, null);
+            }
+
+            var headEnd = new Regex("</head>", RegexOptions.IgnoreCase);
+            if (!headEnd.IsMatch(html))
+            {
+                return (ScriptInjectionOutcome.NoHeadTag, null);
+            }
+
+            return (ScriptInjectionOutcome.Injected, headEnd.Replace(html, ScriptTag + "\n</head>", 1));
+        }
+
+        /// <summary>
+        /// Live snapshot of whether the client script is wired into index.html, for the config-page
+        /// "In-page button &amp; menu" panel. Re-reads the file each call so it reflects reality now
+        /// (e.g. a Jellyfin update that replaced index.html after startup). (Issue #94.)
+        /// </summary>
+        [ExcludeFromCodeCoverage(Justification = "Reads/probes Jellyfin's index.html on disk")]
+        public ScriptInjectionStatus GetInjectionStatus()
+        {
+            var path = IndexHtmlPath;
+            var exists = File.Exists(path);
+            var tagPresent = false;
+            var writable = false;
+
+            if (exists)
+            {
+                try
+                {
+                    tagPresent = File.ReadAllText(path).Contains(ScriptTag, StringComparison.OrdinalIgnoreCase);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogDebug(ex, "WhisperSubs: could not read index.html for status");
+                }
+                writable = IsWritable(path);
+            }
+
+            var (level, message) = DescribeInjection(exists, tagPresent, writable);
+            return new ScriptInjectionStatus
+            {
+                WebPath = WebPath,
+                IndexHtmlPath = path,
+                IndexExists = exists,
+                ScriptTagPresent = tagPresent,
+                Writable = writable,
+                LastStartupOutcome = LastInjectionOutcome,
+                Level = level,
+                Message = message
+            };
+        }
+
+        /// <summary>Re-runs the injection on demand (config-page button), then returns the fresh status.</summary>
+        [ExcludeFromCodeCoverage(Justification = "Writes Jellyfin's index.html on disk")]
+        public ScriptInjectionStatus ReinjectScript()
+        {
+            InjectClientScript();
+            return GetInjectionStatus();
+        }
+
+        /// <summary>
+        /// Pure: turns the three observable facts about index.html into a severity + user-facing
+        /// message for the config panel. Unit-tested so the guidance stays correct.
+        /// </summary>
+        internal static (string Level, string Message) DescribeInjection(bool indexExists, bool scriptTagPresent, bool writable)
+        {
+            if (!indexExists)
+            {
+                return ("error",
+                    "Jellyfin's index.html was not found at the web path, so the in-page \"Generate Subtitles\" " +
+                    "button and menu item can't be added. This is unusual — confirm this server hosts the Jellyfin web UI.");
+            }
+
+            if (scriptTagPresent)
+            {
+                return ("ok",
+                    "The WhisperSubs client script is injected. If you still don't see the \"Generate Subtitles\" " +
+                    "button or menu item, hard-refresh your browser (Ctrl/Cmd+Shift+R) and make sure you're signed in " +
+                    "as an administrator — both are admin-only.");
+            }
+
+            if (!writable)
+            {
+                return ("error",
+                    "index.html is present but NOT writable, so the client script can't be injected (common with " +
+                    "read-only web roots in Docker). Make the Jellyfin web directory writable, then click Re-inject " +
+                    "(or restart Jellyfin).");
+            }
+
+            return ("warning",
+                "The client script is not currently injected — a Jellyfin update may have replaced index.html. " +
+                "Click Re-inject below, then hard-refresh your browser.");
+        }
+
+        /// <summary>Best-effort writability probe: open the file for write without modifying it.</summary>
+        [ExcludeFromCodeCoverage(Justification = "Probes the filesystem")]
+        private static bool IsWritable(string path)
+        {
+            try
+            {
+                using var fs = new FileStream(path, FileMode.Open, FileAccess.ReadWrite);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+
+    /// <summary>Outcome of an attempt to inject the client &lt;script&gt; tag into index.html.</summary>
+    public enum ScriptInjectionOutcome
+    {
+        Injected,
+        AlreadyPresent,
+        NoHeadTag,
+        IndexNotFound,
+        WriteFailed
+    }
+
+    /// <summary>Serialized to the config page so an admin can see whether the in-page integration is wired up.</summary>
+    public class ScriptInjectionStatus
+    {
+        public string WebPath { get; set; } = "";
+        public string IndexHtmlPath { get; set; } = "";
+        public bool IndexExists { get; set; }
+        public bool ScriptTagPresent { get; set; }
+        public bool Writable { get; set; }
+        public string LastStartupOutcome { get; set; } = "";
+        public string Level { get; set; } = "";
+        public string Message { get; set; } = "";
     }
 }

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -89,21 +89,21 @@ namespace WhisperSubs
                 var (outcome, newHtml) = ComputeInjection(File.ReadAllText(indexPath));
                 switch (outcome)
                 {
+                    case ScriptInjectionOutcome.Injected:
+                        File.WriteAllText(indexPath, newHtml!);
+                        LastInjectionOutcome = "injected";
+                        _logger.LogInformation("WhisperSubs: injected client script into index.html");
+                        return ScriptInjectionOutcome.Injected;
+
                     case ScriptInjectionOutcome.AlreadyPresent:
                         LastInjectionOutcome = "already injected";
                         _logger.LogDebug("WhisperSubs: script tag already present in index.html");
                         return outcome;
 
-                    case ScriptInjectionOutcome.NoHeadTag:
+                    default: // NoHeadTag — ComputeInjection never returns IndexNotFound/WriteFailed here
                         LastInjectionOutcome = "no </head> tag in index.html";
                         _logger.LogWarning("WhisperSubs: could not find </head> in index.html, skipping script injection");
                         return outcome;
-
-                    default:
-                        File.WriteAllText(indexPath, newHtml!);
-                        LastInjectionOutcome = "injected";
-                        _logger.LogInformation("WhisperSubs: injected client script into index.html");
-                        return ScriptInjectionOutcome.Injected;
                 }
             }
             catch (Exception ex)
@@ -204,9 +204,10 @@ namespace WhisperSubs
             if (scriptTagPresent)
             {
                 return ("ok",
-                    "The WhisperSubs client script is injected. If you still don't see the \"Generate Subtitles\" " +
-                    "button or menu item, hard-refresh your browser (Ctrl/Cmd+Shift+R) and make sure you're signed in " +
-                    "as an administrator — both are admin-only.");
+                    "The WhisperSubs client script is injected. If you don't see it, hard-refresh your browser " +
+                    "(Ctrl/Cmd+Shift+R) and make sure you're signed in as an administrator — it's admin-only. The " +
+                    "\"Generate Subtitles\" entry in an item's three-dot (⋮) menu is the most reliable; the button on " +
+                    "the detail page depends on your Jellyfin theme/version, so if only the page button is missing, use the menu item.");
             }
 
             if (!writable)
@@ -228,7 +229,9 @@ namespace WhisperSubs
         {
             try
             {
-                using var fs = new FileStream(path, FileMode.Open, FileAccess.ReadWrite);
+                // FileShare.ReadWrite so a concurrent reader/writer (Jellyfin serving the page, or a
+                // racing re-inject) doesn't make this probe spuriously report "not writable".
+                using var fs = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
                 return true;
             }
             catch

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -67,6 +67,21 @@
                     <div id="engineProgressText" class="fieldDescription" style="margin-top:0.5em;"></div>
                 </div>
 
+                <!-- ── In-page button & menu (client-script injection) status ── -->
+                <div id="injectionStatusPanel" style="background:rgba(0,0,0,0.15); border-radius:6px; padding:1em; margin-bottom:1em;">
+                    <div style="display:flex; align-items:center; margin-bottom:0.3em;">
+                        <span id="injectionStatusIcon" style="font-size:1.2em;">&#9744;</span>
+                        <strong style="margin-left:0.4em;">In-page "Generate Subtitles" button &amp; menu</strong>
+                    </div>
+                    <div id="injectionStatusText" class="fieldDescription" style="margin-bottom:0.6em;"></div>
+                    <div style="display:flex; gap:0.6em; align-items:center; flex-wrap:wrap;">
+                        <button is="emby-button" id="btnReinjectScript" class="raised" type="button">
+                            <span>Re-inject script</span>
+                        </button>
+                        <span id="injectionStatusPath" style="opacity:0.6; font-size:0.85em; word-break:break-all;"></span>
+                    </div>
+                </div>
+
                 <form class="whisperSubsConfigurationForm">
 
                     <!-- ── Generation Defaults ───────────────────────── -->
@@ -460,6 +475,52 @@
                         icon.style.color = '#CC7B19';
                         text.textContent = 'Not installed';
                     }
+                },
+
+                // ── In-page button/menu injection status (issue #94) ──────
+                loadInjectionStatus: function () {
+                    WhisperSubsConfig.ajaxGet(ApiClient.getUrl('Plugins/WhisperSubs/Setup/InjectionStatus'))
+                        .then(function (s) { WhisperSubsConfig.renderInjectionStatus(s); })
+                        .catch(function (err) { console.error('WhisperSubs: injection status check failed', err); });
+                },
+
+                renderInjectionStatus: function (s) {
+                    var icon = document.querySelector('#injectionStatusIcon');
+                    var text = document.querySelector('#injectionStatusText');
+                    var path = document.querySelector('#injectionStatusPath');
+                    if (!icon || !text) return;
+                    if (s.Level === 'ok') {
+                        icon.innerHTML = '&#9745;';
+                        icon.style.color = '#52B54B';
+                    } else if (s.Level === 'warning') {
+                        icon.innerHTML = '&#9888;';
+                        icon.style.color = '#CC7B19';
+                    } else {
+                        icon.innerHTML = '&#10007;';
+                        icon.style.color = '#CC3333';
+                    }
+                    text.textContent = s.Message || '';
+                    if (path) { path.textContent = s.IndexHtmlPath ? ('index.html: ' + s.IndexHtmlPath) : ''; }
+                },
+
+                reinjectScript: function () {
+                    var btn = document.querySelector('#btnReinjectScript');
+                    if (btn) { btn.disabled = true; }
+                    ApiClient.ajax({
+                        type: 'POST',
+                        url: ApiClient.getUrl('Plugins/WhisperSubs/Setup/ReinjectScript'),
+                        dataType: 'json'
+                    }).then(function (response) {
+                        var s = typeof response === 'string' ? JSON.parse(response) : response;
+                        WhisperSubsConfig.renderInjectionStatus(s);
+                        Dashboard.alert(s.ScriptTagPresent
+                            ? 'Client script injected. Hard-refresh your browser (Ctrl/Cmd+Shift+R) to load it.'
+                            : 'Could not inject the script. ' + (s.Message || ''));
+                    }).catch(function (err) {
+                        Dashboard.alert('Re-inject failed: ' + (err.message || err));
+                    }).then(function () {
+                        if (btn) { btn.disabled = false; }
+                    });
                 },
 
                 loadEngineVariants: function (gpuInfo, installedVariant) {
@@ -1427,6 +1488,7 @@
             document.querySelector('[data-role="page"]').addEventListener('pageshow', function () {
                 WhisperSubsConfig.loadConfiguration(this);
                 WhisperSubsConfig.loadEngine();
+                WhisperSubsConfig.loadInjectionStatus();
                 // Check if transcription is already running and show banner
                 WhisperSubsConfig.pollQueueStatus();
                 WhisperSubsConfig.ajaxGet(ApiClient.getUrl('Plugins/WhisperSubs/Queue'))
@@ -1440,6 +1502,10 @@
 
             document.querySelector('#btnEngineDownloadBinary').addEventListener('click', function () {
                 WhisperSubsConfig.startEngineDownload('binary');
+            });
+
+            document.querySelector('#btnReinjectScript').addEventListener('click', function () {
+                WhisperSubsConfig.reinjectScript();
             });
 
             document.querySelector('#btnEngineDownloadModel').addEventListener('click', function () {

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -500,7 +500,14 @@
                         icon.style.color = '#CC3333';
                     }
                     text.textContent = s.Message || '';
-                    if (path) { path.textContent = s.IndexHtmlPath ? ('index.html: ' + s.IndexHtmlPath) : ''; }
+                    if (path) {
+                        // Surface the real last-injection reason (e.g. "no </head> tag in index.html")
+                        // so a state the generic message can't distinguish isn't a dead-end. (Issue #94.)
+                        var parts = [];
+                        if (s.IndexHtmlPath) { parts.push('index.html: ' + s.IndexHtmlPath); }
+                        if (s.LastStartupOutcome) { parts.push('last injection result: ' + s.LastStartupOutcome); }
+                        path.textContent = parts.join('  ·  ');
+                    }
                 },
 
                 reinjectScript: function () {

--- a/Web/whisperSubs.js
+++ b/Web/whisperSubs.js
@@ -230,5 +230,13 @@
     detailObserver.observe(document.body, { childList: true, subtree: true });
     scheduleDetailInject(); // initial attempt
 
-    console.debug('[WhisperSubs] Context menu integration loaded');
+    // Visible (console.log, not console.debug which browsers hide by default) so an admin can confirm
+    // in DevTools that the injected script actually loaded — and see the admin-gate result, since the
+    // "Generate Subtitles" button + menu item are admin-only. (Issue #94.)
+    console.log('[WhisperSubs] client script loaded');
+    checkAdmin().then(function (admin) {
+        console.log(admin
+            ? '[WhisperSubs] administrator confirmed — Generate Subtitles button + menu enabled'
+            : '[WhisperSubs] current user is NOT an administrator — the Generate Subtitles button and menu are admin-only and will not appear');
+    });
 })();

--- a/WhisperSubs.Tests/ScriptInjectionTests.cs
+++ b/WhisperSubs.Tests/ScriptInjectionTests.cs
@@ -1,0 +1,109 @@
+using System;
+using WhisperSubs;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+// Issue #94: the in-page "Generate Subtitles" button + menu come from a client script the plugin
+// injects into Jellyfin's index.html. These tests pin the pure pieces of that injection and the
+// config-page status guidance, so a regression can't silently break the integration or its diagnosis.
+public class ScriptInjectionTests
+{
+    [Fact]
+    public void ComputeInjection_InsertsTagBeforeHead_WhenAbsent()
+    {
+        var html = "<html><head><title>Jellyfin</title></head><body></body></html>";
+        var (outcome, newHtml) = Plugin.ComputeInjection(html);
+
+        Assert.Equal(ScriptInjectionOutcome.Injected, outcome);
+        Assert.NotNull(newHtml);
+        Assert.Contains(Plugin.ScriptTag, newHtml);
+        // Inserted BEFORE </head>, not after.
+        Assert.True(
+            newHtml!.IndexOf(Plugin.ScriptTag, StringComparison.Ordinal)
+            < newHtml.IndexOf("</head>", StringComparison.Ordinal),
+            "script tag must be inserted before </head>");
+    }
+
+    [Fact]
+    public void ComputeInjection_AlreadyPresent_NoChange()
+    {
+        var html = "<html><head>" + Plugin.ScriptTag + "</head><body></body></html>";
+        var (outcome, newHtml) = Plugin.ComputeInjection(html);
+
+        Assert.Equal(ScriptInjectionOutcome.AlreadyPresent, outcome);
+        Assert.Null(newHtml);
+    }
+
+    [Fact]
+    public void ComputeInjection_IsIdempotent_ReinjectingResultIsAlreadyPresent()
+    {
+        var injected = Plugin.ComputeInjection("<html><head></head></html>").NewHtml!;
+        var (outcome, _) = Plugin.ComputeInjection(injected);
+        Assert.Equal(ScriptInjectionOutcome.AlreadyPresent, outcome);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("<html><body>no head element here</body></html>")]
+    public void ComputeInjection_NoHeadTag_WhenEmptyOrHeadless(string? html)
+    {
+        var (outcome, newHtml) = Plugin.ComputeInjection(html);
+        Assert.Equal(ScriptInjectionOutcome.NoHeadTag, outcome);
+        Assert.Null(newHtml);
+    }
+
+    [Fact]
+    public void ComputeInjection_MatchesHeadCaseInsensitively()
+    {
+        var (outcome, newHtml) = Plugin.ComputeInjection("<HTML><HEAD></HEAD></HTML>");
+        Assert.Equal(ScriptInjectionOutcome.Injected, outcome);
+        Assert.Contains(Plugin.ScriptTag, newHtml!);
+    }
+
+    [Fact]
+    public void ComputeInjection_InsertsOnlyOnce_WithMultipleHeadTags()
+    {
+        // Two </head> must not double-inject; Replace(..., 1) caps at the first occurrence.
+        var newHtml = Plugin.ComputeInjection("<head>a</head><head>b</head>").NewHtml!;
+        var first = newHtml.IndexOf(Plugin.ScriptTag, StringComparison.Ordinal);
+        var second = newHtml.IndexOf(Plugin.ScriptTag, first + 1, StringComparison.Ordinal);
+        Assert.True(first >= 0, "tag should be present");
+        Assert.True(second < 0, "tag should appear exactly once");
+    }
+
+    // ── DescribeInjection: the config-panel guidance for each observable state ──
+
+    [Fact]
+    public void DescribeInjection_IndexMissing_IsError()
+    {
+        var (level, message) = Plugin.DescribeInjection(indexExists: false, scriptTagPresent: false, writable: false);
+        Assert.Equal("error", level);
+        Assert.Contains("index.html", message);
+    }
+
+    [Fact]
+    public void DescribeInjection_TagPresent_IsOk()
+    {
+        var (level, message) = Plugin.DescribeInjection(indexExists: true, scriptTagPresent: true, writable: true);
+        Assert.Equal("ok", level);
+        Assert.Contains("administrator", message); // reminds that the button is admin-only
+    }
+
+    [Fact]
+    public void DescribeInjection_PresentButNotWritable_IsError_AndMentionsWritable()
+    {
+        var (level, message) = Plugin.DescribeInjection(indexExists: true, scriptTagPresent: false, writable: false);
+        Assert.Equal("error", level);
+        Assert.Contains("writable", message);
+    }
+
+    [Fact]
+    public void DescribeInjection_WritableButNotInjected_IsWarning()
+    {
+        var (level, message) = Plugin.DescribeInjection(indexExists: true, scriptTagPresent: false, writable: true);
+        Assert.Equal("warning", level);
+        Assert.Contains("Re-inject", message);
+    }
+}

--- a/WhisperSubs.Tests/ScriptInjectionTests.cs
+++ b/WhisperSubs.Tests/ScriptInjectionTests.cs
@@ -92,6 +92,15 @@ public class ScriptInjectionTests
     }
 
     [Fact]
+    public void DescribeInjection_TagPresent_IsOkEvenWhenNotWritable()
+    {
+        // "ok" is keyed on the tag being present, NOT on writability — once injected, a read-only
+        // root is fine. A future refactor that gates "ok" on writable must fail this.
+        var (level, _) = Plugin.DescribeInjection(indexExists: true, scriptTagPresent: true, writable: false);
+        Assert.Equal("ok", level);
+    }
+
+    [Fact]
     public void DescribeInjection_PresentButNotWritable_IsError_AndMentionsWritable()
     {
         var (level, message) = Plugin.DescribeInjection(indexExists: true, scriptTagPresent: false, writable: false);

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.21.4.0</Version>
+    <Version>3.22.0.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.21.3.0</Version>
+    <Version>3.21.4.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
Two users (#94 reporter and @NoobOnTour024) couldn't see the in-page "Generate Subtitles" button or the three-dot menu item. Root cause: both come from `whisperSubs.js`, which the plugin injects into Jellyfin's `index.html` at startup (`Plugin.InjectClientScript`). When that injection doesn't stick — **read-only web root** (common in Docker), **no restart** after install/update, or a **cached page** — the script never loads, and there was **no way for an admin to tell why**.

## What this adds (v3.21.4.0)

**Config-page "In-page button & menu" panel** — shows whether the client script is currently injected, with a clear reason for each state:
- ✓ injected (reminds: hard-refresh + the button is admin-only)
- ✗ `index.html` not found
- ✗ present but **not writable** (read-only web root — the most common Docker cause)
- ⚠ not injected (a Jellyfin update likely replaced `index.html`)

**Re-inject button** — re-runs the injection on demand so an admin can fix the *fixable* cases (wiped-by-update / no-restart) **without restarting Jellyfin**. Read-only roots are reported honestly instead.

**Visible client log** — `whisperSubs.js` now logs load + admin status with `console.log` (was `console.debug`, which browsers hide by default), so an admin can confirm in DevTools that the script loaded and whether the admin-only gate passed.

**New admin endpoints:** `GET Setup/InjectionStatus`, `POST Setup/ReinjectScript` (both `RequiresElevation`).

## Implementation / tests
`InjectClientScript` refactored around pure, unit-tested helpers `ComputeInjection` (idempotent insert before `</head>`) and `DescribeInjection` (state → severity + guidance); the disk I/O stays `[ExcludeFromCodeCoverage]`. `ScriptInjectionTests` covers both. **607 tests pass**, build clean (0/0).

Refs #94.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a status panel in the configuration page showing whether the in-page subtitle script is injected, along with the current file path.
  * Added a one-click option to re-inject the script and refresh the displayed status.

* **Bug Fixes**
  * Improved script injection handling for cases where the page is missing, already updated, unwritable, or lacks a closing head tag.
  * Made status messages clearer and more responsive to the current page state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->