### PR TITLE
fix(integration): copy-paste chown/chmod remediation in the not-writable message (#94)

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -216,9 +216,10 @@ namespace WhisperSubs
                 var target = string.IsNullOrEmpty(indexHtmlPath) ? "your index.html" : indexHtmlPath;
                 return ("error",
                     "index.html is present but NOT writable, so the client script can't be injected (common with " +
-                    "read-only web roots in Docker). Make it writable by the Jellyfin user — e.g. on Linux: " +
-                    "sudo chown root:jellyfin \"" + target + "\" && sudo chmod 664 \"" + target + "\" — then click " +
-                    "Re-inject (or restart Jellyfin).");
+                    "read-only web roots in Docker). Make it writable by the Jellyfin service user, then click " +
+                    "Re-inject (or restart Jellyfin). On a Linux package install: sudo chown root:jellyfin \"" + target +
+                    "\" && sudo chmod 664 \"" + target + "\". On Docker the user/group differs (e.g. linuxserver.io " +
+                    "uses your PUID/PGID) and a read-only web mount must be made writable in your compose file.");
             }
 
             return ("warning",

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -166,7 +166,7 @@ namespace WhisperSubs
                 writable = IsWritable(path);
             }
 
-            var (level, message) = DescribeInjection(exists, tagPresent, writable);
+            var (level, message) = DescribeInjection(exists, tagPresent, writable, path);
             return new ScriptInjectionStatus
             {
                 WebPath = WebPath,
@@ -189,10 +189,11 @@ namespace WhisperSubs
         }
 
         /// <summary>
-        /// Pure: turns the three observable facts about index.html into a severity + user-facing
-        /// message for the config panel. Unit-tested so the guidance stays correct.
+        /// Pure: turns the observable facts about index.html into a severity + user-facing message for
+        /// the config panel. <paramref name="indexHtmlPath"/> is woven into the not-writable remediation
+        /// so the fix is copy-paste. Unit-tested so the guidance stays correct.
         /// </summary>
-        internal static (string Level, string Message) DescribeInjection(bool indexExists, bool scriptTagPresent, bool writable)
+        internal static (string Level, string Message) DescribeInjection(bool indexExists, bool scriptTagPresent, bool writable, string indexHtmlPath)
         {
             if (!indexExists)
             {
@@ -212,10 +213,12 @@ namespace WhisperSubs
 
             if (!writable)
             {
+                var target = string.IsNullOrEmpty(indexHtmlPath) ? "your index.html" : indexHtmlPath;
                 return ("error",
                     "index.html is present but NOT writable, so the client script can't be injected (common with " +
-                    "read-only web roots in Docker). Make the Jellyfin web directory writable, then click Re-inject " +
-                    "(or restart Jellyfin).");
+                    "read-only web roots in Docker). Make it writable by the Jellyfin user — e.g. on Linux: " +
+                    "sudo chown root:jellyfin \"" + target + "\" && sudo chmod 664 \"" + target + "\" — then click " +
+                    "Re-inject (or restart Jellyfin).");
             }
 
             return ("warning",

--- a/WhisperSubs.Tests/ScriptInjectionTests.cs
+++ b/WhisperSubs.Tests/ScriptInjectionTests.cs
@@ -78,7 +78,7 @@ public class ScriptInjectionTests
     [Fact]
     public void DescribeInjection_IndexMissing_IsError()
     {
-        var (level, message) = Plugin.DescribeInjection(indexExists: false, scriptTagPresent: false, writable: false);
+        var (level, message) = Plugin.DescribeInjection(indexExists: false, scriptTagPresent: false, writable: false, indexHtmlPath: "");
         Assert.Equal("error", level);
         Assert.Contains("index.html", message);
     }
@@ -86,7 +86,7 @@ public class ScriptInjectionTests
     [Fact]
     public void DescribeInjection_TagPresent_IsOk()
     {
-        var (level, message) = Plugin.DescribeInjection(indexExists: true, scriptTagPresent: true, writable: true);
+        var (level, message) = Plugin.DescribeInjection(indexExists: true, scriptTagPresent: true, writable: true, indexHtmlPath: "/web/index.html");
         Assert.Equal("ok", level);
         Assert.Contains("administrator", message); // reminds that the button is admin-only
     }
@@ -96,22 +96,28 @@ public class ScriptInjectionTests
     {
         // "ok" is keyed on the tag being present, NOT on writability — once injected, a read-only
         // root is fine. A future refactor that gates "ok" on writable must fail this.
-        var (level, _) = Plugin.DescribeInjection(indexExists: true, scriptTagPresent: true, writable: false);
+        var (level, _) = Plugin.DescribeInjection(indexExists: true, scriptTagPresent: true, writable: false, indexHtmlPath: "/web/index.html");
         Assert.Equal("ok", level);
     }
 
     [Fact]
     public void DescribeInjection_PresentButNotWritable_IsError_AndMentionsWritable()
     {
-        var (level, message) = Plugin.DescribeInjection(indexExists: true, scriptTagPresent: false, writable: false);
+        var (level, message) = Plugin.DescribeInjection(
+            indexExists: true, scriptTagPresent: false, writable: false,
+            indexHtmlPath: "/usr/share/jellyfin/web/index.html");
         Assert.Equal("error", level);
         Assert.Contains("writable", message);
+        // The remediation must be copy-paste: concrete chown/chmod with the real path.
+        Assert.Contains("chown", message);
+        Assert.Contains("chmod", message);
+        Assert.Contains("/usr/share/jellyfin/web/index.html", message);
     }
 
     [Fact]
     public void DescribeInjection_WritableButNotInjected_IsWarning()
     {
-        var (level, message) = Plugin.DescribeInjection(indexExists: true, scriptTagPresent: false, writable: true);
+        var (level, message) = Plugin.DescribeInjection(indexExists: true, scriptTagPresent: false, writable: true, indexHtmlPath: "/web/index.html");
         Assert.Equal("warning", level);
         Assert.Contains("Re-inject", message);
     }

--- a/WhisperSubs.Tests/ScriptInjectionTests.cs
+++ b/WhisperSubs.Tests/ScriptInjectionTests.cs
@@ -108,10 +108,23 @@ public class ScriptInjectionTests
             indexHtmlPath: "/usr/share/jellyfin/web/index.html");
         Assert.Equal("error", level);
         Assert.Contains("writable", message);
-        // The remediation must be copy-paste: concrete chown/chmod with the real path.
+        // The remediation must be copy-paste: concrete chown/chmod, the load-bearing 664 mode (644
+        // would NOT grant the jellyfin group write), and the real path QUOTED so paths with spaces
+        // stay valid.
         Assert.Contains("chown", message);
         Assert.Contains("chmod", message);
-        Assert.Contains("/usr/share/jellyfin/web/index.html", message);
+        Assert.Contains("664", message);
+        Assert.Contains("\"/usr/share/jellyfin/web/index.html\"", message);
+    }
+
+    [Fact]
+    public void DescribeInjection_NotWritable_EmptyPath_UsesGenericFallback()
+    {
+        // Defensive fallback when the path is somehow empty — still actionable, no dangling quotes.
+        var (level, message) = Plugin.DescribeInjection(indexExists: true, scriptTagPresent: false, writable: false, indexHtmlPath: "");
+        Assert.Equal("error", level);
+        Assert.Contains("your index.html", message);
+        Assert.Contains("chown", message);
     }
 
     [Fact]

