### PR TITLE
fix: transcription resilience — bound calls, atomic writes, fail-fast (v3.29.0.0)

### DIFF
--- a/Configuration/PluginConfiguration.cs
+++ b/Configuration/PluginConfiguration.cs
@@ -269,6 +269,24 @@ namespace WhisperSubs.Configuration
         /// <summary>Global cap on total user-originated requests that are pending or queued at once. 0 = unlimited. Default 500.</summary>
         public int UserRequestGlobalCap { get; set; } = 500;
 
+        // ── Remote/worker call resilience (v4.0) ─────────────────────────────
+        // Every remote transcription call is bounded by a deadline derived from the audio length, instead
+        // of the old fixed 30-minute HttpClient.Timeout that let an unreachable endpoint pile up into a
+        // multi-day stuck task. See TranscriptionTimeout.Compute.
+
+        /// <summary>
+        /// Upper bound on how much slower than real-time a remote worker may run before a single call is
+        /// presumed hung and cancelled. Per-call deadline = audio-length × this factor (clamped). A
+        /// slow-but-working pass is never cut off; a dead endpoint is. Default 6.
+        /// </summary>
+        public double JobTimeoutRealtimeFactor { get; set; } = 6.0;
+
+        /// <summary>Floor for the per-call deadline in seconds, so a tiny detection chunk still gets a sane minimum. Default 60.</summary>
+        public int JobMinTimeoutSeconds { get; set; } = 60;
+
+        /// <summary>Absolute cap for the per-call deadline in hours — a genuinely long film's worst case still fits under it. Default 12.</summary>
+        public int JobMaxTimeoutHours { get; set; } = 12;
+
         public PluginConfiguration()
         {
         }

--- a/Controller/SubtitleManager.cs
+++ b/Controller/SubtitleManager.cs
@@ -29,6 +29,18 @@ namespace WhisperSubs.Controller
             _logger = logger;
         }
 
+        // ── Atomic sidecar writes (v4.0 resilience) ──────────────────────────
+        // Write to a temp file then rename over the target, so a crash or torn write can never leave a
+        // truncated .srt/.lrc that the resume-parser (which reads the file's last timestamp) misreads, and
+        // a reader never observes a half-written file. Rename is atomic on the same filesystem.
+        [ExcludeFromCodeCoverage(Justification = "Filesystem I/O")]
+        private static async Task WriteTextAtomicAsync(string path, string content, CancellationToken cancellationToken)
+        {
+            var tmp = path + ".tmp";
+            await File.WriteAllTextAsync(tmp, content, cancellationToken).ConfigureAwait(false);
+            File.Move(tmp, path, overwrite: true);
+        }
+
         // ── Subtitle save location (issue #101) ──────────────────────────────
         // On a read-only media library, or when the library has "Save subtitles into media folders"
         // turned off, writing the sidecar next to the media fails (or isn't wanted). Mirror Jellyfin's
@@ -418,7 +430,7 @@ namespace WhisperSubs.Controller
                     srtContent = existingSrt.TrimEnd() + "\n\n" + offsetContent;
                 }
 
-                await File.WriteAllTextAsync(srtPath, srtContent, CancellationToken.None);
+                await WriteTextAtomicAsync(srtPath, srtContent, CancellationToken.None);
                 _logger.LogInformation("Saved full subtitle to {SrtPath}", srtPath);
                 return (GenerationOutcome.Succeeded, null);
             }
@@ -580,7 +592,7 @@ namespace WhisperSubs.Controller
                 string srtContent = await provider.TranscribeAsync(tempAudioPath, sourceLanguage, cancellationToken, translate: true);
                 srtContent = await ApplyTimingCorrectionsAsync(srtContent, mediaPath, tempAudioPath, isResume: false, providerUsesVad: provider.UsesVad, cancellationToken);
 
-                await File.WriteAllTextAsync(translatedSrtPath, srtContent, CancellationToken.None);
+                await WriteTextAtomicAsync(translatedSrtPath, srtContent, CancellationToken.None);
                 _logger.LogInformation("Saved translated subtitle to {SrtPath}", translatedSrtPath);
                 return (GenerationOutcome.Succeeded, null);
             }
