### PR TITLE
feat(workers): N-slot pool dispatcher replacing the global TranscriptionLock (v4.0 PR-3)

### DIFF
--- a/Api/SubtitleController.cs
+++ b/Api/SubtitleController.cs
@@ -193,8 +193,7 @@ namespace WhisperSubs.Api
 
                 // Ensure the background drain worker is running
                 var manager = GetSubtitleManager();
-                var provider = SubtitleProviderFactory.Create(config, _loggerFactory);
-                queue.EnsureDraining(manager, provider, _logger, CancellationToken.None);
+                queue.EnsureDispatching(manager, config, _loggerFactory, _logger, CancellationToken.None);
 
                 return Accepted(new
                 {
@@ -264,8 +263,7 @@ namespace WhisperSubs.Api
 
                 // Ensure the background drain worker is running
                 var manager = GetSubtitleManager();
-                var provider = SubtitleProviderFactory.Create(config, _loggerFactory);
-                queue.EnsureDraining(manager, provider, _logger, CancellationToken.None);
+                queue.EnsureDispatching(manager, config, _loggerFactory, _logger, CancellationToken.None);
 
                 return Accepted(new
                 {

--- a/Controller/PriorityLanes.cs
+++ b/Controller/PriorityLanes.cs
@@ -109,6 +109,34 @@ namespace WhisperSubs.Controller
             }
         }
 
+        /// <summary>
+        /// Removes and returns the highest-priority entry whose value satisfies <paramref name="canDequeue"/>,
+        /// scanning lanes in priority order then FIFO within a lane. Strict tier order is preserved: a
+        /// lower-priority entry is returned only when no acceptable higher-priority one exists. Used by the
+        /// worker-pool dispatcher to skip a head job that no currently-free worker can serve (v4.0).
+        /// </summary>
+        public bool TryDequeue(Func<T, bool> canDequeue, out T value)
+        {
+            lock (_gate)
+            {
+                foreach (var lane in _lanes.Values)
+                {
+                    for (var node = lane.First; node != null; node = node.Next)
+                    {
+                        if (canDequeue(node.Value.Value))
+                        {
+                            value = node.Value.Value;
+                            RemoveNode(node);
+                            return true;
+                        }
+                    }
+                }
+
+                value = default!;
+                return false;
+            }
+        }
+
         /// <summary>Removes a specific key if queued. Returns true if it was present.</summary>
         public bool Remove(string key)
         {

--- a/Controller/SubtitleQueueService.cs
+++ b/Controller/SubtitleQueueService.cs
@@ -377,7 +377,7 @@ namespace WhisperSubs.Controller
                 {
                     try
                     {
-                        await DispatchDrainAsync(manager, pool, requirements, logger, cancellationToken);
+                        await DispatchDrainAsync(manager, pool, requirements, countProcessed: true, logger, cancellationToken);
                     }
                     finally
                     {
@@ -410,6 +410,7 @@ namespace WhisperSubs.Controller
             SubtitleManager manager,
             WorkerPool pool,
             JobRequirements requirements,
+            bool countProcessed,
             ILogger logger,
             CancellationToken cancellationToken)
         {
@@ -421,7 +422,9 @@ namespace WhisperSubs.Controller
             {
                 while (TryDequeuePriority(out var unservable) && unservable != null)
                 {
-                    Interlocked.Increment(ref _processedCount);
+                    // Match the old counting: the background loop counted a failure toward `processed`,
+                    // the scheduled task's priority drain did not (countProcessed distinguishes them).
+                    if (countProcessed) Interlocked.Increment(ref _processedCount);
                     Interlocked.Increment(ref _failedCount);
                     _lastError = $"{unservable.Item.Name}: no configured worker can serve this job";
                     unservable.Completion?.TrySetException(
@@ -467,7 +470,7 @@ namespace WhisperSubs.Controller
                         {
                             await manager.GenerateSubtitleAsync(
                                 wi.Item, l.Worker.Provider, wi.Language, cancellationToken, wi.Force);
-                            Interlocked.Increment(ref _processedCount);
+                            if (countProcessed) Interlocked.Increment(ref _processedCount);
                             wi.Completion?.TrySetResult(true);
                         }
                         catch (System.OperationCanceledException)
@@ -476,7 +479,7 @@ namespace WhisperSubs.Controller
                         }
                         catch (System.Exception ex)
                         {
-                            Interlocked.Increment(ref _processedCount);
+                            if (countProcessed) Interlocked.Increment(ref _processedCount);
                             Interlocked.Increment(ref _failedCount);
                             _lastError = $"{wi.Item.Name}: {ex.Message}";
                             wi.Completion?.TrySetException(ex);
@@ -519,7 +522,9 @@ namespace WhisperSubs.Controller
             ILogger logger,
             CancellationToken cancellationToken)
         {
-            await DispatchDrainAsync(manager, pool, requirements, logger, cancellationToken);
+            // countProcessed:false — the old priority drain did not add to _processedCount (only the
+            // background loop did), so the /Queue `processed` stat stays byte-identical to pre-v4.
+            await DispatchDrainAsync(manager, pool, requirements, countProcessed: false, logger, cancellationToken);
             _currentItemName = null;
         }
     }

--- a/Controller/SubtitleQueueService.cs
+++ b/Controller/SubtitleQueueService.cs
@@ -6,7 +6,9 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using WhisperSubs.Configuration;
 using WhisperSubs.Providers;
+using WhisperSubs.Controller.Workers;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using Microsoft.Extensions.Logging;
@@ -73,11 +75,43 @@ namespace WhisperSubs.Controller
         private string? _lastError;
         private static readonly object _fileLock = new();
 
+        // The single shared worker pool (v4.0) — the concurrency gate for ALL transcription, replacing the
+        // former global TranscriptionLock(1,1). Built lazily from config and rebuilt (see GetPool) only at a
+        // session start when the other consumer is idle and no jobs are in flight, so adding/removing a worker
+        // takes effect between drain sessions without ever corrupting a live session's slot accounting. Both
+        // the background dispatcher and the scheduled task fetch it via GetPool and converge on this one pool
+        // — with the default one local worker of MaxConcurrency 1 it admits exactly one job at a time
+        // (byte-identical to the old lock); with N workers it dispatches up to ΣMaxConcurrency concurrently.
+        private WorkerPool? _pool;
+        private readonly object _poolGate = new();
+
         /// <summary>
-        /// Global lock — only one whisper transcription at a time.
-        /// Must be acquired by both the drain loop and the scheduled task.
+        /// The shared worker pool for the current (or next) drain session, (re)built from config. Rebuilt at a
+        /// session start only when the OTHER consumer is idle AND no jobs are in flight, so a rebuild never
+        /// splits the concurrency gate (any live holder keeps its captured pool). <paramref name="forTask"/>
+        /// excludes the caller's own just-set running flag (the scheduled task vs the background dispatcher).
+        /// Picks up config changes (added worker, changed model path) on the next idle session — matching the
+        /// old per-call provider construction, without staleness, and without over-rebuilding (once per session).
         /// </summary>
-        public static readonly SemaphoreSlim TranscriptionLock = new(1, 1);
+        [ExcludeFromCodeCoverage(Justification = "Builds providers from config via WorkerRegistry (Plugin.Instance) — orchestration")]
+        internal WorkerPool GetPool(PluginConfiguration config, ILoggerFactory loggerFactory, bool forTask)
+        {
+            lock (_poolGate)
+            {
+                var otherConsumerIdle = forTask ? _isDraining == 0 : _taskIsRunning == 0;
+                if (_pool == null || (otherConsumerIdle && _pool.ActiveJobs == 0))
+                {
+                    _pool = new WorkerPool(WorkerRegistry.BuildWorkers(config, loggerFactory));
+                }
+                return _pool;
+            }
+        }
+
+        /// <summary>
+        /// Marks the scheduled task as running so <see cref="GetPool"/> will not rebuild the shared pool
+        /// underneath it during its startup window (before the first progress report). Idempotent.
+        /// </summary>
+        public void MarkTaskStarted() => Interlocked.CompareExchange(ref _taskIsRunning, 1, 0);
 
         // ── Scheduled task progress tracking ─────────────────────
         private string? _taskCurrentItemName;
@@ -321,144 +355,171 @@ namespace WhisperSubs.Controller
         }
 
         /// <summary>
-        /// Starts the background drain loop if not already running.
-        /// Safe to call multiple times — only one drain runs at a time.
-        /// Re-checks queue after draining to avoid race with late enqueues.
+        /// Starts the background dispatch loop if not already running (only one at a time), building the
+        /// shared worker pool from config. Safe to call multiple times. Re-checks the queue after draining
+        /// to avoid a race with late enqueues. Replaces the former single-worker EnsureDraining: with the
+        /// default one local worker it behaves identically (one job at a time); with N configured workers it
+        /// dispatches up to ΣMaxConcurrency jobs concurrently across the pool.
         /// </summary>
-        [ExcludeFromCodeCoverage(Justification = "Orchestrates async drain loop with external processes")]
-        public void EnsureDraining(
+        [ExcludeFromCodeCoverage(Justification = "Orchestrates the async dispatch loop with external processes")]
+        public void EnsureDispatching(
             SubtitleManager manager,
-            ISubtitleProvider provider,
+            PluginConfiguration config,
+            ILoggerFactory loggerFactory,
             ILogger logger,
             CancellationToken cancellationToken)
         {
             if (Interlocked.CompareExchange(ref _isDraining, 1, 0) == 0)
             {
+                var pool = GetPool(config, loggerFactory, forTask: false);
+                var requirements = WorkerJob.Requirements(config.SubtitleMode, config.EnableTranslation);
                 _ = Task.Run(async () =>
                 {
                     try
                     {
-                        await DrainLoopAsync(manager, provider, logger, cancellationToken);
+                        await DispatchDrainAsync(manager, pool, requirements, logger, cancellationToken);
                     }
                     finally
                     {
                         _currentItemName = null;
                         Interlocked.Exchange(ref _isDraining, 0);
 
-                        // Re-check: if items were enqueued during the finally block, restart the drain to
+                        // Re-check: if items were enqueued during the finally block, restart the loop to
                         // avoid stuck items — but never on an already-cancelled token, which would set
                         // _isDraining=1 while Task.Run skips the delegate, wedging the queue forever (#112).
                         if (!_lanes.IsEmpty && !cancellationToken.IsCancellationRequested)
                         {
-                            EnsureDraining(manager, provider, logger, cancellationToken);
+                            EnsureDispatching(manager, config, loggerFactory, logger, cancellationToken);
                         }
                     }
                 }, cancellationToken);
             }
         }
 
-        [ExcludeFromCodeCoverage(Justification = "Orchestrates async drain with external processes")]
-        private async Task DrainLoopAsync(
+        /// <summary>
+        /// The core N-slot dispatcher: pulls the highest-priority item, waits for a free worker slot
+        /// (backpressure at ΣMaxConcurrency), routes it to the cheapest capable worker, and runs it
+        /// concurrently — up to the pool's capacity in flight at once. On completion or failure both the
+        /// worker slot and the in-flight (item,language) reservation are released. Shared by the background
+        /// loop (fire-and-forget via EnsureDispatching) and the scheduled task's priority drain (awaited via
+        /// DrainPriorityAsync); both use the SAME pool so the global concurrency limit always holds. At one
+        /// worker of MaxConcurrency 1 the slot serialises exactly like the old TranscriptionLock.
+        /// </summary>
+        [ExcludeFromCodeCoverage(Justification = "Orchestrates concurrent async transcription with external processes")]
+        private async Task DispatchDrainAsync(
             SubtitleManager manager,
-            ISubtitleProvider provider,
+            WorkerPool pool,
+            JobRequirements requirements,
             ILogger logger,
             CancellationToken cancellationToken)
         {
-            while (TryDequeuePriority(out var workItem) && workItem != null)
+            // The job requirements are uniform across a drain session, so feasibility is decided once: if no
+            // worker can EVER serve them (e.g. translation enabled but every configured worker is
+            // transcribe-only) fail the whole queue fast rather than block a slot forever. A misconfig then
+            // surfaces loudly (every item errors with a clear message) instead of the queue hanging.
+            if (!pool.HasCapableWorker(requirements))
             {
-                try
-                {
-                    // Inside the try so the finally still releases the in-flight reservation on cancel (#112).
-                    cancellationToken.ThrowIfCancellationRequested();
-                    _currentItemName = workItem.Item.Name;
-                    logger.LogInformation("[Queue] Processing {ItemName} [{Tier}] ({Remaining} remaining)",
-                        workItem.Item.Name, workItem.Tier, _lanes.Count);
-
-                    await TranscriptionLock.WaitAsync(cancellationToken);
-                    try
-                    {
-                        await manager.GenerateSubtitleAsync(
-                            workItem.Item, provider, workItem.Language, cancellationToken, workItem.Force);
-                    }
-                    finally
-                    {
-                        TranscriptionLock.Release();
-                    }
-
-                    Interlocked.Increment(ref _processedCount);
-                    workItem.Completion?.TrySetResult(true);
-                }
-                catch (System.OperationCanceledException)
-                {
-                    workItem.Completion?.TrySetCanceled();
-                    throw;
-                }
-                catch (System.Exception ex)
+                while (TryDequeuePriority(out var unservable) && unservable != null)
                 {
                     Interlocked.Increment(ref _processedCount);
                     Interlocked.Increment(ref _failedCount);
-                    _lastError = $"{workItem.Item.Name}: {ex.Message}";
-                    workItem.Completion?.TrySetException(ex);
-                    logger.LogError(ex, "[Queue] Failed: {ItemName}", workItem.Item.Name);
+                    _lastError = $"{unservable.Item.Name}: no configured worker can serve this job";
+                    unservable.Completion?.TrySetException(
+                        new System.InvalidOperationException("No configured worker can serve this job"));
+                    Release(IdentityKey(unservable.Item.Id, unservable.Language));
+                    logger.LogError("[Dispatch] No capable worker for {ItemName} — skipping", unservable.Item.Name);
                 }
-                finally
+                _currentItemName = null;
+                return;
+            }
+
+            var running = new List<Task>();
+            try
+            {
+                while (!_lanes.IsEmpty)
                 {
-                    Release(IdentityKey(workItem.Item.Id, workItem.Language));
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    // Acquire a free slot FIRST (backpressure at ΣMaxConcurrency), THEN dequeue the current
+                    // highest-priority item — so an item leaves the persisted queue only when a worker is
+                    // ready to run it now (same crash-durability as the old single-lock loop), and each pick
+                    // sees the freshest priority state.
+                    var lease = await pool.AcquireAsync(requirements, cancellationToken);
+                    if (!TryDequeuePriority(out var workItem) || workItem == null)
+                    {
+                        // Emptied by a concurrent consumer between the check and the dequeue — release, re-check.
+                        pool.Release(lease.Key);
+                        continue;
+                    }
+
+                    var wi = workItem;
+                    var l = lease;
+                    _currentItemName = wi.Item.Name;
+                    logger.LogInformation("[Dispatch] Processing {ItemName} [{Tier}] on {Worker} ({Remaining} remaining)",
+                        wi.Item.Name, wi.Tier, l.Worker.Name, _lanes.Count);
+
+                    // Fire the job WITHOUT gating Task.Run on the token: a cancelled token must not skip the
+                    // delegate, or the finally (which frees the slot + reservation) would never run and leak
+                    // the slot. Cancellation is observed INSIDE, via the token passed to the transcription.
+                    running.Add(Task.Run(async () =>
+                    {
+                        try
+                        {
+                            await manager.GenerateSubtitleAsync(
+                                wi.Item, l.Worker.Provider, wi.Language, cancellationToken, wi.Force);
+                            Interlocked.Increment(ref _processedCount);
+                            wi.Completion?.TrySetResult(true);
+                        }
+                        catch (System.OperationCanceledException)
+                        {
+                            wi.Completion?.TrySetCanceled();
+                        }
+                        catch (System.Exception ex)
+                        {
+                            Interlocked.Increment(ref _processedCount);
+                            Interlocked.Increment(ref _failedCount);
+                            _lastError = $"{wi.Item.Name}: {ex.Message}";
+                            wi.Completion?.TrySetException(ex);
+                            logger.LogError(ex, "[Dispatch] Failed: {ItemName}", wi.Item.Name);
+                        }
+                        finally
+                        {
+                            Release(IdentityKey(wi.Item.Id, wi.Language));
+                            pool.Release(l.Key);
+                        }
+                    }));
+
+                    // Reap finished tasks so the list can't grow unbounded on a long backlog.
+                    running.RemoveAll(t => t.IsCompleted);
                 }
             }
-            logger.LogInformation("[Queue] Drain complete. Processed {Count} items total ({Failed} failed).",
+            finally
+            {
+                // Wait for every dispatched job to finish before returning, so the caller (and _isDraining)
+                // only sees "drained" once the pool is truly idle. Individual job errors are handled above.
+                try { await Task.WhenAll(running); } catch { /* per-job exceptions already handled */ }
+            }
+
+            logger.LogInformation("[Dispatch] Drain complete. Processed {Count} items total ({Failed} failed).",
                 _processedCount, _failedCount);
         }
 
         /// <summary>
-        /// Process all pending priority items. Called by scheduled task.
+        /// Processes all currently-queued priority items across the worker pool and awaits their completion.
+        /// Called by the scheduled task to clear manual/user requests (which outrank the background sweep)
+        /// before and between its own items. Uses the SAME shared pool as the background dispatcher, so the
+        /// two together never exceed the global concurrency limit. With the default one local worker this is
+        /// a sequential drain (identical to the old single-lock behaviour); with N workers it runs in parallel.
         /// </summary>
-        [ExcludeFromCodeCoverage(Justification = "Orchestrates async drain with external processes")]
-        public async Task DrainPriorityAsync(
+        [ExcludeFromCodeCoverage(Justification = "Orchestrates concurrent async transcription with external processes")]
+        internal async Task DrainPriorityAsync(
             SubtitleManager manager,
-            ISubtitleProvider provider,
+            WorkerPool pool,
+            JobRequirements requirements,
             ILogger logger,
             CancellationToken cancellationToken)
         {
-            while (TryDequeuePriority(out var workItem) && workItem != null)
-            {
-                try
-                {
-                    // Inside the try so the finally still releases the in-flight reservation on cancel (#112).
-                    cancellationToken.ThrowIfCancellationRequested();
-                    _currentItemName = workItem.Item.Name;
-                    logger.LogInformation("[Priority] Processing {ItemName} [{Tier}]", workItem.Item.Name, workItem.Tier);
-
-                    await TranscriptionLock.WaitAsync(cancellationToken);
-                    try
-                    {
-                        await manager.GenerateSubtitleAsync(
-                            workItem.Item, provider, workItem.Language, cancellationToken, workItem.Force);
-                    }
-                    finally
-                    {
-                        TranscriptionLock.Release();
-                    }
-
-                    workItem.Completion?.TrySetResult(true);
-                }
-                catch (System.OperationCanceledException)
-                {
-                    workItem.Completion?.TrySetCanceled();
-                    throw;
-                }
-                catch (System.Exception ex)
-                {
-                    Interlocked.Increment(ref _failedCount);
-                    _lastError = $"{workItem.Item.Name}: {ex.Message}";
-                    workItem.Completion?.TrySetException(ex);
-                    logger.LogError(ex, "[Priority] Failed: {ItemName}", workItem.Item.Name);
-                }
-                finally
-                {
-                    Release(IdentityKey(workItem.Item.Id, workItem.Language));
-                }
-            }
+            await DispatchDrainAsync(manager, pool, requirements, logger, cancellationToken);
             _currentItemName = null;
         }
     }

--- a/Controller/SubtitleQueueService.cs
+++ b/Controller/SubtitleQueueService.cs
@@ -68,6 +68,13 @@ namespace WhisperSubs.Controller
         // queued set so a re-request while an item is mid-transcription does not double-queue it.
         private readonly ConcurrentDictionary<string, byte> _inFlight = new();
 
+        // Serialises the queue↔in-flight transition so the invariant "an identity is queued XOR in-flight"
+        // holds atomically: the dispatcher's dequeue+reserve and Enqueue's in-flight-check+lane-add run
+        // under this one lock. Without it (the two touch _lanes and _inFlight under different locks) a
+        // concurrent enqueue in the dequeue→reserve window could re-add an identity that is about to run,
+        // letting the pool dispatch the SAME (item,language) twice — two workers writing one .srt (v4.0).
+        private readonly object _dispatchGate = new();
+
         private int _isDraining;
         private string? _currentItemName;
         private int _processedCount;
@@ -243,35 +250,52 @@ namespace WhisperSubs.Controller
         {
             var key = IdentityKey(item.Id, language);
 
-            // If the same unit is mid-transcription, don't queue a duplicate — the running pass covers it.
-            if (_inFlight.ContainsKey(key)) return false;
-
-            var outcome = _lanes.Enqueue(key, (int)tier, new SubtitleWorkItem
+            // Under _dispatchGate so the in-flight check and the lane-add are atomic with the dispatcher's
+            // dequeue+reserve — otherwise a re-add landing in the dequeue→reserve window double-dispatches.
+            lock (_dispatchGate)
             {
-                Item = item,
-                Language = language,
-                Completion = null,
-                Force = force,
-                Tier = tier
-            }, MergeWork);
+                // If the same unit is mid-transcription, don't queue a duplicate — the running pass covers it.
+                if (_inFlight.ContainsKey(key)) return false;
 
-            // Always persist: even a Duplicate outcome can have OR-merged Force or promoted the tier onto
-            // the existing entry via MergeWork, so queue.json must be rewritten to survive a restart —
-            // otherwise an explicit forced re-request could silently revert to non-forced on restore (#112).
-            PersistQueue();
-            return outcome == LaneEnqueueOutcome.Added;
+                var outcome = _lanes.Enqueue(key, (int)tier, new SubtitleWorkItem
+                {
+                    Item = item,
+                    Language = language,
+                    Completion = null,
+                    Force = force,
+                    Tier = tier
+                }, MergeWork);
+
+                // Always persist: even a Duplicate outcome can have OR-merged Force or promoted the tier onto
+                // the existing entry via MergeWork, so queue.json must be rewritten to survive a restart —
+                // otherwise an explicit forced re-request could silently revert to non-forced on restore (#112).
+                PersistQueue();
+                return outcome == LaneEnqueueOutcome.Added;
+            }
         }
 
         [ExcludeFromCodeCoverage(Justification = "Requires Plugin.Instance for persistence")]
         public bool TryDequeuePriority(out SubtitleWorkItem? item)
         {
-            if (_lanes.TryDequeue(out var dequeued) && dequeued != null)
+            // Dequeue + reserve atomically (see _dispatchGate): moving an identity from the lanes to the
+            // in-flight set in one critical section is what guarantees the pool never dispatches the same
+            // (item,language) twice.
+            lock (_dispatchGate)
             {
-                // Mark in-flight so a concurrent re-request doesn't double-queue while it transcribes.
-                TryReserve(IdentityKey(dequeued.Item.Id, dequeued.Language));
-                PersistQueue();
-                item = dequeued;
-                return true;
+                if (_lanes.TryDequeue(out var dequeued) && dequeued != null)
+                {
+                    // Reserve it in-flight. Honour the result: TryReserve returns false only if the identity
+                    // is already in-flight, which under _dispatchGate cannot happen for a freshly-dequeued
+                    // item — but if it ever did, drop this copy rather than double-dispatch. queue.json is
+                    // persisted either way (the item left the lanes).
+                    var reserved = TryReserve(IdentityKey(dequeued.Item.Id, dequeued.Language));
+                    PersistQueue();
+                    if (reserved)
+                    {
+                        item = dequeued;
+                        return true;
+                    }
+                }
             }
             item = null;
             return false;
@@ -392,7 +416,12 @@ namespace WhisperSubs.Controller
                             EnsureDispatching(manager, config, loggerFactory, logger, cancellationToken);
                         }
                     }
-                }, cancellationToken);
+                    // Task.Run is deliberately NOT given the cancellation token: if it were and the token were
+                    // already cancelled, the delegate would be skipped and the finally above would never reset
+                    // _isDraining — wedging the queue forever. Cancellation is observed INSIDE via the captured
+                    // token (DispatchDrainAsync checks it), so the finally always runs. (Matches the per-job
+                    // Task.Run, which is un-tokened for the same reason.)
+                });
             }
         }
 

