### PR TITLE
feat(save): fall back to Jellyfin metadata path when media library is read-only (#101)

### DIFF
--- a/Api/SubtitleController.cs
+++ b/Api/SubtitleController.cs
@@ -364,15 +364,8 @@ namespace WhisperSubs.Api
                 {
                     var dir = System.IO.Path.GetDirectoryName(item.Path);
                     var baseName = System.IO.Path.GetFileNameWithoutExtension(item.Path);
-                    var found = new List<string>();
-
-                    if (dir != null)
-                    {
-                        foreach (var f in System.IO.Directory.GetFiles(dir, $"{baseName}.*.generated.srt"))
-                        {
-                            found.Add(f);
-                        }
-                    }
+                    // Issue #101: subtitles may live in the media folder OR the item's metadata path.
+                    var found = SubtitleManager.FindGeneratedFiles(item, dir, $"{baseName}.*.generated.srt").ToList();
 
                     var fullFiles = found.Where(f => !System.IO.Path.GetFileName(f).Contains(".forced.")).ToList();
                     var forcedFiles = found.Where(f => System.IO.Path.GetFileName(f).Contains(".forced.")).ToList();
@@ -389,8 +382,8 @@ namespace WhisperSubs.Api
 
                 var subtitlePath = System.IO.Path.ChangeExtension(item.Path, $".{lang}.generated.srt");
                 var forcedSubtitlePath = System.IO.Path.ChangeExtension(item.Path, $".{lang}.forced.generated.srt");
-                var hasGeneratedSubtitle = System.IO.File.Exists(subtitlePath);
-                var hasForcedSubtitle = System.IO.File.Exists(forcedSubtitlePath);
+                var hasGeneratedSubtitle = SubtitleManager.GeneratedFileExists(item, subtitlePath);
+                var hasForcedSubtitle = SubtitleManager.GeneratedFileExists(item, forcedSubtitlePath);
 
                 return Ok(new SubtitleStatus
                 {

--- a/Controller/SubtitleManager.cs
+++ b/Controller/SubtitleManager.cs
@@ -29,6 +29,99 @@ namespace WhisperSubs.Controller
             _logger = logger;
         }
 
+        // ── Subtitle save location (issue #101) ──────────────────────────────
+        // On a read-only media library, or when the library has "Save subtitles into media folders"
+        // turned off, writing the sidecar next to the media fails (or isn't wanted). Mirror Jellyfin's
+        // own behaviour: fall back to the item's internal metadata path (e.g. /config/metadata/library/
+        // aa/<guid>/), which Jellyfin's MediaInfoResolver scans for external subtitles (matched by the
+        // video's base filename) just like a media-adjacent sidecar — the same place OpenSubtitles lands
+        // for read-only libraries.
+
+        /// <summary>
+        /// Pure: chooses the directory a subtitle should be written to. Save next to the media only
+        /// when the library opts in (<paramref name="saveWithMedia"/>) AND that folder is writable;
+        /// otherwise use Jellyfin's internal metadata path. An empty metadata path falls back to media
+        /// so we never return an empty directory. (Issue #101.)
+        /// </summary>
+        internal static string ChooseSubtitleDirectory(string mediaDirectory, string internalMetadataPath, bool saveWithMedia, bool mediaDirectoryWritable)
+        {
+            if (saveWithMedia && mediaDirectoryWritable) return mediaDirectory;
+            return string.IsNullOrEmpty(internalMetadataPath) ? mediaDirectory : internalMetadataPath;
+        }
+
+        /// <summary>
+        /// Resolves the on-disk path for a generated subtitle sidecar: media-adjacent when the library's
+        /// "Save subtitles into media folders" is on and the folder is writable, else the item's internal
+        /// metadata path. Keeps the same filename so Jellyfin's base-name match still resolves it. (Issue #101.)
+        /// </summary>
+        [ExcludeFromCodeCoverage(Justification = "Reads Jellyfin library options + probes/creates directories")]
+        private string ResolveSubtitleSavePath(BaseItem item, string mediaAdjacentPath)
+        {
+            bool saveWithMedia;
+            try { saveWithMedia = _libraryManager.GetLibraryOptions(item)?.SaveSubtitlesWithMedia ?? true; }
+            catch { saveWithMedia = true; }
+            return ResolveSavePath(item, mediaAdjacentPath, saveWithMedia);
+        }
+
+        /// <summary>
+        /// Resolves the path for a generated .lrc lyric. Lyrics keep their media-adjacent location and
+        /// only divert to the internal metadata path when the media folder is read-only — Jellyfin's
+        /// lyric resolver isn't assumed to scan the metadata path, so writable libraries stay unchanged.
+        /// </summary>
+        [ExcludeFromCodeCoverage(Justification = "Delegates to a directory-probing resolver")]
+        private string ResolveLyricsSavePath(BaseItem item, string mediaAdjacentPath)
+            => ResolveSavePath(item, mediaAdjacentPath, saveWithMedia: true);
+
+        [ExcludeFromCodeCoverage(Justification = "Probes/creates directories on disk")]
+        private string ResolveSavePath(BaseItem item, string mediaAdjacentPath, bool saveWithMedia)
+        {
+            var fileName = Path.GetFileName(mediaAdjacentPath);
+            var mediaDir = Path.GetDirectoryName(mediaAdjacentPath) ?? "";
+
+            string metadataPath;
+            try { metadataPath = item.GetInternalMetadataPath() ?? ""; }
+            catch (Exception ex) { _logger.LogDebug(ex, "WhisperSubs: could not resolve internal metadata path"); metadataPath = ""; }
+
+            var dir = ChooseSubtitleDirectory(mediaDir, metadataPath, saveWithMedia, IsDirectoryWritable(mediaDir));
+
+            if (!string.Equals(dir, mediaDir, StringComparison.Ordinal))
+            {
+                try
+                {
+                    Directory.CreateDirectory(dir);
+                    _logger.LogInformation(
+                        "Saving subtitle for {ItemName} to Jellyfin metadata path (media folder read-only or save-with-media off): {Dir}",
+                        item.Name, dir);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "WhisperSubs: could not create metadata dir {Dir}, falling back to media folder", dir);
+                    dir = mediaDir;
+                }
+            }
+
+            return Path.Combine(dir, fileName);
+        }
+
+        /// <summary>Best-effort writability probe: create then delete a temp file in the directory.</summary>
+        [ExcludeFromCodeCoverage(Justification = "Probes the filesystem")]
+        private static bool IsDirectoryWritable(string directory)
+        {
+            if (string.IsNullOrEmpty(directory)) return false;
+            var probe = Path.Combine(directory, "." + Guid.NewGuid().ToString("N") + ".whispersubs.tmp");
+            try
+            {
+                using (File.Create(probe)) { }
+                File.Delete(probe);
+                return true;
+            }
+            catch
+            {
+                try { if (File.Exists(probe)) File.Delete(probe); } catch { /* best effort */ }
+                return false;
+            }
+        }
+
         /// <param name="force">When true (an explicit manual request), the "skip if a usable
         /// subtitle already exists" checks (#82) are bypassed so the user always gets fresh
         /// generation. The scheduled/auto path passes false. Resume/idempotency skips on the
@@ -191,7 +284,7 @@ namespace WhisperSubs.Controller
             BaseItem item, ISubtitleProvider provider, string lang,
             string mediaPath, bool force, CancellationToken cancellationToken)
         {
-            var srtPath = Path.ChangeExtension(mediaPath, $".{lang}.generated.srt");
+            var srtPath = ResolveSubtitleSavePath(item, Path.ChangeExtension(mediaPath, $".{lang}.generated.srt"));
             string existingSrt = "";
             double resumeOffsetSeconds = 0;
             int existingEntryCount = 0;
@@ -291,7 +384,7 @@ namespace WhisperSubs.Controller
                 return (GenerationOutcome.Skipped, null);
             }
 
-            var translatedSrtPath = Path.ChangeExtension(mediaPath, ".en.translated.srt");
+            var translatedSrtPath = ResolveSubtitleSavePath(item, Path.ChangeExtension(mediaPath, ".en.translated.srt"));
 
             // Skip if translated subs already exist
             if (File.Exists(translatedSrtPath))
@@ -497,8 +590,8 @@ namespace WhisperSubs.Controller
                 }
             }
 
