### PR TITLE
feat(workers): worker model + cost-weighted routing + config (v4.0 PR 2/5)

### DIFF
--- a/Configuration/PluginConfiguration.cs
+++ b/Configuration/PluginConfiguration.cs
@@ -287,6 +287,24 @@ namespace WhisperSubs.Configuration
         /// <summary>Absolute cap for the per-call deadline in hours — a genuinely long film's worst case still fits under it. Default 12.</summary>
         public int JobMaxTimeoutHours { get; set; } = 12;
 
+        // ── Worker pool (v4.0; power-user feature, empty by default) ─────────
+        // Simple by default: a normal single-server install leaves Workers empty and EnableLocalWorker on,
+        // so the plugin behaves exactly as today (the host's own whisper, one job at a time). Power users
+        // add extra OpenAI-compatible endpoints below to transcribe in parallel across machines.
+
+        /// <summary>
+        /// Extra OpenAI-compatible transcription workers to pool alongside the local one. EMPTY for the
+        /// common single-server install. Power users add a second box, a NAS, or a cloud endpoint here.
+        /// </summary>
+        public List<WhisperWorker> Workers { get; set; } = new List<WhisperWorker>();
+
+        /// <summary>
+        /// Whether the Jellyfin host's own local whisper participates as a worker. Default true (the normal
+        /// case). Set false to transcribe ONLY on the configured remote workers — e.g. a weak NAS offloading
+        /// entirely to a beefier box (the pre-v4 behaviour when only a single remote URL was set).
+        /// </summary>
+        public bool EnableLocalWorker { get; set; } = true;
+
         public PluginConfiguration()
         {
         }

--- a/Configuration/WhisperWorker.cs
+++ b/Configuration/WhisperWorker.cs
@@ -1,0 +1,37 @@
+namespace WhisperSubs.Configuration
+{
+    /// <summary>
+    /// One configured extra transcription worker (v4.0 worker pool). This list is EMPTY for a normal
+    /// single-server install — the plugin then just uses the host's own local whisper, exactly as today.
+    /// A power user adds entries here to pool additional OpenAI-compatible endpoints (a second box, a NAS,
+    /// a cloud API). Plain mutable class so it round-trips through the plugin's XML config.
+    /// </summary>
+    public class WhisperWorker
+    {
+        /// <summary>Stable id (dispatch/dedup key); survives a rename.</summary>
+        public string Id { get; set; } = "";
+
+        /// <summary>Display label, e.g. "nas-igpu".</summary>
+        public string Name { get; set; } = "";
+
+        public bool Enabled { get; set; } = true;
+
+        /// <summary>OpenAI-compatible base URL, e.g. <c>http://192.168.1.10:8080</c>.</summary>
+        public string ApiUrl { get; set; } = "";
+
+        /// <summary>Optional bearer token for this worker.</summary>
+        public string ApiKey { get; set; } = "";
+
+        /// <summary>Model to request; empty = the worker's own default / any.</summary>
+        public string Model { get; set; } = "";
+
+        /// <summary>Simultaneous jobs this worker runs; keep 1 per single GPU. Default 1.</summary>
+        public int MaxConcurrency { get; set; } = 1;
+
+        /// <summary>Selection cost: 0 = free/local-priced (preferred); &gt;0 = paid, used only to burst. Default 0.</summary>
+        public double CostWeight { get; set; } = 0;
+
+        /// <summary>Whether this worker can translate to English. Default true.</summary>
+        public bool CanTranslate { get; set; } = true;
+    }
+}

--- a/Controller/Workers/ITranscriptionWorker.cs
+++ b/Controller/Workers/ITranscriptionWorker.cs
@@ -1,0 +1,23 @@
+using WhisperSubs.Providers;
+
+namespace WhisperSubs.Controller.Workers
+{
+    /// <summary>
+    /// A transcription worker (v4.0 pool): a stable identity + advertised <see cref="WorkerCapabilities"/>
+    /// + the <see cref="ISubtitleProvider"/> that does the actual work — the host's own local whisper-cli
+    /// or any remote OpenAI-compatible endpoint. The dispatcher (PR-3) tracks live in-flight load
+    /// separately and snapshots each worker into a <see cref="WorkerSlot"/> for routing, so this stays a
+    /// thin, immutable descriptor.
+    /// </summary>
+    public interface ITranscriptionWorker
+    {
+        string Id { get; }
+        string Name { get; }
+        ISubtitleProvider Provider { get; }
+        WorkerCapabilities Capabilities { get; }
+    }
+
+    /// <summary>Default worker: an id/name + the provider that transcribes + its advertised capabilities.</summary>
+    public sealed record TranscriptionWorker(
+        string Id, string Name, ISubtitleProvider Provider, WorkerCapabilities Capabilities) : ITranscriptionWorker;
+}