--- a/WhisperSubs.Tests/ScriptInjectionTests.cs
+++ b/WhisperSubs.Tests/ScriptInjectionTests.cs
@@ -128,6 +128,17 @@ public class ScriptInjectionTests
     }
 
     [Fact]
+    public void DescribeInjection_NotWritable_QuotesPathWithSpaces()
+    {
+        // The whole reason the path is quoted: a web root with spaces must stay a single copy-paste
+        // argument. Drop the quotes and chown/chmod would split it — this case catches that regression.
+        const string spaced = "/srv/My Media/jellyfin web/index.html";
+        var (level, message) = Plugin.DescribeInjection(indexExists: true, scriptTagPresent: false, writable: false, indexHtmlPath: spaced);
+        Assert.Equal("error", level);
+        Assert.Contains("\"" + spaced + "\"", message); // appears as one quoted token, not bare
+    }
+
+    [Fact]
     public void DescribeInjection_WritableButNotInjected_IsWarning()
     {
         var (level, message) = Plugin.DescribeInjection(indexExists: true, scriptTagPresent: false, writable: true, indexHtmlPath: "/web/index.html");

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.22.0.0</Version>
+    <Version>3.22.1.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
Follow-up to #94 / v3.22.0.0. @NoobOnTour024 confirmed the root cause was exactly the read-only `index.html` case the new panel detects — and fixed it himself with `sudo chown root:jellyfin … && sudo chmod 664 …`. He suggested keeping that check in the interface (which v3.22.0.0 already does).

This makes the panel's "not writable" guidance **copy-paste** instead of abstract: it now shows the concrete remediation with the server's real `index.html` path:

> index.html is present but NOT writable … Make it writable by the Jellyfin user — e.g. on Linux: `sudo chown root:jellyfin "<path>" && sudo chmod 664 "<path>"` — then click Re-inject (or restart Jellyfin).

- `DescribeInjection` now takes the `indexHtmlPath` and weaves it into the not-writable message; the path is quoted so paths with spaces stay valid.
- `ScriptInjectionTests` updated for the new signature and now asserts the message carries `chown`/`chmod` + the real path.
- v3.22.1.0 (patch — message refinement). 608 tests pass, build clean.

Refs #94.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved guidance when script injection cannot be completed, including clearer file path details and actionable repair steps.
  * Made status messages more precise for missing, writable, and non-writable web files.
* **Tests**
  * Updated automated checks to cover the revised status and guidance messages.
* **Chores**
  * Bumped the app version to 3.22.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->