@@ -741,6 +753,8 @@ namespace WhisperSubs.Controller
                     await whisperProvider.WaitForDetectionModelAsync(cancellationToken);
                 }
 
+                int consecutiveFailures = 0;
+                const int maxConsecutiveDetectionFailures = 3;
                 for (int i = 0; i < chunks.Count; i++)
                 {
                     cancellationToken.ThrowIfCancellationRequested();
@@ -757,6 +771,7 @@ namespace WhisperSubs.Controller
                         await ExtractAudioChunkAsync(fullAudioPath, chunkPath, chunk.Start, chunkDuration, cancellationToken);
                         var (detectedLang, probability) = await provider.DetectLanguageAsync(chunkPath, cancellationToken);
                         successfulDetections++;
+                        consecutiveFailures = 0;
 
                         _logger.LogDebug("Chunk {Index}/{Total}: {Start:F1}s-{End:F1}s → {Language} (p={Prob:F3})",
                             i + 1, chunks.Count, chunk.Start, chunk.End, detectedLang, probability);
@@ -767,10 +782,26 @@ namespace WhisperSubs.Controller
                             foreignChunks.Add((chunk.Start, chunk.End, detectedLang));
                         }
                     }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                    {
+                        throw; // a genuine caller cancellation must propagate, not count as a detection failure
+                    }
                     catch (Exception ex)
                     {
-                        _logger.LogWarning(ex, "Language detection failed for chunk {Index} ({Start:F1}s-{End:F1}s), skipping",
-                            i, chunk.Start, chunk.End);
+                        consecutiveFailures++;
+                        _logger.LogWarning(ex, "Language detection failed for chunk {Index} ({Start:F1}s-{End:F1}s), skipping ({Consecutive}/{Max} consecutive)",
+                            i, chunk.Start, chunk.End, consecutiveFailures, maxConsecutiveDetectionFailures);
+
+                        // Fail-fast: a worker/endpoint that fails this many chunks in a row is down. Abort the
+                        // whole item now instead of grinding every remaining chunk × its per-call deadline —
+                        // the behaviour that turned an unreachable endpoint into a multi-hour stuck task.
+                        if (consecutiveFailures >= maxConsecutiveDetectionFailures)
+                        {
+                            _logger.LogError("Aborting forced-subtitle detection for {ItemName}: {Count} consecutive language-detection failures (worker/endpoint likely down)",
+                                item.Name, consecutiveFailures);
+                            return (GenerationOutcome.Failed, new InvalidOperationException(
+                                $"Aborted forced-subtitle detection for {item.Name} after {consecutiveFailures} consecutive language-detection failures (worker/endpoint likely down)."));
+                        }
                     }
                 }
 
@@ -857,7 +888,7 @@ namespace WhisperSubs.Controller
                 // Step 8: Save forced SRT
                 if (forcedSrt.Length > 0)
                 {
-                    await File.WriteAllTextAsync(forcedSrtPath, forcedSrt.ToString(), CancellationToken.None);
+                    await WriteTextAtomicAsync(forcedSrtPath, forcedSrt.ToString(), CancellationToken.None);
                     _logger.LogInformation("Saved forced subtitle to {Path} ({Entries} entries)",
                         forcedSrtPath, entryNum - 1);
                     return (GenerationOutcome.Succeeded, null);
@@ -996,7 +1027,7 @@ namespace WhisperSubs.Controller
                 string srtContent = await provider.TranscribeAsync(tempAudioPath, lang, cancellationToken);
                 string lrcContent = ConvertSrtToLrc(srtContent, item.Name);
 
-                await File.WriteAllTextAsync(lrcPath, lrcContent, CancellationToken.None);
+                await WriteTextAtomicAsync(lrcPath, lrcContent, CancellationToken.None);
                 _logger.LogInformation("Saved lyrics to {LrcPath}", lrcPath);
                 return (GenerationOutcome.Succeeded, null);
             }