--- a/Controller/Workers/WorkerModel.cs
+++ b/Controller/Workers/WorkerModel.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+
+namespace WhisperSubs.Controller.Workers
+{
+    /// <summary>
+    /// Static, slow-changing facts a transcription worker advertises so the scheduler can route a job to it
+    /// without any backend-specific conditionals (v4.0 worker pool). A "worker" is the host's own local
+    /// whisper-cli OR any remote OpenAI-compatible endpoint (CPU faster-whisper, NVIDIA/CUDA, AMD/ROCm, a
+    /// NAS, a cloud API — the user's choice). This model is deliberately backend-agnostic so the pool serves
+    /// any user's topology, not one reference setup.
+    /// </summary>
+    public sealed record WorkerCapabilities
+    {
+        /// <summary>Max jobs this worker runs at once. Default 1 — a single GPU saturates on one whisper stream.</summary>
+        public int MaxConcurrency { get; init; } = 1;
+
+        /// <summary>Whether the worker can translate to English (OpenAI /v1/audio/translations, or whisper-cli --translate).</summary>
+        public bool CanTranslate { get; init; } = true;
+
+        /// <summary>Models the worker can serve; empty = "any" (the common homelab case, and the local worker).</summary>
+        public IReadOnlySet<string> Models { get; init; } = new HashSet<string>();
+
+        /// <summary>A free local worker (the host's own CPU/GPU, or a LAN box) vs a paid/remote one.</summary>
+        public bool IsLocal { get; init; } = true;
+
+        /// <summary>Selection cost: 0 = free local (always preferred); &gt;0 = paid/cloud, used only to burst when locals are full.</summary>
+        public double CostWeight { get; init; }
+
+        /// <summary>Stable tiebreak among otherwise-equal workers. Lower = preferred.</summary>
+        public int Priority { get; init; }
+    }
+
+    /// <summary>A live routing snapshot of one worker — a pure value (no Jellyfin/HTTP types), so selection is unit-testable.</summary>
+    public readonly record struct WorkerSlot(string Id, bool Healthy, int InFlight, WorkerCapabilities Capabilities);
+
+    /// <summary>What a specific job needs from a worker (drives the hard capability filter).</summary>
+    public readonly record struct JobRequirements(bool Translate, string? RequiredModel);
+}

--- a/Controller/Workers/WorkerPlan.cs
+++ b/Controller/Workers/WorkerPlan.cs
@@ -1,0 +1,35 @@
+namespace WhisperSubs.Controller.Workers
+{
+    /// <summary>Which set of workers the pool should be built from (backward-compatibility).</summary>
+    public enum WorkerSource
+    {
+        /// <summary>The admin configured an explicit <c>Workers</c> list.</summary>
+        ExplicitList,
+        /// <summary>No list, but a legacy single <c>RemoteWhisperApiUrl</c> is set — remote-only, as pre-v4.</summary>
+        LegacyRemote,
+        /// <summary>Nothing configured — the host's own local whisper only (today's default).</summary>
+        LocalOnly
+    }
+
+    /// <summary>
+    /// Pure backward-compatibility decision for composing the worker pool (v4.0). Guarantees that a normal
+    /// single-server install with no new config behaves EXACTLY as today, and that an existing legacy
+    /// single-remote-URL install stays remote-only (the host's local whisper is not silently activated — a
+    /// behaviour change that would otherwise surprise an upgrading remote-offload user).
+    /// </summary>
+    public static class WorkerPlan
+    {
+        /// <summary>
+        /// Decide the worker composition. An explicit <c>Workers</c> list wins, plus the local worker when
+        /// <paramref name="enableLocalWorker"/>. Otherwise a legacy <c>RemoteWhisperApiUrl</c> means
+        /// remote-ONLY (local not added, exactly the pre-v4 behaviour). Otherwise: local only.
+        /// </summary>
+        public static (WorkerSource Source, bool AddLocal) Decide(
+            int explicitWorkerCount, bool hasLegacyRemoteUrl, bool enableLocalWorker)
+        {
+            if (explicitWorkerCount > 0) return (WorkerSource.ExplicitList, enableLocalWorker);
+            if (hasLegacyRemoteUrl) return (WorkerSource.LegacyRemote, false);
+            return (WorkerSource.LocalOnly, true);
+        }
+    }
+}