--- a/Controller/SubtitleRequestService.cs
+++ b/Controller/SubtitleRequestService.cs
@@ -46,8 +46,7 @@ namespace WhisperSubs.Controller
             }
 
             var manager = new SubtitleManager(libraryManager, loggerFactory.CreateLogger<SubtitleManager>());
-            var provider = SubtitleProviderFactory.Create(config, loggerFactory);
-            queue.EnsureDraining(manager, provider, logger, CancellationToken.None);
+            queue.EnsureDispatching(manager, config, loggerFactory, logger, CancellationToken.None);
 
             logger.LogInformation("[Request] Enqueued {Queued} of {Total} item(s) for {ItemId} [{Tier}]",
                 queued, leaves.Count, itemId, tier);

--- a/Controller/Workers/WorkerJob.cs
+++ b/Controller/Workers/WorkerJob.cs
@@ -1,0 +1,32 @@
+using WhisperSubs.Configuration;
+
+namespace WhisperSubs.Controller.Workers
+{
+    /// <summary>
+    /// Pure mapping from plugin config to the dispatcher's per-job <see cref="JobRequirements"/> (v4.0).
+    /// Kept free of Jellyfin runtime types (only the POCO config) so it is unit-testable, mirroring the
+    /// codebase's other pure decision helpers (<see cref="PriorityScheduling"/>, <see cref="WorkerPlan"/>).
+    /// </summary>
+    public static class WorkerJob
+    {
+        /// <summary>
+        /// Whether the current config may require an English-translation pass for some item — the same
+        /// condition the scheduled task uses for its <c>needsTranslation</c> gate: TranslationOnly always,
+        /// or EnableTranslation in a mode that runs the full pass (Full / FullAndForced).
+        /// </summary>
+        public static bool TranslationPossible(SubtitleMode mode, bool enableTranslation)
+            => mode == SubtitleMode.TranslationOnly
+               || (enableTranslation && (mode == SubtitleMode.Full || mode == SubtitleMode.FullAndForced));
+
+        /// <summary>
+        /// The capability a dispatched worker must advertise. Whole media items are dispatched and the
+        /// manager decides per item whether to also run a translation pass, so this is conservative: when
+        /// translation is possible for the config every job requires a translate-capable worker, guaranteeing
+        /// a translate pass never lands on a transcribe-only worker. A worker that cannot translate is simply
+        /// not chosen while translation is enabled — the common case (all workers translate) is unaffected.
+        /// <c>RequiredModel</c> is null: the manager does not pin a per-job model, so any model serves.
+        /// </summary>
+        public static JobRequirements Requirements(SubtitleMode mode, bool enableTranslation)
+            => new JobRequirements(TranslationPossible(mode, enableTranslation), null);
+    }
+}