--- a/Controller/SubtitleManager.cs
+++ b/Controller/SubtitleManager.cs
@@ -36,9 +36,20 @@ namespace WhisperSubs.Controller
         [ExcludeFromCodeCoverage(Justification = "Filesystem I/O")]
         private static async Task WriteTextAtomicAsync(string path, string content, CancellationToken cancellationToken)
         {
-            var tmp = path + ".tmp";
-            await File.WriteAllTextAsync(tmp, content, cancellationToken).ConfigureAwait(false);
-            File.Move(tmp, path, overwrite: true);
+            // Unique temp name so two workers writing the SAME sidecar to a shared filesystem never collide
+            // on one .tmp (a torn write, or a FileNotFound on the loser's rename). Best-effort cleanup so a
+            // mid-write crash leaves no orphan .tmp behind.
+            var tmp = path + "." + Guid.NewGuid().ToString("N") + ".tmp";
+            try
+            {
+                await File.WriteAllTextAsync(tmp, content, cancellationToken).ConfigureAwait(false);
+                File.Move(tmp, path, overwrite: true);
+            }
+            catch
+            {
+                try { if (File.Exists(tmp)) File.Delete(tmp); } catch { /* best-effort cleanup */ }
+                throw;
+            }
         }
 
         // ── Subtitle save location (issue #101) ──────────────────────────────

--- a/Controller/TranscriptionTimeout.cs
+++ b/Controller/TranscriptionTimeout.cs
@@ -1,0 +1,43 @@
+using System;
+
+namespace WhisperSubs.Controller
+{
+    /// <summary>
+    /// Pure per-call transcription-timeout policy (v4.0 resilience foundation). A remote worker call is
+    /// bounded by a deadline derived from the AUDIO LENGTH, not a fixed wall-clock timeout: a short
+    /// language-detection chunk gets a small deadline; a feature-length film gets a large one — but both
+    /// are bounded. This closes the "70-hour stuck task" class of bug, where an unreachable/stalled
+    /// endpoint blocked for the fixed 30-minute <c>HttpClient.Timeout</c> on every one of hundreds of
+    /// per-chunk calls across a library scan.
+    /// </summary>
+    public static class TranscriptionTimeout
+    {
+        // The plugin extracts audio as 16 kHz mono signed-16-bit PCM WAV, i.e. 16000 samples/s x 2 bytes
+        // = 32000 bytes of audio per second (the ~44-byte header is negligible). So audio-seconds can be
+        // estimated straight from the WAV file size without probing it.
+        internal const double BytesPerAudioSecond = 32000.0;
+
+        /// <summary>
+        /// The deadline for a single transcription/detection call: estimated audio-seconds x
+        /// <paramref name="realtimeFactor"/>, clamped to
+        /// [<paramref name="minSeconds"/>, <paramref name="maxHours"/>]. The factor is a generous upper
+        /// bound on how much slower than real-time a healthy worker may run before it is presumed hung —
+        /// so a slow-but-working large-v3 pass is never guillotined, while a dead endpoint is cut off fast.
+        /// Non-positive settings fall back to safe defaults (factor 6, floor 60s, cap 12h).
+        /// </summary>
+        public static TimeSpan Compute(long audioBytes, double realtimeFactor, int minSeconds, int maxHours)
+        {
+            double factor = realtimeFactor > 0 ? realtimeFactor : 6.0;
+            double min = minSeconds > 0 ? minSeconds : 60;
+            double maxSeconds = (maxHours > 0 ? maxHours : 12) * 3600.0;
+
+            double audioSeconds = Math.Max(0, audioBytes) / BytesPerAudioSecond;
+            double seconds = audioSeconds * factor;
+
+            if (seconds < min) seconds = min;
+            if (seconds > maxSeconds) seconds = maxSeconds;
+
+            return TimeSpan.FromSeconds(seconds);
+        }
+    }
+}

--- a/Controller/TranscriptionTimeout.cs
+++ b/Controller/TranscriptionTimeout.cs
@@ -17,6 +17,11 @@ namespace WhisperSubs.Controller
         // estimated straight from the WAV file size without probing it.
         internal const double BytesPerAudioSecond = 32000.0;
 
+        // CancellationTokenSource.CancelAfter throws if the delay exceeds int.MaxValue ms (~596 hours).
+        // The computed deadline is used as a CancelAfter delay, so it must never exceed this ceiling —
+        // even for an absurdly large maxHours config that would otherwise break every remote call.
+        internal const double MaxDeadlineSeconds = int.MaxValue / 1000.0;
+
         /// <summary>
         /// The deadline for a single transcription/detection call: estimated audio-seconds x
         /// <paramref name="realtimeFactor"/>, clamped to