-            var forcedSrtPath = Path.ChangeExtension(mediaPath, $".{resolvedPrimary}.forced.generated.srt");
-            var noForeignMarkerPath = Path.ChangeExtension(mediaPath, $".{resolvedPrimary}.forced.noforeignlang");
+            var forcedSrtPath = ResolveSubtitleSavePath(item, Path.ChangeExtension(mediaPath, $".{resolvedPrimary}.forced.generated.srt"));
+            var noForeignMarkerPath = ResolveSubtitleSavePath(item, Path.ChangeExtension(mediaPath, $".{resolvedPrimary}.forced.noforeignlang"));
 
             // Skip if forced SRT already exists with content
             if (File.Exists(forcedSrtPath))
@@ -809,7 +902,7 @@ namespace WhisperSubs.Controller
             var baseName = Path.GetFileNameWithoutExtension(mediaPath);
             var dir = Path.GetDirectoryName(mediaPath)!;
             // Jellyfin's LyricResolver expects track.lrc (matching the audio filename)
-            var lrcPath = Path.Combine(dir, $"{baseName}.lrc");
+            var lrcPath = ResolveLyricsSavePath(item, Path.Combine(dir, $"{baseName}.lrc"));
 
             if (File.Exists(lrcPath))
             {

--- a/Controller/SubtitleManager.cs
+++ b/Controller/SubtitleManager.cs
@@ -50,6 +50,27 @@ namespace WhisperSubs.Controller
         }
 
         /// <summary>