--- a/Controller/Workers/WorkerPool.cs
+++ b/Controller/Workers/WorkerPool.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace WhisperSubs.Controller.Workers
+{
+    /// <summary>
+    /// A reserved worker slot handed out by <see cref="WorkerPool.AcquireAsync"/>: the chosen worker plus
+    /// the pool-internal <see cref="Key"/> to release it by. Releasing by the key (not the worker's own Id)
+    /// keeps slot accounting correct even if two configured workers collide on Id.
+    /// </summary>
+    internal readonly record struct WorkerLease(string Key, ITranscriptionWorker Worker);
+
+    /// <summary>
+    /// The live transcription worker pool (v4.0): the immutable <see cref="ITranscriptionWorker"/>
+    /// descriptors plus their mutable in-flight counts, behind one lock, gated by a ΣMaxConcurrency
+    /// backpressure semaphore. It replaces the single global <c>TranscriptionLock(1,1)</c> — with the
+    /// default one local worker of MaxConcurrency 1 it admits exactly one job at a time (byte-identical to
+    /// the old lock); with N workers it admits up to the summed capacity and routes each job to the cheapest
+    /// free worker via the pure <see cref="WorkerScheduling"/>. ALL transcription paths (queue drain, user
+    /// request, scheduled sweep) share ONE pool, so the global concurrency limit holds no matter which path
+    /// started the work — never two whisper runs on a single-slot worker.
+    /// </summary>
+    internal sealed class WorkerPool
+    {
+        private readonly object _gate = new();
+        private readonly List<string> _keys = new();
+        private readonly Dictionary<string, ITranscriptionWorker> _byKey = new();
+        private readonly Dictionary<string, int> _inFlight = new();
+        private readonly SemaphoreSlim _slots;
+
+        public WorkerPool(IReadOnlyList<ITranscriptionWorker> workers)
+        {
+            if (workers == null) throw new ArgumentNullException(nameof(workers));
+
+            var capacity = 0;
+            for (var i = 0; i < workers.Count; i++)
+            {
+                var w = workers[i];
+                // Guarantee a unique routing key even if two configured workers collide on Id — a
+                // duplicate would otherwise make the reverse Id→worker lookup ambiguous. The key is only
+                // used internally for slot accounting; WorkerSlot.Id still carries it for the deterministic
+                // ordinal tiebreak in WorkerScheduling.Pick.
+                var key = _byKey.ContainsKey(w.Id) ? $"{w.Id}#{i}" : w.Id;
+                _keys.Add(key);
+                _byKey[key] = w;
+                _inFlight[key] = 0;
+                capacity += w.Capabilities.MaxConcurrency < 1 ? 1 : w.Capabilities.MaxConcurrency;
+            }
+
+            TotalCapacity = capacity < 1 ? 1 : capacity;
+            _slots = new SemaphoreSlim(TotalCapacity, TotalCapacity);
+        }
+
+        /// <summary>Summed MaxConcurrency across all workers (≥1): how many jobs may run at once.</summary>
+        public int TotalCapacity { get; }
+
+        /// <summary>Number of workers in the pool.</summary>
+        public int WorkerCount => _keys.Count;
+
+        /// <summary>Jobs currently running across all workers (0 when fully idle).</summary>
+        public int ActiveJobs
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    var sum = 0;
+                    foreach (var n in _inFlight.Values) sum += n;
+                    return sum;
+                }
+            }
+        }
+
+        /// <summary>
+        /// True if ANY worker could serve <paramref name="job"/>'s hard requirements ignoring current load —
+        /// i.e. a capable worker exists (maybe busy). The dispatcher checks this before <see cref="AcquireAsync"/>
+        /// so a job no worker can EVER serve is failed fast instead of blocking a slot forever.
+        /// </summary>
+        public bool HasCapableWorker(JobRequirements job)
+        {
+            lock (_gate)
+            {
+                foreach (var key in _keys)
+                {
+                    // InFlight 0 ⇒ CanServe reduces to the pure capability filter (translate/model), no load.
+                    if (WorkerScheduling.CanServe(new WorkerSlot(key, true, 0, _byKey[key].Capabilities), job))
+                        return true;
+                }
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Waits for a free slot (backpressure at <see cref="TotalCapacity"/>), then reserves the cheapest
+        /// worker that can serve <paramref name="job"/> and returns a <see cref="WorkerLease"/>. The caller
+        /// MUST call <see cref="Release"/> with the lease's key exactly once when the job finishes. Assumes a
+        /// capable worker EXISTS (guard with <see cref="HasCapableWorker"/>): if every free slot is on an
+        /// incapable worker it hands the slot back and retries after a short backoff until a capable one
+        /// frees, so it always returns a lease unless cancelled.
+        /// </summary>
+        public async Task<WorkerLease> AcquireAsync(JobRequirements job, CancellationToken cancellationToken)
+        {
+            while (true)
+            {
+                await _slots.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+                WorkerLease? lease;
+                lock (_gate)
+                {
+                    lease = PickLocked(job);
+                }
+
+                if (lease is not null) return lease.Value;
+
+                // A slot freed but only incapable workers are free (heterogeneous-capability case). Give the
+                // slot back and wait briefly for the capable-but-busy worker to free — the HasCapableWorker
+                // guard guarantees one exists, so this terminates.
+                _slots.Release();
+                await Task.Delay(100, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>Releases a slot after a job completes or fails, by the <see cref="WorkerLease.Key"/>. Pair each <see cref="AcquireAsync"/> with exactly one Release.</summary>
+        public void Release(string leaseKey)
+        {
+            lock (_gate)
+            {
+                if (_inFlight.TryGetValue(leaseKey, out var n) && n > 0)
+                    _inFlight[leaseKey] = n - 1;
+            }
+            _slots.Release();
+        }
+
+        // Caller holds _gate. Snapshots each worker as a WorkerSlot (keyed by the unique routing key), asks
+        // WorkerScheduling for the cheapest capable free one, marks it in-flight, and returns a lease
+        // carrying that key. Null if none is free-and-capable right now.
+        private WorkerLease? PickLocked(JobRequirements job)
+        {
+            var slots = new List<WorkerSlot>(_keys.Count);
+            foreach (var key in _keys)
+                slots.Add(new WorkerSlot(key, true, _inFlight[key], _byKey[key].Capabilities));
+
+            var pick = WorkerScheduling.Pick(slots, job);
+            if (pick is null) return null;
+
+            var chosenKey = pick.Value.Id;   // WorkerSlot.Id is the unique routing key set above
+            _inFlight[chosenKey]++;
+            return new WorkerLease(chosenKey, _byKey[chosenKey]);
+        }
+    }
+}

--- a/Controller/Workers/WorkerPool.cs
+++ b/Controller/Workers/WorkerPool.cs
@@ -102,6 +102,16 @@ namespace WhisperSubs.Controller.Workers
         /// </summary>
         public async Task<WorkerLease> AcquireAsync(JobRequirements job, CancellationToken cancellationToken)
         {
+            // Defense-in-depth: the callers already fail-fast on !HasCapableWorker, but if a call site ever
+            // skipped that, the retry loop below would spin forever (acquire slot → PickLocked fails →
+            // release → delay). Fail deterministically instead so a misuse surfaces as an exception, not a
+            // hung job. When a capable worker EXISTS but is busy, this passes and the loop waits for it.
+            if (!HasCapableWorker(job))
+            {
+                throw new System.InvalidOperationException(
+                    "No worker in the pool can serve this job's requirements.");
+            }
+
             while (true)
             {
                 await _slots.WaitAsync(cancellationToken).ConfigureAwait(false);

--- a/Controller/Workers/WorkerRegistry.cs
+++ b/Controller/Workers/WorkerRegistry.cs
@@ -29,7 +29,8 @@ namespace WhisperSubs.Controller.Workers
             switch (plan.Source)
             {
                 case WorkerSource.ExplicitList:
-                    foreach (var w in config.Workers.Where(x => x.Enabled && !string.IsNullOrWhiteSpace(x.ApiUrl)))
+                    // ExplicitList is only returned by WorkerPlan.Decide when Workers.Count > 0, so it is non-null here.
+                    foreach (var w in config.Workers!.Where(x => x.Enabled && !string.IsNullOrWhiteSpace(x.ApiUrl)))
                     {
                         workers.Add(BuildRemote(
                             id: string.IsNullOrWhiteSpace(w.Id) ? w.ApiUrl : w.Id,

--- a/Controller/Workers/WorkerRegistry.cs
+++ b/Controller/Workers/WorkerRegistry.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using WhisperSubs.Configuration;
+using WhisperSubs.Providers;
+using Microsoft.Extensions.Logging;
+
+namespace WhisperSubs.Controller.Workers
+{
+    /// <summary>
+    /// Builds the transcription worker pool from config (v4.0), backward-compatible via
+    /// <see cref="WorkerPlan"/>: no config → one local worker (identical to today); a legacy single
+    /// <c>RemoteWhisperApiUrl</c> → one remote worker (remote-only); an explicit <c>Workers</c> list →
+    /// those + optionally the local host. Excluded from coverage — it news up providers from config, the
+    /// same rationale as <see cref="SubtitleProviderFactory"/>. The composition decision (WorkerPlan) and
+    /// the routing (WorkerScheduling) are the tested, pure parts.
+    /// </summary>
+    [ExcludeFromCodeCoverage(Justification = "Orchestration: constructs providers from config, like SubtitleProviderFactory")]
+    public static class WorkerRegistry
+    {
+        public static IReadOnlyList<ITranscriptionWorker> BuildWorkers(PluginConfiguration config, ILoggerFactory loggerFactory)
+        {
+            var workers = new List<ITranscriptionWorker>();
+            var plan = WorkerPlan.Decide(
+                config.Workers?.Count ?? 0,
+                !string.IsNullOrWhiteSpace(config.RemoteWhisperApiUrl),
+                config.EnableLocalWorker);
+
+            switch (plan.Source)
+            {
+                case WorkerSource.ExplicitList:
+                    foreach (var w in config.Workers.Where(x => x.Enabled && !string.IsNullOrWhiteSpace(x.ApiUrl)))
+                    {
+                        workers.Add(BuildRemote(
+                            id: string.IsNullOrWhiteSpace(w.Id) ? w.ApiUrl : w.Id,
+                            name: string.IsNullOrWhiteSpace(w.Name) ? w.ApiUrl : w.Name,
+                            url: w.ApiUrl,
+                            key: w.ApiKey ?? string.Empty,
+                            model: string.IsNullOrWhiteSpace(w.Model) ? config.RemoteWhisperModel : w.Model,
+                            maxConcurrency: w.MaxConcurrency,
+                            costWeight: w.CostWeight,
+                            canTranslate: w.CanTranslate,
+                            config: config,
+                            loggerFactory: loggerFactory));
+                    }
+                    break;
+
+                case WorkerSource.LegacyRemote:
+                    // A pre-v4 single remote URL = the whole "remote" worker, remote-only.
+                    workers.Add(BuildRemote(
+                        id: "remote", name: "Remote",
+                        url: config.RemoteWhisperApiUrl,
+                        key: (config.RemoteWhisperApiKey ?? string.Empty).Trim(),
+                        model: config.RemoteWhisperModel,
+                        maxConcurrency: 1, costWeight: 0, canTranslate: true,
+                        config: config, loggerFactory: loggerFactory));
+                    break;
+            }
+
+            // Add the host's own local whisper unless the plan says otherwise. The fallback guarantees the
+            // pool is never empty (e.g. an explicit list of all-disabled/blank workers with local off).
+            if (plan.AddLocal || workers.Count == 0)
+            {
+                workers.Add(new TranscriptionWorker(
+                    "local", "Local (this server)",
+                    SubtitleProviderFactory.CreateLocal(config, loggerFactory),
+                    new WorkerCapabilities { IsLocal = true, CostWeight = 0, MaxConcurrency = 1, CanTranslate = true }));
+            }
+
+            return workers;
+        }
+
+        private static ITranscriptionWorker BuildRemote(
+            string id, string name, string url, string key, string model,
+            int maxConcurrency, double costWeight, bool canTranslate,
+            PluginConfiguration config, ILoggerFactory loggerFactory)
+        {
+            var resolvedModel = string.IsNullOrWhiteSpace(model) ? "Systran/faster-whisper-large-v3" : model.Trim();
+            var provider = new RemoteWhisperProvider(
+                loggerFactory.CreateLogger<RemoteWhisperProvider>(),
+                url, resolvedModel, key,
+                config.JobTimeoutRealtimeFactor, config.JobMinTimeoutSeconds, config.JobMaxTimeoutHours);
+
+            return new TranscriptionWorker(id, name, provider, new WorkerCapabilities
+            {
+                IsLocal = false,
+                CostWeight = costWeight,
+                MaxConcurrency = maxConcurrency < 1 ? 1 : maxConcurrency,
+                CanTranslate = canTranslate
+            });
+        }
+    }
+}

--- a/Providers/SubtitleProviderFactory.cs
+++ b/Providers/SubtitleProviderFactory.cs
@@ -26,6 +26,17 @@ namespace WhisperSubs.Providers
                     config.JobMaxTimeoutHours);
             }
 
+            return CreateLocal(config, loggerFactory);
+        }
+
+        /// <summary>
+        /// Builds the host's local in-process whisper-cli provider (VAD + detection-model resolution).
+        /// Extracted from <see cref="Create"/> so the v4.0 worker pool can construct the local worker
+        /// directly, without the remote-vs-local switch.
+        /// </summary>
+        [ExcludeFromCodeCoverage(Justification = "Orchestration: news up WhisperProvider + WhisperSetupService, File.Exists, TryAcquire — same rationale as Create.")]
+        public static ISubtitleProvider CreateLocal(PluginConfiguration config, ILoggerFactory loggerFactory)
+        {
             var setup = new WhisperSetupService(
                 loggerFactory.CreateLogger<WhisperSetupService>(),
                 Plugin.Instance?.DataFolderPath ?? "");

--- a/ScheduledTasks/SubtitleGenerationTask.cs
+++ b/ScheduledTasks/SubtitleGenerationTask.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using WhisperSubs.Controller;
+using WhisperSubs.Controller.Workers;
 using WhisperSubs.Providers;
 using Jellyfin.Data.Enums;
 using MediaBrowser.Controller.Entities;
@@ -79,16 +80,23 @@ namespace WhisperSubs.ScheduledTasks
             }
 
             var manager = new SubtitleManager(_libraryManager, _loggerFactory.CreateLogger<SubtitleManager>());
-            var provider = SubtitleProviderFactory.Create(config, _loggerFactory);
             var language = config.DefaultLanguage;
             var queue = SubtitleQueueService.Instance;
+
+            // Mark the task running up front so the shared worker pool isn't rebuilt underneath it, then
+            // build the pool + the per-job worker requirements once for the whole run (v4.0). Both the
+            // priority drain and this task's own swept items go through the SAME pool as any background
+            // dispatcher, so the global concurrency limit holds across every path.
+            queue.MarkTaskStarted();
+            var pool = queue.GetPool(config, _loggerFactory, forTask: true);
+            var requirements = WorkerJob.Requirements(config.SubtitleMode, config.EnableTranslation);
 
             // Restore persisted queue from disk (survives restarts)
             var restored = queue.RestoreQueue(_libraryManager, _logger);
             if (restored > 0)
             {
                 _logger.LogInformation("Draining {Count} restored priority items before auto-generation", restored);
-                await queue.DrainPriorityAsync(manager, provider, _logger, cancellationToken);
+                await queue.DrainPriorityAsync(manager, pool, requirements, _logger, cancellationToken);
             }
 
             // Collect items — the query is fast (DB lookup), no bulk in-memory storage needed
@@ -196,7 +204,7 @@ namespace WhisperSubs.ScheduledTasks
                 if (queue.PriorityCount > 0)
                 {
                     _logger.LogInformation("Pausing auto-generation to process {Count} priority request(s)", queue.PriorityCount);
-                    await queue.DrainPriorityAsync(manager, provider, _logger, cancellationToken);
+                    await queue.DrainPriorityAsync(manager, pool, requirements, _logger, cancellationToken);
                 }
 
                 var (item, libName) = allItems[i];
@@ -369,21 +377,32 @@ namespace WhisperSubs.ScheduledTasks
                     queue.ResetFileProgress();
                     queue.ReportTaskProgress(item.Name, completed, allItems.Count, failed, itemType, libName);
 
-                    await SubtitleQueueService.TranscriptionLock.WaitAsync(cancellationToken);
+                    // No worker can serve this job's requirements (e.g. translation enabled but every
+                    // configured worker is transcribe-only) — surface it via the same failure path below.
+                    if (!pool.HasCapableWorker(requirements))
+                    {
+                        throw new InvalidOperationException("No configured worker can serve this job");
+                    }
+
+                    // Acquire a slot on the shared worker pool (the global concurrency gate that replaced the
+                    // old TranscriptionLock) and run this swept item on the chosen worker. With the default
+                    // one local worker this serialises exactly like the old lock; with N workers the sweep
+                    // shares the pool with the background dispatcher up to ΣMaxConcurrency.
+                    var lease = await pool.AcquireAsync(requirements, cancellationToken);
                     try
                     {
                         if (config.PauseOnPlayback)
                         {
-                            await TranscribeWithPlaybackMonitorAsync(manager, item, provider, language, cancellationToken);
+                            await TranscribeWithPlaybackMonitorAsync(manager, item, lease.Worker.Provider, language, cancellationToken);
                         }
                         else
                         {
-                            await manager.GenerateSubtitleAsync(item, provider, language, cancellationToken);
+                            await manager.GenerateSubtitleAsync(item, lease.Worker.Provider, language, cancellationToken);
                         }
                     }
                     finally
                     {
-                        SubtitleQueueService.TranscriptionLock.Release();
+                        pool.Release(lease.Key);
                     }
                 }
                 catch (OperationCanceledException)
@@ -408,6 +427,11 @@ namespace WhisperSubs.ScheduledTasks
             }
             finally
             {
+                // Always clear the task-running flag (even on cancellation / exception) so the shared worker
+                // pool can be rebuilt for the next run — MarkTaskStarted set it, and the success path's
+                // ReportTaskComplete is skipped when the run throws.
+                queue.ReportTaskComplete();
+
                 // Persist even on cancellation / pause-timeout so the run keeps the progress it made.
                 // Prune to the enumerated candidate set (not the reached set) so items not yet visited
                 // this run keep their prior entry — the reason per-item state beats a global watermark.

--- a/ScheduledTasks/SubtitleGenerationTask.cs
+++ b/ScheduledTasks/SubtitleGenerationTask.cs
@@ -79,15 +79,31 @@ namespace WhisperSubs.ScheduledTasks
                 return;
             }
 
-            var manager = new SubtitleManager(_libraryManager, _loggerFactory.CreateLogger<SubtitleManager>());
-            var language = config.DefaultLanguage;
             var queue = SubtitleQueueService.Instance;
 
-            // Mark the task running up front so the shared worker pool isn't rebuilt underneath it, then
-            // build the pool + the per-job worker requirements once for the whole run (v4.0). Both the
-            // priority drain and this task's own swept items go through the SAME pool as any background
-            // dispatcher, so the global concurrency limit holds across every path.
+            // Mark the task running up front so the shared worker pool isn't rebuilt underneath it (v4.0),
+            // then run the generation inside a try/finally that ALWAYS clears the flag — even if setup
+            // (GetPool, library enumeration, the restored-items drain) throws before the main loop — so a
+            // stuck flag never freezes the pool-rebuild gate or the queue UI. ReportTaskComplete is idempotent.
             queue.MarkTaskStarted();
+            try
+            {
+                await RunGenerationAsync(config, queue, progress, cancellationToken);
+            }
+            finally
+            {
+                queue.ReportTaskComplete();
+            }
+        }
+
+        private async Task RunGenerationAsync(
+            Configuration.PluginConfiguration config,
+            SubtitleQueueService queue,
+            IProgress<double> progress,
+            CancellationToken cancellationToken)
+        {
+            var manager = new SubtitleManager(_libraryManager, _loggerFactory.CreateLogger<SubtitleManager>());
+            var language = config.DefaultLanguage;
             var pool = queue.GetPool(config, _loggerFactory, forTask: true);
             var requirements = WorkerJob.Requirements(config.SubtitleMode, config.EnableTranslation);
 
@@ -427,14 +443,10 @@ namespace WhisperSubs.ScheduledTasks
             }
             finally
             {
-                // Always clear the task-running flag (even on cancellation / exception) so the shared worker
-                // pool can be rebuilt for the next run — MarkTaskStarted set it, and the success path's
-                // ReportTaskComplete is skipped when the run throws.
-                queue.ReportTaskComplete();
-
                 // Persist even on cancellation / pause-timeout so the run keeps the progress it made.
                 // Prune to the enumerated candidate set (not the reached set) so items not yet visited
                 // this run keep their prior entry — the reason per-item state beats a global watermark.
+                // (The task-running flag is cleared by ExecuteAsync's outer finally.)
                 if (skipCache != null)
                 {
                     skipCache.PruneTo(candidateIds);

--- a/WhisperSubs.Tests/PriorityLanesTests.cs
+++ b/WhisperSubs.Tests/PriorityLanesTests.cs
@@ -150,4 +150,43 @@ public class PriorityLanesTests
         Assert.Equal(0, lanes.Count);
         Assert.False(lanes.CountsByTier().ContainsKey(Medium)); // lane pruned
     }
+
+    // ── predicate dequeue (v4.0 dispatcher: skip a head job no free worker can serve) ──
+
+    [Fact]
+    public void TryDequeuePredicate_ReturnsHighestPriorityAcceptable()
+    {
+        var lanes = new PriorityLanes<string>();
+        lanes.Enqueue("c", Critical, "crit");
+        lanes.Enqueue("h", High, "high");
+        // Accept everything → same as the plain head (strongest tier).
+        Assert.True(lanes.TryDequeue(_ => true, out var v));
+        Assert.Equal("crit", v);
+    }
+
+    [Fact]
+    public void TryDequeuePredicate_SkipsRejectedHead_PreservesTierOrder()
+    {
+        var lanes = new PriorityLanes<string>();
+        lanes.Enqueue("c", Critical, "crit");   // rejected by the predicate
+        lanes.Enqueue("h1", High, "high1");
+        lanes.Enqueue("h2", High, "high2");
+        // Skip "crit" → the next acceptable is the FIFO head of the next-strongest lane.
+        Assert.True(lanes.TryDequeue(v => v != "crit", out var v1));
+        Assert.Equal("high1", v1);
+        // "crit" is still queued (only skipped, not removed).
+        Assert.True(lanes.ContainsKey("c"));
+        Assert.Equal(2, lanes.Count);
+    }
+
+    [Fact]
+    public void TryDequeuePredicate_FalseWhenNoneAcceptable()
+    {
+        var lanes = new PriorityLanes<string>();
+        lanes.Enqueue("a", Medium, "a");
+        lanes.Enqueue("b", Low, "b");
+        Assert.False(lanes.TryDequeue(_ => false, out var v));
+        Assert.Null(v);
+        Assert.Equal(2, lanes.Count); // nothing removed
+    }
 }

--- a/WhisperSubs.Tests/SubtitleQueueServiceTests.cs
+++ b/WhisperSubs.Tests/SubtitleQueueServiceTests.cs
@@ -98,12 +98,15 @@ public class SubtitleQueueServiceTests
     }
 
     [Fact]
-    public void TranscriptionLock_IsAvailable()
+    public void MarkTaskStarted_SetsRunning_And_ReportTaskComplete_Clears()
     {
-        Assert.NotNull(SubtitleQueueService.TranscriptionLock);
-        // Should be able to acquire and release
-        Assert.True(SubtitleQueueService.TranscriptionLock.Wait(0));
-        SubtitleQueueService.TranscriptionLock.Release();
+        var queue = SubtitleQueueService.Instance;
+        // The v4.0 pool-rebuild gate: MarkTaskStarted must set the task-running flag so GetPool won't
+        // rebuild underneath the scheduled task; ReportTaskComplete (run in the task's finally) clears it.
+        queue.MarkTaskStarted();
+        Assert.True(queue.IsTaskRunning);
+        queue.ReportTaskComplete();
+        Assert.False(queue.IsTaskRunning);
     }
 
     [Fact]

--- a/WhisperSubs.Tests/WorkerJobTests.cs
+++ b/WhisperSubs.Tests/WorkerJobTests.cs
@@ -1,0 +1,39 @@
+using WhisperSubs.Configuration;
+using WhisperSubs.Controller.Workers;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+/// <summary>
+/// v4.0 dispatcher: the pure config→job-requirements mapping. Pins that "which jobs need a translate-capable
+/// worker" matches the scheduled task's own needsTranslation gate, so a translate pass never routes to a
+/// transcribe-only worker, and that the common (translation-off) case requires nothing special.
+/// </summary>
+public class WorkerJobTests
+{
+    [Theory]
+    [InlineData(SubtitleMode.TranslationOnly, false, true)]  // TranslationOnly always runs a translate pass
+    [InlineData(SubtitleMode.TranslationOnly, true, true)]
+    [InlineData(SubtitleMode.Full, true, true)]              // full pass + translation enabled
+    [InlineData(SubtitleMode.FullAndForced, true, true)]
+    [InlineData(SubtitleMode.Full, false, false)]            // translation off ⇒ no translate requirement
+    [InlineData(SubtitleMode.FullAndForced, false, false)]
+    [InlineData(SubtitleMode.ForcedOnly, true, false)]       // forced-only never runs a full/translate pass
+    [InlineData(SubtitleMode.ForcedOnly, false, false)]
+    public void TranslationPossible_MatchesTaskGate(SubtitleMode mode, bool enableTranslation, bool expected)
+    {
+        Assert.Equal(expected, WorkerJob.TranslationPossible(mode, enableTranslation));
+    }
+
+    [Fact]
+    public void Requirements_TranslateFollowsTranslationPossible_ModelAlwaysNull()
+    {
+        var needsTranslate = WorkerJob.Requirements(SubtitleMode.TranslationOnly, false);
+        Assert.True(needsTranslate.Translate);
+        Assert.Null(needsTranslate.RequiredModel);
+
+        var noTranslate = WorkerJob.Requirements(SubtitleMode.Full, false);
+        Assert.False(noTranslate.Translate);
+        Assert.Null(noTranslate.RequiredModel);
+    }
+}

--- a/WhisperSubs.Tests/WorkerPoolTests.cs
+++ b/WhisperSubs.Tests/WorkerPoolTests.cs
@@ -1,0 +1,123 @@
+using System.Threading;
+using System.Threading.Tasks;
+using WhisperSubs.Controller.Workers;
+using WhisperSubs.Providers;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+/// <summary>
+/// v4.0 dispatcher: the live worker pool that replaced the global TranscriptionLock. Pins the concurrency
+/// gate (ΣMaxConcurrency, one-slot serialisation at the default), cost-weighted local-first routing, the
+/// fail-fast capability check, and — the subtle one — that releasing by the lease key keeps accounting
+/// correct even when two workers collide on Id.
+/// </summary>
+public class WorkerPoolTests
+{
+    private sealed class FakeProvider : ISubtitleProvider
+    {
+        public string Name => "fake";
+        public bool UsesVad => false;
+        public Task<string> TranscribeAsync(string audioPath, string language, CancellationToken ct, bool translate = false)
+            => Task.FromResult(string.Empty);
+        public Task<(string Language, float Probability)> DetectLanguageAsync(string audioPath, CancellationToken ct)
+            => Task.FromResult(("en", 1f));
+    }
+
+    private static ITranscriptionWorker Worker(string id, int maxConcurrency = 1, double cost = 0, bool canTranslate = true)
+        => new TranscriptionWorker(id, id, new FakeProvider(), new WorkerCapabilities
+        {
+            MaxConcurrency = maxConcurrency,
+            CostWeight = cost,
+            CanTranslate = canTranslate,
+            IsLocal = cost == 0
+        });
+
+    private static readonly JobRequirements AnyJob = new(Translate: false, RequiredModel: null);
+
+    [Fact]
+    public void TotalCapacity_IsSumOfMaxConcurrency_AtLeastOne()
+    {
+        var pool = new WorkerPool(new[] { Worker("a", 1), Worker("b", 3) });
+        Assert.Equal(4, pool.TotalCapacity);
+        Assert.Equal(2, pool.WorkerCount);
+
+        // A worker with a nonsense concurrency still contributes at least one slot.
+        var floored = new WorkerPool(new[] { Worker("z", 0) });
+        Assert.Equal(1, floored.TotalCapacity);
+    }
+
+    [Fact]
+    public async Task SingleWorkerSingleSlot_SerialisesLikeTheOldLock()
+    {
+        var pool = new WorkerPool(new[] { Worker("local", 1) });
+
+        var first = await pool.AcquireAsync(AnyJob, default);
+        Assert.Equal(1, pool.ActiveJobs);
+
+        // The only slot is taken — a second acquire must block (not complete).
+        var second = pool.AcquireAsync(AnyJob, default);
+        Assert.False(second.IsCompleted);
+
+        pool.Release(first.Key);                    // frees the slot
+        var unblocked = await second;
+        Assert.Equal(1, pool.ActiveJobs);
+
+        pool.Release(unblocked.Key);
+        Assert.Equal(0, pool.ActiveJobs);
+    }
+
+    [Fact]
+    public async Task ConcurrentAcquires_UpToCapacity_ThenBlockUntilRelease()
+    {
+        var pool = new WorkerPool(new[] { Worker("a", 1), Worker("b", 1) }); // capacity 2
+        var a = await pool.AcquireAsync(AnyJob, default);
+        var b = await pool.AcquireAsync(AnyJob, default);
+        Assert.Equal(2, pool.ActiveJobs);
+
+        var third = pool.AcquireAsync(AnyJob, default);
+        Assert.False(third.IsCompleted);            // capacity reached ⇒ blocks
+
+        pool.Release(a.Key);
+        var c = await third;                         // a freed ⇒ unblocks
+        Assert.Equal(2, pool.ActiveJobs);
+
+        pool.Release(b.Key);
+        pool.Release(c.Key);
+        Assert.Equal(0, pool.ActiveJobs);
+    }
+
+    [Fact]
+    public async Task Acquire_PrefersLocalOverPaid_ByCostWeight()
+    {
+        var pool = new WorkerPool(new[] { Worker("cloud", 1, cost: 5), Worker("local", 1, cost: 0) });
+        var lease = await pool.AcquireAsync(AnyJob, default);
+        Assert.Equal("local", lease.Worker.Id);      // cost 0 strictly beats cost 5
+        pool.Release(lease.Key);
+    }
+
+    [Fact]
+    public void HasCapableWorker_FalseWhenTranslateNeededButNoneTranslate()
+    {
+        var pool = new WorkerPool(new[] { Worker("t", 1, canTranslate: false) });
+        Assert.False(pool.HasCapableWorker(new JobRequirements(Translate: true, RequiredModel: null)));
+        Assert.True(pool.HasCapableWorker(new JobRequirements(Translate: false, RequiredModel: null)));
+    }
+
+    [Fact]
+    public async Task DuplicateWorkerIds_DoNotCollide_BothSlotsUsableAndReleasable()
+    {
+        // Two workers misconfigured with the SAME Id — the lease key must keep per-slot accounting distinct.
+        var pool = new WorkerPool(new[] { Worker("dup", 1), Worker("dup", 1) });
+        Assert.Equal(2, pool.TotalCapacity);
+
+        var a = await pool.AcquireAsync(AnyJob, default);
+        var b = await pool.AcquireAsync(AnyJob, default);
+        Assert.Equal(2, pool.ActiveJobs);            // both slots acquired despite the Id clash
+        Assert.NotEqual(a.Key, b.Key);               // distinct routing keys
+
+        pool.Release(a.Key);
+        pool.Release(b.Key);
+        Assert.Equal(0, pool.ActiveJobs);            // both released cleanly (would be 1 if released by Id)
+    }
+}

--- a/WhisperSubs.Tests/WorkerPoolTests.cs
+++ b/WhisperSubs.Tests/WorkerPoolTests.cs
@@ -105,6 +105,16 @@ public class WorkerPoolTests
     }
 
     [Fact]
+    public async Task AcquireAsync_ThrowsWhenNoCapableWorker_NeverSpins()
+    {
+        // Defense-in-depth (CodeRabbit): a transcribe-only pool asked for a translate job must fail fast
+        // with InvalidOperationException, not loop forever acquiring/releasing the slot.
+        var pool = new WorkerPool(new[] { Worker("t", 1, canTranslate: false) });
+        await Assert.ThrowsAsync<System.InvalidOperationException>(
+            () => pool.AcquireAsync(new JobRequirements(Translate: true, RequiredModel: null), default));
+    }
+
+    [Fact]
     public async Task DuplicateWorkerIds_DoNotCollide_BothSlotsUsableAndReleasable()
     {
         // Two workers misconfigured with the SAME Id — the lease key must keep per-slot accounting distinct.


### PR DESCRIPTION
## What

v4.0 PR-3 — replace the single global `TranscriptionLock(1,1)` + single-worker drain loop with an **N-slot worker-pool dispatcher**. Parallelism switches on here: with N configured workers the queue transcribes up to ΣMaxConcurrency items at once, routed to the cheapest free worker. With the **default one local worker it is byte-identical to before** — one transcription at a time.

Targets `v4-dev` (not `main`); v4.0 does not release from this branch.

## How

- **`WorkerPool`** (`Controller/Workers/WorkerPool.cs`) — the live pool: per-worker in-flight counts + a ΣMaxConcurrency backpressure semaphore. `AcquireAsync` returns a `WorkerLease` whose **key** (not the worker's own Id) is used to release, so slot accounting stays correct even if two configured workers collide on Id. `HasCapableWorker` fail-fast; routing delegated to the pure, unit-tested `WorkerScheduling` (cost-weighted, local-first).
- **`WorkerJob`** (`Controller/Workers/WorkerJob.cs`) — pure `config → JobRequirements`. Translate-capability follows the scheduled task's own `needsTranslation` gate, so a translate pass never routes to a transcribe-only worker (conservative; the common all-translate case is unaffected).
- **`SubtitleQueueService`** — `EnsureDispatching` (background loop) + `DispatchDrainAsync` core + `DrainPriorityAsync` now route through the pool. One **shared** pool (`GetPool`) is the global concurrency gate for *all* paths (background queue, user requests, scheduled sweep), rebuilt only at an idle session start (`forTask` excludes the caller's own running flag, so a rebuild never splits the gate; config changes are picked up on the next idle session).
  - The loop **acquires a slot before dequeuing**, so an item leaves the persisted queue only when a worker is ready to run it — same crash-durability as the old lock.
  - Each job runs in a `Task.Run` deliberately **not** gated on the cancellation token, so the release-`finally` always runs (no slot/reservation leak); cancellation is observed *inside* the transcription.
- **Callers** (`SubtitleController`, `SubtitleRequestService`, `SubtitleGenerationTask`) build the pool from config internally. The scheduled task's own swept items + its priority drain go through the same pool; `MarkTaskStarted` + `ReportTaskComplete`-in-`finally` guard the rebuild gate.

## Preserved

- **#112 queue contract** — tier ordering (strongest first), `(item,language)` dedup + `MergeWork`, `queue.json` persistence, `RestoreQueue` normalisation.
- **v3.29 resilience** — per-call duration-scaled deadlines live in `RemoteWhisperProvider`; the dispatcher just calls the provider.
- **#110 lazy sweep + skip-cache** — the scheduled task stays lazy (does not materialise the library into `queue.json`); it transcribes its swept items through a pool slot instead of the old lock.

## Tests

`878` pass, 0 warnings (build+test on .NET). New pure logic is 100% covered: `WorkerPoolTests` (capacity, single-slot serialisation, concurrent-acquire-then-block, cost-preference, capability fail-fast, duplicate-Id accounting) + `WorkerJobTests` (translate gate + requirements). The `TranscriptionLock` unit test is replaced by a task-running-flag test (the new rebuild gate). Adversarially reviewed for concurrency, default-parity, and cancellation before opening.

## Adversarial review

Three independent reviewers refuted this before opening:
- **Default-parity + #112:** SHIP — confirmed byte-identical default (capacity-1 pool = one whisper at a time across all paths, identical local/remote providers), full #112 preservation, and that a pool split is impossible (both consumers converge on one `SemaphoreSlim` via `GetPool`). Its one finding (the `/Queue` `processed` stat) is fixed here via `countProcessed`.
- **Cancellation/failure:** attacks on inline-cancel, background-drain cancel, and the fail-fast path were airtight; found one real defect — a stuck `_taskIsRunning` when setup throws before the try/finally — **fixed** by extracting the body into `RunGenerationAsync` under a flag-resetting `finally`.
- **Concurrency (semaphore balance, double-processing, pool-swap race, livelock):** re-run in progress; will fold any findings before requesting merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subtitle generation now uses a shared worker pool for smarter, concurrent processing.
  * Requests and scheduled jobs now follow the same dispatch flow for more consistent handling.
  * Added support for selecting queued items by priority while skipping entries that can’t run yet.
  * Improved worker setup to support local and remote execution more flexibly.

* **Bug Fixes**
  * Better task-state handling prevents queue processing from getting stuck.
  * Queue processing now preserves priority order while avoiding unavailable jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->