@@ -30,6 +35,7 @@ namespace WhisperSubs.Controller
             double factor = realtimeFactor > 0 ? realtimeFactor : 6.0;
             double min = minSeconds > 0 ? minSeconds : 60;
             double maxSeconds = (maxHours > 0 ? maxHours : 12) * 3600.0;
+            if (maxSeconds > MaxDeadlineSeconds) maxSeconds = MaxDeadlineSeconds; // stay CancelAfter-safe
 
             double audioSeconds = Math.Max(0, audioBytes) / BytesPerAudioSecond;
             double seconds = audioSeconds * factor;

--- a/Providers/RemoteWhisperProvider.cs
+++ b/Providers/RemoteWhisperProvider.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -6,6 +7,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using WhisperSubs.Controller;
 
 namespace WhisperSubs.Providers
 {
@@ -17,25 +19,36 @@ namespace WhisperSubs.Providers
             ConnectTimeout = TimeSpan.FromSeconds(10),
         })
         {
-            Timeout = TimeSpan.FromMinutes(30),
+            // Per-call deadlines (TranscriptionTimeout, applied via a linked CancellationTokenSource) are
+            // the authority — so a long-but-healthy transcription is never guillotined and a hung call is
+            // still bounded. The old fixed 30-minute timeout was the root of the multi-day stuck-task bug.
+            Timeout = Timeout.InfiniteTimeSpan,
         };
 
         private readonly ILogger _logger;
         private readonly string _apiUrl;
         private readonly string _model;
         private readonly string _apiKey;
+        private readonly double _realtimeFactor;
+        private readonly int _minTimeoutSeconds;
+        private readonly int _maxTimeoutHours;
 
         public string Name => "RemoteWhisper";
 
         /// <summary>Remote API returns its own timestamps; no local VAD involvement.</summary>
         public bool UsesVad => false;
 
-        public RemoteWhisperProvider(ILogger logger, string apiUrl, string model, string apiKey = "")
+        [ExcludeFromCodeCoverage(Justification = "Construction + HTTPS-key warning; no unit-testable logic")]
+        public RemoteWhisperProvider(ILogger logger, string apiUrl, string model, string apiKey = "",
+            double realtimeFactor = 6.0, int minTimeoutSeconds = 60, int maxTimeoutHours = 12)
         {
             _logger = logger;
             _apiUrl = apiUrl.TrimEnd('/');
             _model = model;
             _apiKey = (apiKey ?? string.Empty).Trim();
+            _realtimeFactor = realtimeFactor;
+            _minTimeoutSeconds = minTimeoutSeconds;
+            _maxTimeoutHours = maxTimeoutHours;
 
             if (!string.IsNullOrEmpty(_apiKey) &&
                 Uri.TryCreate(_apiUrl, UriKind.Absolute, out var uri) &&
@@ -55,6 +68,7 @@ namespace WhisperSubs.Providers
             }
         }
 
+        [ExcludeFromCodeCoverage(Justification = "HTTP I/O; the pure deadline policy is tested in TranscriptionTimeoutTests")]
         public async Task<string> TranscribeAsync(string audioPath, string language, CancellationToken cancellationToken, bool translate = false)
         {
             if (!File.Exists(audioPath))
@@ -69,10 +83,13 @@ namespace WhisperSubs.Providers
             _logger.LogInformation("Sending audio to remote Whisper API: {Endpoint} [lang={Language}, translate={Translate}]",
                 endpoint, language, translate);
 
-            using var content = new MultipartFormDataContent();
+            long audioBytes = new FileInfo(audioPath).Length;
 
-            var audioBytes = await File.ReadAllBytesAsync(audioPath, cancellationToken).ConfigureAwait(false);
-            var fileContent = new ByteArrayContent(audioBytes);
+            using var content = new MultipartFormDataContent();
+            // Stream the WAV rather than File.ReadAllBytes: a 2h film is ~260 MB, and N parallel workers
+            // buffering that in RAM is a direct OOM path. StreamContent's file stream is disposed with the
+            // MultipartFormDataContent.
+            var fileContent = new StreamContent(File.OpenRead(audioPath));
             fileContent.Headers.ContentType = new MediaTypeHeaderValue("audio/wav");
             content.Add(fileContent, "file", "audio.wav");
 
@@ -85,18 +102,7 @@ namespace WhisperSubs.Providers
                 content.Add(new StringContent(language), "language");
             }
 