--- a/Controller/Workers/WorkerScheduling.cs
+++ b/Controller/Workers/WorkerScheduling.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+
+namespace WhisperSubs.Controller.Workers
+{
+    /// <summary>
+    /// Pure worker-selection policy (v4.0), mirroring the codebase's other unit-tested decision helpers
+    /// (<see cref="PriorityScheduling"/>). Given the highest-priority job already chosen by the queue, it
+    /// picks the cheapest capable worker with a free slot. "Prefer local, burst to a paid worker only when
+    /// every local one is saturated" falls out of the cost-weighted score — no special-casing, no backend
+    /// names in the logic.
+    /// </summary>
+    public static class WorkerScheduling
+    {
+        /// <summary>Hard constraints — can this worker serve this job right now?</summary>
+        public static bool CanServe(WorkerSlot s, JobRequirements job)
+            => s.Healthy
+               && s.InFlight < s.Capabilities.MaxConcurrency
+               && (!job.Translate || s.Capabilities.CanTranslate)
+               && (job.RequiredModel is null
+                   || s.Capabilities.Models.Count == 0            // empty = serves any model
+                   || s.Capabilities.Models.Contains(job.RequiredModel));
+
+        /// <summary>
+        /// Soft preference — lower is better. A local worker's <c>CostWeight</c> is 0, so its score is
+        /// dominated by load and it always beats any paid worker; a paid worker (CostWeight &gt; 0) is only
+        /// ever the minimum when no local worker can serve the job.
+        /// </summary>
+        public static double Score(WorkerSlot s)
+            => s.Capabilities.CostWeight * 1_000_000.0   // 0 for local ⇒ strictly beats any paid worker
+               + s.InFlight * 1000.0                     // spread load: prefer the least-busy
+               + s.Capabilities.Priority;                // stable, admin-tunable tiebreak
+
+        /// <summary>
+        /// The best worker for a job: the minimum-<see cref="Score"/> worker that <see cref="CanServe"/>s it,
+        /// ties broken by ordinal Id for determinism. Null means nothing is feasible right now — the caller
+        /// re-queues the job (never fails it).
+        /// </summary>
+        public static WorkerSlot? Pick(IReadOnlyList<WorkerSlot> slots, JobRequirements job)
+        {
+            WorkerSlot? best = null;
+            double bestScore = double.MaxValue;
+            foreach (var s in slots)
+            {
+                if (!CanServe(s, job)) continue;
+                var score = Score(s);
+                bool better = best is null
+                    || score < bestScore
+                    || (score == bestScore && string.CompareOrdinal(s.Id, best.Value.Id) < 0);
+                if (better)
+                {
+                    best = s;
+                    bestScore = score;
+                }
+            }
+            return best;
+        }
+    }
+}

--- a/WhisperSubs.Tests/ConfigurationTests.cs
+++ b/WhisperSubs.Tests/ConfigurationTests.cs
@@ -18,6 +18,26 @@ public class ConfigurationTests
     }
 
     [Fact]