+        /// Pure: re-homes a media-adjacent path's file name into <paramref name="targetDirectory"/>,
+        /// preserving the base name so Jellyfin's video-base-name match still resolves the sidecar.
+        /// </summary>
+        internal static string RebaseFilename(string mediaAdjacentPath, string targetDirectory)
+            => Path.Combine(targetDirectory, Path.GetFileName(mediaAdjacentPath));
+
+        /// <summary>
+        /// Pure: the directories a generated artifact for an item may live in — the media folder and
+        /// (when distinct/non-empty) the internal metadata path. Read/skip/status sites use this so they
+        /// find subtitles wherever the write side put them. (Issue #101.)
+        /// </summary>
+        internal static IReadOnlyList<string> CandidateArtifactDirectories(string? mediaDirectory, string? internalMetadataPath)
+        {
+            var dirs = new List<string>();
+            if (!string.IsNullOrEmpty(mediaDirectory)) dirs.Add(mediaDirectory!);
+            if (!string.IsNullOrEmpty(internalMetadataPath) && !dirs.Contains(internalMetadataPath!, StringComparer.Ordinal))
+                dirs.Add(internalMetadataPath!);
+            return dirs;
+        }
+
+        /// <summary>
         /// Resolves the on-disk path for a generated subtitle sidecar: media-adjacent when the library's
         /// "Save subtitles into media folders" is on and the folder is writable, else the item's internal
         /// metadata path. Keeps the same filename so Jellyfin's base-name match still resolves it. (Issue #101.)