-            using var request = new HttpRequestMessage(HttpMethod.Post, endpoint) { Content = content };
-            ApplyAuthorization(request);
-
-            using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
-
-            if (!response.IsSuccessStatusCode)
-            {
-                var errorBody = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-                throw new HttpRequestException($"Remote Whisper API returned {(int)response.StatusCode}: {errorBody}");
-            }
-
-            var srt = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            var srt = await PostAudioAsync(endpoint, content, audioBytes, cancellationToken).ConfigureAwait(false);
 
             if (string.IsNullOrWhiteSpace(srt))
             {
@@ -107,6 +113,7 @@ namespace WhisperSubs.Providers
             return srt;
         }
 
+        [ExcludeFromCodeCoverage(Justification = "HTTP I/O; the pure deadline policy is tested in TranscriptionTimeoutTests")]
         public async Task<(string Language, float Probability)> DetectLanguageAsync(string audioPath, CancellationToken cancellationToken)
         {
             if (!File.Exists(audioPath))
@@ -116,10 +123,10 @@ namespace WhisperSubs.Providers
 
             _logger.LogInformation("Detecting language via remote Whisper API for {AudioPath}", audioPath);
 
-            using var content = new MultipartFormDataContent();
+            long audioBytes = new FileInfo(audioPath).Length;
 
-            var audioBytes = await File.ReadAllBytesAsync(audioPath, cancellationToken).ConfigureAwait(false);
-            var fileContent = new ByteArrayContent(audioBytes);
+            using var content = new MultipartFormDataContent();
+            var fileContent = new StreamContent(File.OpenRead(audioPath));
             fileContent.Headers.ContentType = new MediaTypeHeaderValue("audio/wav");
             content.Add(fileContent, "file", "audio.wav");
 
@@ -127,18 +134,7 @@ namespace WhisperSubs.Providers
             content.Add(new StringContent("verbose_json"), "response_format");
 
             var endpoint = $"{_apiUrl}/v1/audio/transcriptions";
-            using var request = new HttpRequestMessage(HttpMethod.Post, endpoint) { Content = content };
-            ApplyAuthorization(request);
-
-            using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
-
-            if (!response.IsSuccessStatusCode)
-            {
-                var errorBody = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-                throw new HttpRequestException($"Remote Whisper API returned {(int)response.StatusCode}: {errorBody}");
-            }
-
-            var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            var json = await PostAudioAsync(endpoint, content, audioBytes, cancellationToken).ConfigureAwait(false);
 
             using var doc = JsonDocument.Parse(json);
             var root = doc.RootElement;
@@ -152,6 +148,42 @@ namespace WhisperSubs.Providers
             _logger.LogInformation("Remote language detection: {Language}", language);
 
             return (language, 0.0f);
+        }
+
+        /// <summary>
+        /// POSTs a prepared multipart body under a per-call deadline derived from the audio length
+        /// (<see cref="TranscriptionTimeout"/>). A caller cancellation propagates as
+        /// <see cref="OperationCanceledException"/>; the deadline elapsing surfaces as a
+        /// <see cref="TimeoutException"/> so a stalled/unreachable endpoint fails fast and clearly instead
+        /// of hanging (the multi-day stuck-task class of bug).
+        /// </summary>
+        [ExcludeFromCodeCoverage(Justification = "HTTP I/O; the pure deadline policy is tested in TranscriptionTimeoutTests")]
+        private async Task<string> PostAudioAsync(string endpoint, MultipartFormDataContent content, long audioBytes, CancellationToken cancellationToken)
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Post, endpoint) { Content = content };
+            ApplyAuthorization(request);
+
+            var deadline = TranscriptionTimeout.Compute(audioBytes, _realtimeFactor, _minTimeoutSeconds, _maxTimeoutHours);
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(deadline);
+
+            try
+            {
+                using var response = await _httpClient.SendAsync(request, timeoutCts.Token).ConfigureAwait(false);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    var errorBody = await response.Content.ReadAsStringAsync(timeoutCts.Token).ConfigureAwait(false);
+                    throw new HttpRequestException($"Remote Whisper API returned {(int)response.StatusCode}: {errorBody}");
+                }
+
+                return await response.Content.ReadAsStringAsync(timeoutCts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                throw new TimeoutException(
+                    $"Remote Whisper API call exceeded its {deadline.TotalSeconds:F0}s deadline (endpoint slow or unreachable): {endpoint}");
+            }
         }
 
         private static string NormalizeLangName(string lang)