+    public void WorkerPoolDefaults_AreSimpleAndEmpty()
+    {
+        // Simple by default: no extra workers + local worker on ⇒ today's single-server behaviour (v4.0).
+        var config = new PluginConfiguration();
+        Assert.NotNull(config.Workers);
+        Assert.Empty(config.Workers);
+        Assert.True(config.EnableLocalWorker);
+    }
+
+    [Fact]
+    public void WhisperWorker_Defaults()
+    {
+        var w = new WhisperWorker();
+        Assert.True(w.Enabled);
+        Assert.Equal(1, w.MaxConcurrency);
+        Assert.Equal(0, w.CostWeight);
+        Assert.True(w.CanTranslate);
+    }
+
+    [Fact]
     public void RequestQueueDefaults_AreSafeAndOptIn()
     {
         var config = new PluginConfiguration();

--- a/WhisperSubs.Tests/WorkerPlanTests.cs
+++ b/WhisperSubs.Tests/WorkerPlanTests.cs
@@ -1,0 +1,42 @@
+using WhisperSubs.Controller.Workers;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+/// <summary>
+/// v4.0 worker pool backward-compatibility. The composition decision must keep a normal single-server
+/// install identical to today, and a legacy remote-offload install remote-only.
+/// </summary>
+public class WorkerPlanTests
+{
+    [Fact]
+    public void NoConfig_IsLocalOnly()
+    {
+        // The overwhelming common case: no workers, no remote URL ⇒ the host's own whisper, exactly as today.
+        var (source, addLocal) = WorkerPlan.Decide(explicitWorkerCount: 0, hasLegacyRemoteUrl: false, enableLocalWorker: true);
+        Assert.Equal(WorkerSource.LocalOnly, source);
+        Assert.True(addLocal);
+    }
+
+    [Fact]
+    public void LegacyRemoteUrl_IsRemoteOnly_NeverAddsLocal()
+    {
+        // Pre-v4, setting a remote URL sent ALL work remote and never touched the local whisper. Preserve
+        // that: even with EnableLocalWorker at its default true, a legacy remote install stays remote-only.
+        var (source, addLocal) = WorkerPlan.Decide(explicitWorkerCount: 0, hasLegacyRemoteUrl: true, enableLocalWorker: true);
+        Assert.Equal(WorkerSource.LegacyRemote, source);
+        Assert.False(addLocal);
+    }
+
+    [Fact]
+    public void ExplicitList_UsesList_PlusLocalWhenEnabled()
+    {
+        var withLocal = WorkerPlan.Decide(explicitWorkerCount: 2, hasLegacyRemoteUrl: false, enableLocalWorker: true);
+        Assert.Equal(WorkerSource.ExplicitList, withLocal.Source);
+        Assert.True(withLocal.AddLocal);
+
+        var withoutLocal = WorkerPlan.Decide(explicitWorkerCount: 2, hasLegacyRemoteUrl: true, enableLocalWorker: false);
+        Assert.Equal(WorkerSource.ExplicitList, withoutLocal.Source);   // explicit list wins even over a legacy URL
+        Assert.False(withoutLocal.AddLocal);
+    }
+}

--- a/WhisperSubs.Tests/WorkerSchedulingTests.cs
+++ b/WhisperSubs.Tests/WorkerSchedulingTests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using WhisperSubs.Controller.Workers;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+/// <summary>
+/// v4.0 worker pool: the pure selection policy. Verifies the hard capability filter and the cost-weighted
+/// "prefer local, burst to paid only when locals are saturated" behaviour that must hold for any topology.
+/// </summary>
+public class WorkerSchedulingTests
+{
+    private static WorkerCapabilities Caps(bool local = true, double cost = 0, int maxConc = 1,
+        bool canTranslate = true, int priority = 0, string[]? models = null)
+        => new()
+        {
+            IsLocal = local, CostWeight = cost, MaxConcurrency = maxConc, CanTranslate = canTranslate,
+            Priority = priority, Models = new HashSet<string>(models ?? Array.Empty<string>())
+        };
+
+    private static WorkerSlot Slot(string id, bool healthy = true, int inFlight = 0, WorkerCapabilities? caps = null)
+        => new(id, healthy, inFlight, caps ?? Caps());
+
+    private static readonly JobRequirements AnyJob = new(false, null);
+
+    // ── CanServe (hard constraints) ──
+    [Fact] public void CanServe_HealthyFreeWorker_True()
+        => Assert.True(WorkerScheduling.CanServe(Slot("a"), AnyJob));
+
+    [Fact] public void CanServe_Unhealthy_False()
+        => Assert.False(WorkerScheduling.CanServe(Slot("a", healthy: false), AnyJob));
+
+    [Fact] public void CanServe_AtCapacity_False()
+        => Assert.False(WorkerScheduling.CanServe(Slot("a", inFlight: 1, caps: Caps(maxConc: 1)), AnyJob));
+
+    [Fact] public void CanServe_TranslateJob_NeedsTranslateCapability()
+    {
+        var job = new JobRequirements(true, null);
+        Assert.False(WorkerScheduling.CanServe(Slot("a", caps: Caps(canTranslate: false)), job));
+        Assert.True(WorkerScheduling.CanServe(Slot("b", caps: Caps(canTranslate: true)), job));
+    }
+
+    [Fact] public void CanServe_ModelConstraint()
+    {
+        var job = new JobRequirements(false, "large-v3");
+        Assert.True(WorkerScheduling.CanServe(Slot("any"), job));                                        // empty models = any
+        Assert.True(WorkerScheduling.CanServe(Slot("has", caps: Caps(models: new[] { "large-v3" })), job));
+        Assert.False(WorkerScheduling.CanServe(Slot("no", caps: Caps(models: new[] { "small" })), job));
+    }
+
+    // ── Pick (prefer local, burst to paid) ──
+    [Fact] public void Pick_PrefersLocalOverPaid()
+    {
+        var local = Slot("local", caps: Caps(local: true, cost: 0));
+        var cloud = Slot("cloud", caps: Caps(local: false, cost: 5));
+        Assert.Equal("local", WorkerScheduling.Pick(new[] { cloud, local }, AnyJob)!.Value.Id);
+    }
+
+    [Fact] public void Pick_BurstsToPaid_OnlyWhenLocalsSaturated()
+    {
+        var localFull = Slot("local", inFlight: 1, caps: Caps(local: true, cost: 0, maxConc: 1));
+        var cloud = Slot("cloud", caps: Caps(local: false, cost: 5));
+        Assert.Equal("cloud", WorkerScheduling.Pick(new[] { localFull, cloud }, AnyJob)!.Value.Id);
+    }
+
+    [Fact] public void Pick_PrefersLeastBusyAmongEqualCost()
+    {
+        var busy = Slot("busy", inFlight: 1, caps: Caps(cost: 0, maxConc: 3));
+        var idle = Slot("idle", inFlight: 0, caps: Caps(cost: 0, maxConc: 3));
+        Assert.Equal("idle", WorkerScheduling.Pick(new[] { busy, idle }, AnyJob)!.Value.Id);
+    }
+
+    [Fact] public void Pick_PriorityTiebreak()
+    {
+        var lo = Slot("x", caps: Caps(cost: 0, priority: 10));
+        var hi = Slot("y", caps: Caps(cost: 0, priority: 1));
+        Assert.Equal("y", WorkerScheduling.Pick(new[] { lo, hi }, AnyJob)!.Value.Id);
+    }
+
+    [Fact] public void Pick_DeterministicTiebreakById()
+    {
+        // Identical everything → lowest ordinal Id wins, deterministically.
+        Assert.Equal("a", WorkerScheduling.Pick(new[] { Slot("b"), Slot("a") }, AnyJob)!.Value.Id);
+    }
+
+    [Fact] public void Pick_NullWhenNothingFeasible()
+    {
+        var full = Slot("a", inFlight: 1, caps: Caps(maxConc: 1));
+        var down = Slot("b", healthy: false);
+        Assert.Null(WorkerScheduling.Pick(new[] { full, down }, AnyJob));
+        Assert.Null(WorkerScheduling.Pick(Array.Empty<WorkerSlot>(), AnyJob));
+    }
+}


### PR DESCRIPTION
PR 2 of the v4.0 worker-pool series (→ v4-dev). Pure decision core + config, backend-agnostic and simple-by-default; no runtime behaviour change yet (dispatcher is PR-3).

- WorkerCapabilities / WorkerSlot / JobRequirements — pure routing model for local whisper-cli + any remote OpenAI-compatible endpoint.
- WorkerScheduling.CanServe/Score/Pick — pure, 100%-tested: hard capability filter + cost-weighted score so local workers always win, paid/cloud only bursts when locals are saturated.
- Config: List<WhisperWorker> (EMPTY default) + EnableLocalWorker (on) — normal single-server install untouched; power users add endpoints.
- ITranscriptionWorker + WorkerPlan.Decide — backward-compat: no config → local only; legacy single RemoteWhisperApiUrl → remote-only; explicit list → those + optional local.

All new pure logic 100% covered. 860 tests pass.