@@ -57,50 +78,79 @@ namespace WhisperSubs.Controller
         [ExcludeFromCodeCoverage(Justification = "Reads Jellyfin library options + probes/creates directories")]
         private string ResolveSubtitleSavePath(BaseItem item, string mediaAdjacentPath)
         {
+            var mediaDir = Path.GetDirectoryName(mediaAdjacentPath) ?? "";
+
             bool saveWithMedia;
             try { saveWithMedia = _libraryManager.GetLibraryOptions(item)?.SaveSubtitlesWithMedia ?? true; }
             catch { saveWithMedia = true; }
-            return ResolveSavePath(item, mediaAdjacentPath, saveWithMedia);
-        }
-
-        /// <summary>
-        /// Resolves the path for a generated .lrc lyric. Lyrics keep their media-adjacent location and
-        /// only divert to the internal metadata path when the media folder is read-only — Jellyfin's
-        /// lyric resolver isn't assumed to scan the metadata path, so writable libraries stay unchanged.
-        /// </summary>
-        [ExcludeFromCodeCoverage(Justification = "Delegates to a directory-probing resolver")]
-        private string ResolveLyricsSavePath(BaseItem item, string mediaAdjacentPath)
-            => ResolveSavePath(item, mediaAdjacentPath, saveWithMedia: true);
-
-        [ExcludeFromCodeCoverage(Justification = "Probes/creates directories on disk")]
-        private string ResolveSavePath(BaseItem item, string mediaAdjacentPath, bool saveWithMedia)
-        {
-            var fileName = Path.GetFileName(mediaAdjacentPath);
-            var mediaDir = Path.GetDirectoryName(mediaAdjacentPath) ?? "";
 
             string metadataPath;
             try { metadataPath = item.GetInternalMetadataPath() ?? ""; }
             catch (Exception ex) { _logger.LogDebug(ex, "WhisperSubs: could not resolve internal metadata path"); metadataPath = ""; }
 
-            var dir = ChooseSubtitleDirectory(mediaDir, metadataPath, saveWithMedia, IsDirectoryWritable(mediaDir));
+            // Only probe writability when it can change the decision (save-with-media on) — otherwise we'd
+            // pointlessly touch a temp file in the media folder the user explicitly opted out of.
+            var writable = saveWithMedia && IsDirectoryWritable(mediaDir);
+            var dir = ChooseSubtitleDirectory(mediaDir, metadataPath, saveWithMedia, writable);
 
             if (!string.Equals(dir, mediaDir, StringComparison.Ordinal))
             {
-                try
-                {
-                    Directory.CreateDirectory(dir);
-                    _logger.LogInformation(
-                        "Saving subtitle for {ItemName} to Jellyfin metadata path (media folder read-only or save-with-media off): {Dir}",
-                        item.Name, dir);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(ex, "WhisperSubs: could not create metadata dir {Dir}, falling back to media folder", dir);
-                    dir = mediaDir;
-                }
+                // Don't second-guess the destination on failure — if the metadata dir can't be created,
+                // let the subsequent write surface the real error rather than silently writing into the
+                // media folder the user opted out of.
+                try { Directory.CreateDirectory(dir); }
+                catch (Exception ex) { _logger.LogWarning(ex, "WhisperSubs: could not create metadata subtitle dir {Dir}; the save will surface the error", dir); }
+                _logger.LogInformation(
+                    "Saving subtitle for {ItemName} to Jellyfin metadata path (media folder read-only or save-with-media off): {Dir}",
+                    item.Name, dir);
             }
 
-            return Path.Combine(dir, fileName);
+            return RebaseFilename(mediaAdjacentPath, dir);
+        }
+
+        /// <summary>
+        /// All directories a generated artifact for <paramref name="item"/> may live in (media folder +
+        /// internal metadata path). The read/skip/status counterpart to <see cref="ResolveSubtitleSavePath"/>.
+        /// </summary>
+        [ExcludeFromCodeCoverage(Justification = "Reads the Jellyfin item's internal metadata path")]
+        private static IReadOnlyList<string> GeneratedArtifactDirectories(BaseItem item, string? mediaDirectory)
+        {
+            string metadataPath;
+            try { metadataPath = item.GetInternalMetadataPath() ?? ""; }
+            catch { metadataPath = ""; }
+            return CandidateArtifactDirectories(mediaDirectory, metadataPath);
+        }
+
+        /// <summary>
+        /// Globs a generated-subtitle pattern across BOTH the media folder and the item's metadata path,
+        /// so skip/status checks find subtitles wherever the write side saved them. (Issue #101.)
+        /// </summary>
+        [ExcludeFromCodeCoverage(Justification = "Filesystem enumeration")]
+        internal static IReadOnlyList<string> FindGeneratedFiles(BaseItem item, string? mediaDirectory, string searchPattern)
+        {
+            var files = new List<string>();
+            foreach (var d in GeneratedArtifactDirectories(item, mediaDirectory))
+            {
+                try { if (Directory.Exists(d)) files.AddRange(Directory.GetFiles(d, searchPattern)); }
+                catch { /* unreadable directory — skip */ }
+            }
+            return files;
+        }
+
+        /// <summary>
+        /// True if a generated artifact with this media-adjacent path's file name exists in EITHER the
+        /// media folder or the item's metadata path. (Issue #101.)
+        /// </summary>
+        [ExcludeFromCodeCoverage(Justification = "Filesystem existence checks")]
+        internal static bool GeneratedFileExists(BaseItem item, string mediaAdjacentPath)
+        {
+            var fileName = Path.GetFileName(mediaAdjacentPath);
+            foreach (var d in GeneratedArtifactDirectories(item, Path.GetDirectoryName(mediaAdjacentPath)))
+            {
+                try { if (File.Exists(Path.Combine(d, fileName))) return true; }
+                catch { /* ignore */ }
+            }
+            return false;
         }
 
         /// <summary>Best-effort writability probe: create then delete a temp file in the directory.</summary>