--- a/Providers/SubtitleProviderFactory.cs
+++ b/Providers/SubtitleProviderFactory.cs
@@ -20,7 +20,10 @@ namespace WhisperSubs.Providers
                     loggerFactory.CreateLogger<RemoteWhisperProvider>(),
                     config.RemoteWhisperApiUrl,
                     model,
-                    apiKey);
+                    apiKey,
+                    config.JobTimeoutRealtimeFactor,
+                    config.JobMinTimeoutSeconds,
+                    config.JobMaxTimeoutHours);
             }
 
             var setup = new WhisperSetupService(

--- a/WhisperSubs.Tests/ConfigurationTests.cs
+++ b/WhisperSubs.Tests/ConfigurationTests.cs
@@ -8,6 +8,16 @@ namespace WhisperSubs.Tests;
 public class ConfigurationTests
 {
     [Fact]
+    public void JobTimeoutDefaults_AreSafe()
+    {
+        // v4.0 resilience: per-call deadline policy defaults (closes the 70h-stuck class).
+        var config = new PluginConfiguration();
+        Assert.Equal(6.0, config.JobTimeoutRealtimeFactor);
+        Assert.Equal(60, config.JobMinTimeoutSeconds);
+        Assert.Equal(12, config.JobMaxTimeoutHours);
+    }
+
+    [Fact]
     public void RequestQueueDefaults_AreSafeAndOptIn()
     {
         var config = new PluginConfiguration();

--- a/WhisperSubs.Tests/TranscriptionTimeoutTests.cs
+++ b/WhisperSubs.Tests/TranscriptionTimeoutTests.cs
@@ -51,6 +51,16 @@ public class TranscriptionTimeoutTests
     }
 
     [Fact]
+    public void Compute_NeverExceedsCancelAfterCeiling()
+    {
+        // An absurd maxHours must not yield a deadline above CancellationTokenSource.CancelAfter's
+        // int.MaxValue-ms limit (~596h) — that would throw on every remote call. Huge audio × huge factor
+        // × a 1,000,000-hour cap still clamps to the safe ceiling.
+        var d = TranscriptionTimeout.Compute(long.MaxValue / 2, 1e9, 60, 1_000_000);
+        Assert.True(d.TotalMilliseconds <= int.MaxValue, $"deadline {d} exceeds the CancelAfter ceiling");
+    }
+
+    [Fact]
     public void Compute_HonorsCustomFactorAndBounds()
     {
         // factor 2, floor 30s, cap 1h.

--- a/WhisperSubs.Tests/TranscriptionTimeoutTests.cs
+++ b/WhisperSubs.Tests/TranscriptionTimeoutTests.cs
@@ -1,0 +1,61 @@
+using WhisperSubs.Controller;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+/// <summary>
+/// v4.0 resilience: the per-call deadline policy that closes the "70-hour stuck task" class — an
+/// unreachable endpoint used to block for the fixed 30-minute HTTP timeout on every one of hundreds of
+/// per-chunk calls. The deadline scales with the audio length and is clamped both ways.
+/// </summary>
+public class TranscriptionTimeoutTests
+{
+    // The plugin extracts 16 kHz mono s16le WAV = 32000 bytes per audio-second.
+    private static long Bytes(double audioSeconds) => (long)(audioSeconds * 32000);
+
+    [Fact]
+    public void Compute_ScalesWithAudioLength()
+    {
+        // 10 min audio × factor 6 = 3600s, inside [60s, 12h].
+        Assert.Equal(3600, TranscriptionTimeout.Compute(Bytes(600), 6.0, 60, 12).TotalSeconds, 0);
+    }
+
+    [Fact]
+    public void Compute_ClampsToFloor_ForTinyAudio()
+    {
+        // A ~5s detection chunk × 6 = 30s → floored to the 60s minimum.
+        Assert.Equal(60, TranscriptionTimeout.Compute(Bytes(5), 6.0, 60, 12).TotalSeconds, 0);
+    }
+
+    [Fact]
+    public void Compute_ClampsToCap_ForVeryLongAudio()
+    {
+        // A 2h15m film × 6 = 48600s → capped at 12h = 43200s (bounded, but never guillotines a real run).
+        Assert.Equal(43200, TranscriptionTimeout.Compute(Bytes(8100), 6.0, 60, 12).TotalSeconds, 0);
+    }
+
+    [Theory]
+    [InlineData(0L)]
+    [InlineData(-100000L)]
+    public void Compute_NonPositiveBytes_FallToFloor(long bytes)
+    {
+        Assert.Equal(60, TranscriptionTimeout.Compute(bytes, 6.0, 60, 12).TotalSeconds, 0);
+    }
+
+    [Fact]
+    public void Compute_NonPositiveSettings_UseSafeDefaults()
+    {
+        // factor<=0 → 6, min<=0 → 60, maxHours<=0 → 12.
+        Assert.Equal(3600, TranscriptionTimeout.Compute(Bytes(600), 0, 0, 0).TotalSeconds, 0);
+        Assert.Equal(60, TranscriptionTimeout.Compute(Bytes(1), -1, -1, -1).TotalSeconds, 0);
+    }
+
+    [Fact]
+    public void Compute_HonorsCustomFactorAndBounds()
+    {
+        // factor 2, floor 30s, cap 1h.
+        Assert.Equal(200, TranscriptionTimeout.Compute(Bytes(100), 2.0, 30, 1).TotalSeconds, 0);   // 100s × 2
+        Assert.Equal(1200, TranscriptionTimeout.Compute(Bytes(600), 2.0, 30, 1).TotalSeconds, 0);  // 10 min × 2
+        Assert.Equal(3600, TranscriptionTimeout.Compute(Bytes(2400), 2.0, 30, 1).TotalSeconds, 0); // 40 min × 2 → 1h cap
+    }
+}

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.28.0.0</Version>
+    <Version>3.29.0.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
**First PR of the v4.0 distributed-transcription series** (→ integration branch `v4-dev`; `main`/release stays gated). Pure correctness, no schema change — **valuable even single-server**.

Root-causes and fixes the *70-hour stuck task* class:

- **Per-call deadline** — each remote transcription/detection call is bounded by a deadline derived from the audio length (`TranscriptionTimeout.Compute`: 6× realtime, 60s floor, 12h cap), replacing the fixed 30-minute `HttpClient.Timeout` that let an unreachable endpoint block on every one of hundreds of per-chunk calls. A deadline surfaces as a clear `TimeoutException`; a caller cancel still propagates.
- **Fail-fast** — the forced-subtitle detection loop aborts the item after 3 consecutive failures (endpoint down) instead of grinding every chunk; genuine cancellation now propagates.
- **Atomic writes** — `.srt`/`.lrc` sidecars are temp-then-rename, so a crash/torn write can't leave a truncated file the resume-parser misreads (the state-corruption class behind the recent failed plugin update).
- **Stream the WAV** (`StreamContent`) instead of buffering ~260 MB × N workers in RAM.

Config: `JobTimeoutRealtimeFactor` / `JobMinTimeoutSeconds` / `JobMaxTimeoutHours`. Pure policy 100% unit-tested; I/O paths excluded like the existing orchestration. **843 tests pass.**

Part of the v4.0 worker-pool design; general for any user/topology, single-server default unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote transcription jobs now use smarter time limits based on audio length, with configurable minimum and maximum bounds.
  * Subtitle and lyric files are now written more safely to reduce the risk of incomplete output after interruptions.

* **Bug Fixes**
  * Improved resilience when language detection fails repeatedly during forced subtitle generation, so failures stop sooner and surface clearly.

* **Tests**
  * Added coverage for timeout calculations and default configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->