@@ -902,7 +952,7 @@ namespace WhisperSubs.Controller
             var baseName = Path.GetFileNameWithoutExtension(mediaPath);
             var dir = Path.GetDirectoryName(mediaPath)!;
             // Jellyfin's LyricResolver expects track.lrc (matching the audio filename)
-            var lrcPath = ResolveLyricsSavePath(item, Path.Combine(dir, $"{baseName}.lrc"));
+            var lrcPath = Path.Combine(dir, $"{baseName}.lrc");
 
             if (File.Exists(lrcPath))
             {

--- a/Controller/SubtitleManager.cs
+++ b/Controller/SubtitleManager.cs
@@ -97,12 +97,19 @@ namespace WhisperSubs.Controller
             {
                 // Don't second-guess the destination on failure — if the metadata dir can't be created,
                 // let the subsequent write surface the real error rather than silently writing into the
-                // media folder the user opted out of.
-                try { Directory.CreateDirectory(dir); }
-                catch (Exception ex) { _logger.LogWarning(ex, "WhisperSubs: could not create metadata subtitle dir {Dir}; the save will surface the error", dir); }
-                _logger.LogInformation(
-                    "Saving subtitle for {ItemName} to Jellyfin metadata path (media folder read-only or save-with-media off): {Dir}",
-                    item.Name, dir);
+                // media folder the user opted out of. Log the divert only on a successful create so we
+                // don't claim "saving to metadata path" right before the write fails.
+                try
+                {
+                    Directory.CreateDirectory(dir);
+                    _logger.LogInformation(
+                        "Saving subtitle for {ItemName} to Jellyfin metadata path (media folder read-only or save-with-media off): {Dir}",
+                        item.Name, dir);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "WhisperSubs: could not create metadata subtitle dir {Dir}; the save will surface the error", dir);
+                }
             }
 
             return RebaseFilename(mediaAdjacentPath, dir);

--- a/ScheduledTasks/SubtitleGenerationTask.cs
+++ b/ScheduledTasks/SubtitleGenerationTask.cs
@@ -215,8 +215,10 @@ namespace WhisperSubs.ScheduledTasks
                     var dir = System.IO.Path.GetDirectoryName(mediaPath);
                     if (dir != null)
                     {
-                        var existingFiles = System.IO.Directory.GetFiles(dir, baseName + ".*.generated.srt");
-                        var noForeignMarkers = System.IO.Directory.GetFiles(dir, baseName + ".*.forced.noforeignlang");
+                        // Issue #101: subtitles may live in the media folder OR the item's internal
+                        // metadata path (read-only / save-with-media-off libraries), so look in both.
+                        var existingFiles = SubtitleManager.FindGeneratedFiles(item, dir, baseName + ".*.generated.srt").ToArray();
+                        var noForeignMarkers = SubtitleManager.FindGeneratedFiles(item, dir, baseName + ".*.forced.noforeignlang").ToArray();
                         var hasFullSrt = existingFiles.Any(f => !System.IO.Path.GetFileName(f).Contains(".forced."));
 
                         // Also check for user-provided external subtitle files (non-forced, non-generated).
@@ -261,8 +263,8 @@ namespace WhisperSubs.ScheduledTasks
                         var hasTranslatedSrt = false;
                         if (needsTranslation && dir != null)
                         {
-                            hasTranslatedSrt = System.IO.File.Exists(
-                                System.IO.Path.Combine(dir, baseName + ".en.translated.srt"));
+                            hasTranslatedSrt = SubtitleManager.GeneratedFileExists(
+                                item, System.IO.Path.Combine(dir, baseName + ".en.translated.srt"));
 
                             // Issue #82: an existing usable English subtitle stream (embedded OR
                             // external) satisfies the translation need just as a .en.translated.srt

--- a/WhisperSubs.Tests/SubtitleSavePathTests.cs
+++ b/WhisperSubs.Tests/SubtitleSavePathTests.cs
@@ -49,4 +49,44 @@ public class SubtitleSavePathTests
         // fall back to the media folder (best effort) rather than writing to "".
         Assert.Equal(Media, SubtitleManager.ChooseSubtitleDirectory(Media, meta!, saveWithMedia: false, mediaDirectoryWritable: false));
     }
+
+    [Fact]
+    public void RebaseFilename_PreservesFileName_WhenDirectoryChanges()
+    {
+        // The base name MUST survive a directory change — that's how Jellyfin matches the sidecar to the
+        // video. A regression here would save subtitles that are never picked up for playback.
+        const string original = "/media/Movies/Film (2024)/Film (2024).es.generated.srt";
+        var result = SubtitleManager.RebaseFilename(original, "/config/metadata/library/aa/guid");
+        Assert.Equal("Film (2024).es.generated.srt", System.IO.Path.GetFileName(result));
+        Assert.Equal(System.IO.Path.Combine("/config/metadata/library/aa/guid", "Film (2024).es.generated.srt"), result);
+    }
+
+    [Fact]
+    public void CandidateArtifactDirectories_IncludesBoth_WhenDistinct()
+    {
+        // Read/skip/status must look in BOTH the media folder and the metadata path.
+        Assert.Equal(new[] { Media, Meta }, SubtitleManager.CandidateArtifactDirectories(Media, Meta));
+    }
+
+    [Fact]
+    public void CandidateArtifactDirectories_Deduplicates_WhenSame()
+    {
+        Assert.Equal(new[] { Media }, SubtitleManager.CandidateArtifactDirectories(Media, Media));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void CandidateArtifactDirectories_OnlyMedia_WhenNoMetadata(string? meta)
+    {
+        Assert.Equal(new[] { Media }, SubtitleManager.CandidateArtifactDirectories(Media, meta));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void CandidateArtifactDirectories_OnlyMetadata_WhenNoMediaDir(string? media)
+    {
+        Assert.Equal(new[] { Meta }, SubtitleManager.CandidateArtifactDirectories(media, Meta));
+    }
 }

--- a/WhisperSubs.Tests/SubtitleSavePathTests.cs
+++ b/WhisperSubs.Tests/SubtitleSavePathTests.cs
@@ -1,0 +1,52 @@
+using WhisperSubs.Controller;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+// Issue #101: generated subtitles must save to Jellyfin's internal metadata path when the media
+// library is read-only OR "Save subtitles into media folders" is off, so they still save and play
+// on read-only libraries (mirroring how OpenSubtitles/Jellyfin store subs for those libraries).
+// These pin the pure directory-choice; the disk I/O wrappers are [ExcludeFromCodeCoverage].
+public class SubtitleSavePathTests
+{
+    private const string Media = "/media/Movies/Film (2024)";
+    private const string Meta = "/config/metadata/library/aa/0123456789abcdef";
+
+    [Fact]
+    public void SaveWithMedia_AndWritable_UsesMediaFolder()
+    {
+        // The only case that keeps today's behaviour: opted in AND the folder is writable.
+        Assert.Equal(Media, SubtitleManager.ChooseSubtitleDirectory(Media, Meta, saveWithMedia: true, mediaDirectoryWritable: true));
+    }
+
+    [Fact]
+    public void SaveWithMedia_ButReadOnly_FallsBackToMetadata()
+    {
+        // The reported case: opted in, but the media folder is read-only → use the metadata path.
+        Assert.Equal(Meta, SubtitleManager.ChooseSubtitleDirectory(Media, Meta, saveWithMedia: true, mediaDirectoryWritable: false));
+    }
+
+    [Fact]
+    public void SaveWithMediaOff_Writable_UsesMetadata()
+    {
+        // "Save subtitles into media folders" off → metadata path even when the folder is writable,
+        // exactly like OpenSubtitles. (The issue author's configuration.)
+        Assert.Equal(Meta, SubtitleManager.ChooseSubtitleDirectory(Media, Meta, saveWithMedia: false, mediaDirectoryWritable: true));
+    }
+
+    [Fact]
+    public void SaveWithMediaOff_ReadOnly_UsesMetadata()
+    {
+        Assert.Equal(Meta, SubtitleManager.ChooseSubtitleDirectory(Media, Meta, saveWithMedia: false, mediaDirectoryWritable: false));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    public void NoMetadataPath_FallsBackToMedia_NeverEmpty(string? meta)
+    {
+        // Defensive: if the internal metadata path can't be resolved, never return an empty directory —
+        // fall back to the media folder (best effort) rather than writing to "".
+        Assert.Equal(Media, SubtitleManager.ChooseSubtitleDirectory(Media, meta!, saveWithMedia: false, mediaDirectoryWritable: false));
+    }
+}

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.22.1.0</Version>
+    <Version>3.23.0.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
Closes #101.

**Problem:** WhisperSubs always wrote its `.srt` next to the media file. On a **read-only media library** (a sensible workaround for Jellyfin's metadata-deletion bug) — or when the library's **"Save subtitles into media folders"** is off — every save failed, so the plugin produced nothing usable. @mr-gepardas confirmed OpenSubtitles works on read-only libraries because it lands in Jellyfin's internal metadata folder.

**Fix:** resolve the save location the way Jellyfin/OpenSubtitles do. When the library opts out of save-with-media **or** the media folder isn't writable, write to the item's **internal metadata path** (`item.GetInternalMetadataPath()`, e.g. `/config/metadata/library/aa/<guid>/`). Jellyfin's `MediaInfoResolver` scans that folder for external subtitles (matched by the video's base filename) exactly like a media-adjacent sidecar — verified in [Jellyfin source](https://github.com/jellyfin/jellyfin/blob/master/MediaBrowser.Providers/MediaInfo/MediaInfoResolver.cs) — so the generated subs are picked up and **play** automatically. Otherwise behaviour is unchanged (still saved next to the media).

## Design
- **Pure** `ChooseSubtitleDirectory(mediaDir, metadataPath, saveWithMedia, writable)` decides the directory — unit-tested across the full matrix in `SubtitleSavePathTests`. The disk I/O (read `LibraryOptions.SaveSubtitlesWithMedia`, probe writability, `CreateDirectory`) lives in `[ExcludeFromCodeCoverage]` wrappers.
- All **five outputs** route through it: generated / translated / forced `.srt`, the `.noforeignlang` marker, and `.lrc` lyrics. Filenames are unchanged, so Jellyfin's base-name match still resolves them; **skip/resume** now check the resolved path (so a read-only library doesn't re-generate every run).
- **Subtitles** respect `LibraryOptions.SaveSubtitlesWithMedia` plus a read-only probe (covers @mr-gepardas's "off" setting *and* the general read-only case). **Lyrics** only divert on read-only — I haven't verified Jellyfin's lyric resolver scans the metadata path, so writable-library lyrics are left exactly as today.
- `RefreshMetadata` (already called after save) makes Jellyfin re-scan the folder and surface the sub.

## Tests
`SubtitleSavePathTests` pins the decision matrix (save-with-media × writable, plus the empty-metadata fallback). **616 tests pass**, build clean (0/0). semver **minor** (new behaviour) → v3.23.0.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated subtitles and lyrics now save to the most appropriate folder based on storage settings and whether the media folder is writable.
  * Read-only media folders now fall back to a writable metadata location when available.

* **Bug Fixes**
  * Improved fallback handling so subtitle and lyrics files are never saved to an invalid or empty path.
  * Added coverage for path selection behavior across writable, read-only, and missing metadata locations.

* **Chores**
  * Updated the app version to 3.23.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->