### PR TITLE
feat(worker): whisper.cpp + Vulkan OpenAI-compatible worker image (v4.0 PR-4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ docker exec jellyfin /opt/whisper/whisper-cli --help
 
 whisper.cpp supports GPU offloading via **Vulkan** (Intel, AMD, and some NVIDIA GPUs), **CUDA** (NVIDIA), and **ROCm** (AMD). GPU acceleration dramatically reduces transcription time, especially with larger models.
 
+> **Offloading to another machine?** You can run transcription on a separate host as an OpenAI-compatible worker and point the plugin at it over HTTP — see [`worker/`](worker/README.md) for a ready-to-run whisper.cpp + Vulkan worker image (plus notes for CPU/NVIDIA/AMD backends).
+
 > **Docker users:** Passing the GPU device (e.g., `/dev/dri`) to a container is **not enough** -- the container also needs the matching userspace libraries installed. The auto-setup wizard detects both the device and the library and will fall back to CPU if the library is missing.
 >
 > | Backend | Device | Required library | Install command (Debian/Ubuntu) |

--- a/worker/.dockerignore
+++ b/worker/.dockerignore
@@ -1,0 +1,7 @@
+# Keep the build context minimal -- only the Dockerfile + adapter + entrypoint
+# are needed by the build. Everything else is docs/examples.
+README.md
+docker-compose.example.yml
+*.md
+.git
+.gitignore

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# whisper-subs worker image: whisper.cpp `whisper-server` (Vulkan, static) fronted
+# by a tiny stdlib-only Python adapter that speaks the plugin's OpenAI-audio dialect.
+#
+# Build (Intel/AMD iGPU via Vulkan, the shipped default):
+#   docker build -t drumsergio/whisper-subs-worker:0.1.0 worker/
+#
+# Other backends are a one-line flag change (see worker/README.md):
+#   CPU-only : --build-arg WHISPER_CMAKE_FLAGS="-DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON"
+#   +ffmpeg  : --build-arg INSTALL_FFMPEG=true      (accept non-WAV audio from other clients)
+# CUDA/ROCm need a different base image + runtime libs -- documented in the README.
+
+# Pin base images by explicit tag (never :latest). For fully reproducible CI builds,
+# replace with a digest pin, e.g. debian:trixie-slim@sha256:<digest>.
+ARG BUILD_IMAGE=debian:trixie-slim
+ARG RUNTIME_IMAGE=debian:trixie-slim
+
+# --------------------------------------------------------------------------- #
+# Stage 1: build whisper-server (static, Vulkan) from a pinned whisper.cpp tag
+# --------------------------------------------------------------------------- #
+FROM ${BUILD_IMAGE} AS build
+
+# Keep in lockstep with the plugin's pinned whisper.cpp (CLAUDE.md / build-release.yml).
+ARG WHISPER_VERSION=v1.8.4
+# Mirrors the plugin's `vulkan` CI matrix flags exactly.
+ARG WHISPER_CMAKE_FLAGS="-DGGML_VULKAN=ON -DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON -DGGML_BMI2=ON"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git cmake g++ make pkg-config ca-certificates \
+        libvulkan-dev glslc \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+RUN git clone --depth 1 --branch "${WHISPER_VERSION}" \
+        https://github.com/ggml-org/whisper.cpp.git .
+
+# -DBUILD_SHARED_LIBS=OFF is MANDATORY (static link; see plugin CLAUDE.md).
+# static libgcc/libstdc++ avoids GLIBCXX drift between build and runtime layers.
+RUN cmake -B build \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=OFF \
+        -DCMAKE_EXE_LINKER_FLAGS="-static-libgcc -static-libstdc++" \
+        ${WHISPER_CMAKE_FLAGS} \
+    && cmake --build build --config Release --target whisper-server -j"$(nproc)" \
+    && test -x build/bin/whisper-server
+
+# --------------------------------------------------------------------------- #
+# Stage 2: slim runtime
+# --------------------------------------------------------------------------- #
+FROM ${RUNTIME_IMAGE} AS runtime
+
+ARG INSTALL_FFMPEG=false
+
+# Runtime deps:
+#   python3        -> the adapter (standard library only)
+#   tini           -> PID 1, reaps the whisper-server child, forwards signals
+#   curl           -> Docker healthcheck + the model downloader
+#   ca-certificates-> HTTPS to Hugging Face for model download
+#   libvulkan1     -> Vulkan loader (dlopens the ICD driver)
+#   mesa-vulkan-drivers -> Intel (ANV) + AMD (RADV) Vulkan drivers + ICD JSONs
+#   libgomp1       -> OpenMP runtime used by the whisper.cpp CPU paths
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 tini curl ca-certificates \
+        libvulkan1 libgomp1 mesa-vulkan-drivers \
+    && if [ "$INSTALL_FFMPEG" = "true" ]; then \
+           apt-get install -y --no-install-recommends ffmpeg; \
+       fi \
+    && rm -rf /var/lib/apt/lists/*
+
+# Non-root user; own the model cache so a named volume is writable on first run.
+# (Debian base has no uid-1000 user; on an Ubuntu-based CUDA build, pick a free uid.)
+RUN useradd --uid 1000 --create-home --shell /usr/sbin/nologin whisper \
+    && mkdir -p /models /opt/whisper-adapter \
+    && chown -R whisper:whisper /models
+
+COPY --from=build /src/build/bin/whisper-server        /usr/local/bin/whisper-server
+COPY --from=build /src/models/download-ggml-model.sh   /usr/local/bin/download-ggml-model.sh
+COPY adapter.py     /opt/whisper-adapter/adapter.py
+COPY entrypoint.sh  /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/whisper-server \
+             /usr/local/bin/download-ggml-model.sh \
+             /usr/local/bin/entrypoint.sh
+
+ENV WHISPER_MODEL=large-v3-turbo-q5_0 \
+    WHISPER_MODEL_DIR=/models \
+    WHISPER_BIN=/usr/local/bin/whisper-server \
+    WHISPER_LANGUAGE=auto \
+    LISTEN_HOST=0.0.0.0 \
+    LISTEN_PORT=8080 \
+    WHISPER_BACKEND_HOST=127.0.0.1 \
+    WHISPER_BACKEND_PORT=8081 \
+    CONVERT=false
+
+EXPOSE 8080
+VOLUME ["/models"]
+
+USER whisper
+WORKDIR /opt/whisper-adapter
+
+# tini as PID 1 so the whisper-server grandchild is reaped and SIGTERM is forwarded.
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/entrypoint.sh"]

--- a/worker/README.md
+++ b/worker/README.md
@@ -1,0 +1,278 @@
+# WhisperSubs Worker Image
+
+An example, ready-to-run **OpenAI-compatible transcription worker** for the
+WhisperSubs remote worker pool. It wraps whisper.cpp's `whisper-server`
+([ggml-org/whisper.cpp](https://github.com/ggml-org/whisper.cpp), `examples/server`)
+built with **Vulkan** — so it GPU-accelerates on **Intel** and **AMD** integrated
+or discrete GPUs — behind a tiny standard-library Python adapter that speaks the
+exact HTTP dialect the plugin's `RemoteWhisperProvider` expects.
+
+You run one (or several) of these on any machine with a spare GPU, then point the
+plugin at each over HTTP. The plugin extracts audio and farms transcription out to
+the workers; all audio still stays inside your own network.
+
+> This is one **example** backend. Any server that implements the OpenAI
+> `/v1/audio/transcriptions` and `/v1/audio/translations` endpoints works — see
+> [Alternative backends](#alternative-backends) for CPU/NVIDIA options.
+
+---
+
+## What the plugin sends (the contract this image serves)
+
+`Providers/RemoteWhisperProvider.cs` posts `multipart/form-data`. The worker must
+serve exactly this:
+
+| Purpose | Method + path | Key form fields | Returns |
+|---|---|---|---|
+| Transcribe | `POST /v1/audio/transcriptions` | `file` (16 kHz mono WAV), `model`, `response_format=srt`, `language` (optional 2-letter; omitted for auto) | SRT text |
+| Detect language | `POST /v1/audio/transcriptions` | `file`, `model`, `response_format=verbose_json` (no `language`) | JSON containing a top-level `language` |
+| Translate → English | `POST /v1/audio/translations` | `file`, `model`, `response_format=srt`, `language` (optional source) | English SRT |
+
+Auth is an optional `Authorization: Bearer <key>`. The `file` is always a 16 kHz
+mono `s16le` WAV (the plugin extracts it with FFmpeg before sending).
+
+---
+
+## Design: why a thin adapter (and not `whisper-server` directly)
+
+`whisper-server` is **not** fully OpenAI-compatible, verified against
+whisper.cpp **v1.8.4** (`examples/server/server.cpp`):
+
+1. **One inference path, not two.** It registers a single inference route —
+   `--request-path` + `--inference-path`, default `/inference` — plus `/load` and
+   `/health`. It cannot serve both `/v1/audio/transcriptions` **and**
+   `/v1/audio/translations`; `--inference-path` can only point the one route at one
+   of them.
+2. **Translate is a form field, not a path.** Translation is selected by a
+   `translate=true` multipart field (`server.cpp` parses `translate`, `language`,
+   `response_format` from the form). The plugin instead selects it by **path**
+   (`/v1/audio/translations`), sending no `translate` field.
+3. **It defaults `language` to `"en"`.** A request with no `language` field would
+   force English and break both auto-transcription and the `verbose_json`
+   language-detection call.
+
+A pure reverse proxy (nginx/Caddy) can rewrite the path but **cannot inject a new
+multipart field** into a streamed request body, so it could never map the
+translations path to `translate=true`. Hence a minimal body-aware adapter:
+
+- routes `POST /v1/audio/transcriptions` → upstream `/inference` **verbatim**;
+- routes `POST /v1/audio/translations` → upstream `/inference` with a
+  `translate=true` part **prepended** to the multipart body — no reparse, the body
+  is **streamed** straight through so a 2-hour film (~260 MB WAV) is never buffered
+  in RAM (matters when several workers run at once);
+- launches `whisper-server` with `--language auto` so detection and auto-mode work
+  (`response_format=verbose_json` returns whisper's language name, which the plugin
+  maps to a 2-letter code);
+- adds optional Bearer auth and a cheap readiness probe;
+- supervises the `whisper-server` child and exits (so the container restarts) if it
+  dies.
+
+The adapter is ~300 lines of Python standard library — **no pip dependencies** —
+in [`adapter.py`](adapter.py). `response_format=srt` and `verbose_json` are both
+native to `whisper-server`, so no response rewriting is needed.
+
+> **One model per worker.** `whisper-server` serves a single model, fixed at
+> startup by `WHISPER_MODEL`. The plugin's per-worker **Model** field is sent but
+> ignored by this backend — choose the model on the worker.
+
+---
+
+## Quick start — Intel / AMD iGPU (Vulkan)
+
+```bash
+# from the repo root
+docker compose -f worker/docker-compose.example.yml up -d
+docker logs -f whisper-subs-worker      # first boot downloads the model
+```
+
+Then in Jellyfin: **Dashboard → Plugins → WhisperSubs → Workers**, add a worker:
+
+| Field | Value |
+|---|---|
+| **Endpoint** | `http://<worker-host>:9010` — base URL, **no** `/v1` suffix |
+| **API key** | only if you set `API_KEY` on the worker |
+| **Model** | informational (the worker's `WHISPER_MODEL` is authoritative) |
+| **Max concurrency** | **1** — one GPU processes ~one stream at a time |
+
+whisper.cpp runs one transcription per GPU context, so keep **MaxConcurrency = 1**
+per single-GPU worker. To do more in parallel, run more workers (another GPU,
+another host) and add each to the pool.
+
+---
+
+## Configuration (environment variables)
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `WHISPER_MODEL` | `large-v3-turbo-q5_0` | GGML model name; downloaded on first run into `/models` |
+| `WHISPER_MODEL_DIR` | `/models` | Model cache directory (mount a volume here) |
+| `API_KEY` | *(empty)* | If set, `Authorization: Bearer <key>` is required on the POST routes |
+| `LISTEN_PORT` | `8080` | Adapter listen port (inside the container) |
+| `CONVERT` | `false` | `true` runs FFmpeg to accept non-WAV audio (needs `INSTALL_FFMPEG=true` image) |
+| `WHISPER_THREADS` | *(whisper default)* | CPU threads (`--threads`) |
+| `WHISPER_LANGUAGE` | `auto` | Upstream default language; per-request `language` still overrides |
+| `WHISPER_EXTRA_ARGS` | *(empty)* | Extra `whisper-server` flags, e.g. `--flash-attn` or `--vad --vad-model /models/ggml-silero-v5.1.2.bin` |
+| `WHISPER_BACKEND_PORT` | `8081` | Internal `whisper-server` port (localhost only) |
+| `WHISPER_READY_TIMEOUT` | `600` | Seconds to wait for the model to load before serving |
+
+---
+
+## GPU backends
+
+### Intel iGPU (Vulkan) — the default
+
+The shipped image already targets Vulkan. Pass `/dev/dri` and add the host
+`render` group (see the compose file). Leave `VK_ICD_FILENAMES` **unset** to let
+the Vulkan loader auto-discover the Mesa **ANV** driver; only pin it if multiple
+GPUs are present and you need a specific one. On Debian/Mesa the Intel ICD is
+usually `/usr/share/vulkan/icd.d/intel_icd.x86_64.json` (verify with
+`docker exec whisper-subs-worker ls /usr/share/vulkan/icd.d/`). The entrypoint
+self-heals a wrong pin by unsetting it and falling back to auto-discovery.
+
+### AMD GPU
+
+- **Vulkan (this image, no rebuild):** works via Mesa **RADV** — pass `/dev/dri`
+  exactly as for Intel. Pin `radeon_icd.x86_64.json` only if needed.
+- **ROCm/HIP (alternative):** rebuild against the ROCm toolkit — different base
+  image and runtime libs:
+  ```bash
+  # build inside rocm/dev-ubuntu-22.04, then a rocm/runtime base:
+  cmake -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF \
+    -DGGML_HIP=ON -DCMAKE_C_COMPILER=hipcc -DCMAKE_CXX_COMPILER=hipcc \
+    --target whisper-server
+  ```
+  Runtime needs `/dev/kfd` + `/dev/dri` and `rocm-hip-runtime`. (This mirrors the
+  plugin's own ROCm build recipe.)
+
+### NVIDIA GPU
+
+- **CUDA (recommended for NVIDIA):** rebuild with the CUDA toolkit base image:
+  ```bash
+  docker build -t whisper-subs-worker:cuda \
+    --build-arg BUILD_IMAGE=nvidia/cuda:12.6.3-devel-ubuntu24.04 \
+    --build-arg RUNTIME_IMAGE=nvidia/cuda:12.6.3-runtime-ubuntu24.04 \
+    --build-arg WHISPER_CMAKE_FLAGS="-DGGML_CUDA=ON -DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON" \
+    worker/
+  ```
+  Run with the NVIDIA Container Toolkit: `docker run --gpus all ...` (or compose
+  `deploy.resources.reservations.devices` / `runtime: nvidia`). The CUDA runtime
+  base already provides the NVIDIA userspace libs; `mesa-vulkan-drivers` is
+  unnecessary for this variant.
+- **Vulkan on NVIDIA:** also possible with the default image if the NVIDIA Vulkan
+  ICD is exposed to the container, but CUDA is the better-supported path.
+
+### CPU only (no GPU)
+
+```bash
+docker build -t whisper-subs-worker:cpu \
+  --build-arg WHISPER_CMAKE_FLAGS="-DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON" \
+  worker/
+```
+
+Drop the `devices:` / `group_add:` lines from the compose file. Expect real-time
+factors well above 1 on large models — prefer a smaller model (see below) or a GPU.
+
+---
+
+## Alternative backends
+
+You are not tied to this image. The plugin talks plain OpenAI audio, so any
+compliant server works. Pick by hardware:
+
+- **[Speaches](https://github.com/speaches-ai/speaches)** (formerly
+  *faster-whisper-server*) — a drop-in OpenAI-compatible server exposing
+  `POST /v1/audio/transcriptions` and `POST /v1/audio/translations`. Built on
+  **faster-whisper / CTranslate2**, whose accelerated backends are **CPU (INT8)**
+  and **NVIDIA CUDA (FP16)**. It is an excellent choice for **CPU-only** boxes and
+  **NVIDIA** GPUs. **CTranslate2 has no Vulkan/oneAPI path, so it does *not*
+  accelerate on Intel iGPUs** — which is exactly why this whisper.cpp + Vulkan image
+  exists for the Intel/AMD-iGPU case.
+- **Any other OpenAI `/v1/audio/*` server** (self-hosted or otherwise) that returns
+  SRT for `response_format=srt` and a `language` field for `verbose_json`.
+
+Whatever you choose, point the plugin's worker **Endpoint** at its base URL and set
+**MaxConcurrency** to match how many streams that backend can really run at once.
+
+---
+
+## Model selection
+
+Models download automatically on first run from
+[huggingface.co/ggerganov/whisper.cpp](https://huggingface.co/ggerganov/whisper.cpp)
+via whisper.cpp's `download-ggml-model.sh`. Set `WHISPER_MODEL` to any known name:
+
+| `WHISPER_MODEL` | Approx. size | Notes |
+|---|---|---|
+| `large-v3-turbo-q5_0` | ~547 MB | **Default.** Best speed/quality/size balance; ideal for an iGPU |
+| `large-v3-turbo` | ~1.6 GB | Full turbo; a bit more quality, more memory |
+| `large-v3` | ~3.1 GB | Highest quality, slowest; ~10 GB RAM under load |
+| `medium` / `small` / `base` | ~1.5 GB / ~466 MB / ~142 MB | Lighter/faster, lower accuracy — good for CPU workers |
+
+`large-v3-turbo-q5_0` is the recommended default: fast, small, and high quality.
+Raise `mem_limit` in the compose file if you move to a full large model.
+
+---
+
+## Verify it works
+
+Readiness (unauthenticated; returns `{"status":"ok"}` once the model is loaded):
+
+```bash
+curl -fsS http://<worker-host>:9010/health
+```
+
+Full smoke test — transcribe a 1-second silent WAV (add `-H "Authorization: Bearer <key>"`
+if `API_KEY` is set):
+
+```bash
+# 16 kHz mono s16le WAV, exactly what the plugin sends
+docker run --rm linuxserver/ffmpeg -f lavfi -i anullsrc=r=16000:cl=mono \
+  -t 1 -c:a pcm_s16le -f wav - > /tmp/silence.wav 2>/dev/null
+
+curl -fsS http://<worker-host>:9010/v1/audio/transcriptions \
+  -F file=@/tmp/silence.wav -F model=whisper-1 -F response_format=srt
+
+# language detection
+curl -fsS http://<worker-host>:9010/v1/audio/transcriptions \
+  -F file=@/tmp/silence.wav -F model=whisper-1 -F response_format=verbose_json
+
+# translation route (adapter injects translate=true)
+curl -fsS http://<worker-host>:9010/v1/audio/translations \
+  -F file=@/tmp/silence.wav -F model=whisper-1 -F response_format=srt
+```
+
+---
+
+## Building & publishing
+
+The published image is built and pushed by CI, mirroring the repo's conventions:
+
+- **Registry:** Docker Hub, image `drumsergio/whisper-subs-worker`.
+- **Tags:** semantic version tags only — e.g. `0.1.0` — **never `:latest`**.
+- **Base images:** pinned by explicit tag; use a `@sha256:` digest pin for fully
+  reproducible CI builds.
+- **whisper.cpp:** pinned to the same tag the plugin uses (`v1.8.4`); bump it in the
+  Dockerfile `WHISPER_VERSION` arg in lockstep with the plugin's pin.
+
+Local build:
+
+```bash
+docker build -t drumsergio/whisper-subs-worker:0.1.0 worker/
+```
+
+---
+
+## Security notes
+
+- The upstream `whisper-server` binds to `127.0.0.1` only; the adapter is the sole
+  public listener. Set `API_KEY` to require a Bearer token on the transcription and
+  translation routes (the readiness probe stays open so healthchecks work).
+- For traffic that leaves the host, terminate **TLS** at a reverse proxy in front of
+  the worker and use an `https://` endpoint in the plugin (it warns when a key is
+  sent over plain HTTP).
+- The container runs as a non-root user; GPU access is granted only via `/dev/dri`
+  plus the host `render` group.
+
+---
+
+*Part of [WhisperSubs](https://github.com/GeiserX/whisper-subs) — GPL-3.0.*

--- a/worker/README.md
+++ b/worker/README.md
@@ -264,14 +264,26 @@ docker build -t drumsergio/whisper-subs-worker:0.1.0 worker/
 
 ## Security notes
 
-- The upstream `whisper-server` binds to `127.0.0.1` only; the adapter is the sole
-  public listener. Set `API_KEY` to require a Bearer token on the transcription and
-  translation routes (the readiness probe stays open so healthchecks work).
-- For traffic that leaves the host, terminate **TLS** at a reverse proxy in front of
-  the worker and use an `https://` endpoint in the plugin (it warns when a key is
-  sent over plain HTTP).
-- The container runs as a non-root user; GPU access is granted only via `/dev/dri`
-  plus the host `render` group.
+> **Run this on a trusted network only, unless you set `API_KEY` *and* put TLS in front.**
+> With no `API_KEY` (the default) the worker is an **unauthenticated** transcription/translation
+> endpoint — anyone who can reach the published port can drive your GPU/CPU. The adapter listens on
+> `0.0.0.0` (it must, so the plugin can reach it from another host) and logs a loud warning at startup
+> when it is serving without a key. Do **not** port-forward it or run it on a public VPS unprotected.
+
+- Set `API_KEY` to require a `Bearer` token on the transcription and translation routes (the readiness
+  probe stays open so Docker healthchecks work). The check is constant-time. The upstream
+  `whisper-server` binds to `127.0.0.1` only; the adapter is the sole public listener.
+- For traffic that leaves the host, terminate **TLS** at a reverse proxy in front of the worker and use
+  an `https://` endpoint in the plugin (it warns when a key is sent over plain HTTP).
+- The adapter frames requests strictly by a single non-negative `Content-Length`, rejects
+  `Transfer-Encoding` and oversized bodies (`WHISPER_MAX_BODY_BYTES`, default 8 GiB), and drops a
+  stalled socket after `WHISPER_SOCKET_TIMEOUT` (default 120 s) so one slow client can't wedge the GPU
+  slot. It is still wise to bound total connections at a reverse proxy for an exposed deployment.
+- The container runs as a non-root user; the example compose adds `no-new-privileges`, `cap_drop: ALL`,
+  and a read-only root filesystem. GPU access is granted only via `/dev/dri` plus the host `render` group.
+- **`CONVERT=true`** (with an `INSTALL_FFMPEG=true` image) makes `whisper-server` shell out to FFmpeg on
+  the uploaded media — a much larger parser attack surface. Leave it off unless you need non-WAV input,
+  and never enable it on an exposed worker.
 
 ---
 

--- a/worker/adapter.py
+++ b/worker/adapter.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# whisper-subs worker adapter
+# ===========================
+#
+# A tiny, dependency-free (Python standard library only) HTTP adapter that makes
+# an upstream `whisper-server` (ggml-org/whisper.cpp, examples/server) speak the
+# exact OpenAI-audio dialect that the whisper-subs plugin's RemoteWhisperProvider
+# expects.
+#
+# WHY THIS EXISTS
+# ---------------
+# whisper.cpp's `whisper-server` exposes a SINGLE inference path (default
+# `/inference`, remappable with `--inference-path`). It cannot serve both
+# `/v1/audio/transcriptions` AND `/v1/audio/translations` at once, and it selects
+# translation via a `translate` multipart FIELD rather than a distinct path.
+#
+# The plugin (Providers/RemoteWhisperProvider.cs), by contrast, is hard-wired to:
+#   * POST /v1/audio/transcriptions   -> transcribe (or detect language)
+#   * POST /v1/audio/translations     -> translate to English
+# with multipart fields: file, model, response_format (srt | verbose_json),
+# and an optional language. Translation is chosen purely by the PATH.
+#
+# A pure reverse proxy (nginx/Caddy) can rewrite the path but cannot inject a new
+# multipart field into a streamed body, so the translations route could never be
+# mapped to whisper.cpp's `translate=true`. This adapter does exactly and only
+# that mapping, while STREAMING the (potentially very large) audio body straight
+# through so N concurrent workers never buffer whole films in RAM.
+#
+# WHAT IT DOES
+# ------------
+#   * POST /v1/audio/transcriptions  -> proxied verbatim to upstream /inference.
+#   * POST /v1/audio/translations    -> proxied to /inference with a `translate=true`
+#                                       multipart part PREPENDED to the body (no
+#                                       reparsing, fully streamed).
+#   * GET|HEAD /health and GET|HEAD on the two audio paths -> cheap readiness probe
+#     (200 when the upstream model is loaded, 503 while loading). Never runs
+#     inference, never requires the API key -> safe for Docker healthchecks.
+#   * Optional Bearer auth on the POST routes when API_KEY is set.
+#   * Spawns and supervises the upstream `whisper-server` child process; if it
+#     dies, the adapter exits non-zero so the container restarts.
+#
+# Language handling: whisper-server defaults `language` to "en" (server.cpp), which
+# would break auto-detect and the plugin's verbose_json language-detection call.
+# We therefore launch it with `--language auto`; an explicit `language` field in a
+# request still overrides per-call. (See entrypoint / adapter spawn below.)
+
+import http.client
+import os
+import shlex
+import signal
+import socket
+import subprocess
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+# --------------------------------------------------------------------------- #
+# Configuration (all via environment; sensible defaults for the shipped image)
+# --------------------------------------------------------------------------- #
+def _env(name, default):
+    v = os.environ.get(name)
+    return v if v is not None and v != "" else default
+
+
+LISTEN_HOST = _env("LISTEN_HOST", "0.0.0.0")
+LISTEN_PORT = int(_env("LISTEN_PORT", "8080"))
+
+BACKEND_HOST = _env("WHISPER_BACKEND_HOST", "127.0.0.1")
+BACKEND_PORT = int(_env("WHISPER_BACKEND_PORT", "8081"))
+BACKEND_INFERENCE_PATH = _env("WHISPER_INFERENCE_PATH", "/inference")
+
+# Long, finite ceiling. The plugin enforces its own per-call deadline and drops
+# the socket; we just must not guillotine a legitimately long film transcription.
+BACKEND_TIMEOUT = float(_env("WHISPER_BACKEND_TIMEOUT", str(24 * 60 * 60)))
+
+API_KEY = _env("API_KEY", "")  # empty -> no auth required
+
+WHISPER_BIN = _env("WHISPER_BIN", "/usr/local/bin/whisper-server")
+# entrypoint.sh resolves + downloads the model and exports the absolute path.
+MODEL_FILE = _env("WHISPER_MODEL_FILE", "")
+WHISPER_LANGUAGE = _env("WHISPER_LANGUAGE", "auto")
+WHISPER_THREADS = _env("WHISPER_THREADS", "")   # "" -> whisper.cpp default
+WHISPER_CONVERT = _env("CONVERT", "false").lower() in ("1", "true", "yes", "y")
+WHISPER_EXTRA_ARGS = _env("WHISPER_EXTRA_ARGS", "")
+
+READY_TIMEOUT = int(_env("WHISPER_READY_TIMEOUT", "600"))  # seconds to first-ready
+
+CHUNK = 256 * 1024
+
+TRANSCRIBE_PATH = "/v1/audio/transcriptions"
+TRANSLATE_PATH = "/v1/audio/translations"
+
+
+def log(msg):
+    sys.stdout.write("[adapter] %s\n" % msg)
+    sys.stdout.flush()
+
+
+# --------------------------------------------------------------------------- #
+# Upstream whisper-server lifecycle
+# --------------------------------------------------------------------------- #
+_child = None  # type: subprocess.Popen | None
+
+
+def spawn_whisper_server():
+    global _child
+    if not MODEL_FILE or not os.path.isfile(MODEL_FILE):
+        log("FATAL: model file not found: %r (set WHISPER_MODEL / WHISPER_MODEL_FILE)" % MODEL_FILE)
+        sys.exit(1)
+
+    cmd = [
+        WHISPER_BIN,
+        "--host", BACKEND_HOST,
+        "--port", str(BACKEND_PORT),
+        "--model", MODEL_FILE,
+        "--inference-path", BACKEND_INFERENCE_PATH,
+        # Default to auto-detect so a request WITHOUT a language field detects the
+        # spoken language instead of forcing English (whisper-server defaults to
+        # "en"). The plugin's verbose_json language-detection call relies on this.
+        "--language", WHISPER_LANGUAGE,
+    ]
+    if WHISPER_THREADS:
+        cmd += ["--threads", WHISPER_THREADS]
+    if WHISPER_CONVERT:
+        # Requires ffmpeg in the image (build with --build-arg INSTALL_FFMPEG=true).
+        cmd += ["--convert"]
+    if WHISPER_EXTRA_ARGS:
+        cmd += shlex.split(WHISPER_EXTRA_ARGS)
+
+    log("starting upstream: %s" % " ".join(shlex.quote(c) for c in cmd))
+    _child = subprocess.Popen(cmd)
+
+    # If the upstream dies, take the whole container down so it restarts cleanly
+    # (docker-compose `restart: unless-stopped`) rather than serving 502s forever.
+    def _watch():
+        code = _child.wait()
+        log("upstream whisper-server exited (code=%s); shutting down" % code)
+        os._exit(1 if code else 0)
+
+    threading.Thread(target=_watch, name="whisper-watch", daemon=True).start()
+
+
+def _terminate_child():
+    if _child and _child.poll() is None:
+        try:
+            _child.terminate()
+            try:
+                _child.wait(timeout=10)
+            except Exception:
+                _child.kill()
+        except Exception:
+            pass
+
+
+def backend_ready():
+    try:
+        c = http.client.HTTPConnection(BACKEND_HOST, BACKEND_PORT, timeout=5)
+        c.request("GET", "/health")
+        r = c.getresponse()
+        r.read()
+        c.close()
+        return r.status == 200
+    except Exception:
+        return False
+
+
+def wait_until_ready(timeout):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if backend_ready():
+            return True
+        if _child and _child.poll() is not None:
+            return False  # child already crashed; watcher will exit us
+        time.sleep(1.0)
+    return False
+
+
+# --------------------------------------------------------------------------- #
+# HTTP handler
+# --------------------------------------------------------------------------- #
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    server_version = "whisper-subs-worker"
+
+    # Quieter, single-line access log.
+    def log_message(self, fmt, *args):
+        log("%s - %s" % (self.address_string(), fmt % args))
+
+    # -- helpers ----------------------------------------------------------- #
+    def _send_json(self, status, payload, close=False):
+        body = payload.encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        if close:
+            self.close_connection = True
+            self.send_header("Connection", "close")
+        self.end_headers()
+        try:
+            self.wfile.write(body)
+        except Exception:
+            pass
+
+    def _readiness(self):
+        if backend_ready():
+            self._send_json(200, '{"status":"ok"}')
+        else:
+            self._send_json(503, '{"status":"loading model"}', close=True)
+
+    def _authorized(self):
+        if not API_KEY:
+            return True
+        return self.headers.get("Authorization", "") == "Bearer " + API_KEY
+
+    # -- verbs ------------------------------------------------------------- #
+    def do_HEAD(self):
+        if self.path in ("/health", TRANSCRIBE_PATH, TRANSLATE_PATH, "/"):
+            # HEAD readiness: status only, no body.
+            ok = backend_ready()
+            self.send_response(200 if ok else 503)
+            self.send_header("Content-Length", "0")
+            if not ok:
+                self.close_connection = True
+                self.send_header("Connection", "close")
+            self.end_headers()
+        else:
+            self.send_response(404)
+            self.send_header("Content-Length", "0")
+            self.close_connection = True
+            self.end_headers()
+
+    def do_GET(self):
+        # GET on the audio paths is a lightweight readiness probe only; the real
+        # work is POST. This lets a healthcheck "hit the transcriptions endpoint"
+        # without spending a GPU inference and without needing the API key.
+        if self.path in ("/health", TRANSCRIBE_PATH, TRANSLATE_PATH, "/"):
+            self._readiness()
+        else:
+            self._send_json(404, '{"error":"not found"}', close=True)
+
+    def do_POST(self):
+        if self.path == TRANSCRIBE_PATH:
+            self._proxy_inference(inject_translate=False)
+        elif self.path == TRANSLATE_PATH:
+            self._proxy_inference(inject_translate=True)
+        else:
+            self._send_json(404, '{"error":"not found"}', close=True)
+
+    # -- core proxy -------------------------------------------------------- #
+    def _proxy_inference(self, inject_translate):
+        if not self._authorized():
+            self._send_json(401, '{"error":"unauthorized"}', close=True)
+            return
+
+        content_type = self.headers.get("Content-Type", "")
+        content_length = self.headers.get("Content-Length")
+
+        if content_length is None:
+            # We stream by Content-Length; the plugin always sends one. Chunked
+            # uploads are rejected rather than silently buffered.
+            self._send_json(411, '{"error":"length required"}', close=True)
+            return
+
+        try:
+            body_len = int(content_length)
+        except ValueError:
+            self._send_json(400, '{"error":"bad content-length"}', close=True)
+            return
+
+        prefix = b""
+        total_len = body_len
+        if inject_translate:
+            boundary = _extract_boundary(content_type)
+            if not boundary:
+                self._send_json(
+                    400,
+                    '{"error":"translations route requires multipart/form-data"}',
+                    close=True,
+                )
+                return
+            # Prepend a well-formed multipart part. The original body already
+            # starts with `--boundary...`, so `prefix + body` stays valid and the
+            # injected field is simply the first one parsed. No reparse, no buffer.
+            prefix = (
+                "--%s\r\n"
+                'Content-Disposition: form-data; name="translate"\r\n'
+                "\r\n"
+                "true\r\n" % boundary
+            ).encode("latin-1")
+            total_len = body_len + len(prefix)
+
+        try:
+            conn = http.client.HTTPConnection(
+                BACKEND_HOST, BACKEND_PORT, timeout=BACKEND_TIMEOUT
+            )
+            conn.putrequest(
+                "POST", BACKEND_INFERENCE_PATH, skip_host=True, skip_accept_encoding=True
+            )
+            conn.putheader("Host", "%s:%d" % (BACKEND_HOST, BACKEND_PORT))
+            conn.putheader("Content-Type", content_type)
+            conn.putheader("Content-Length", str(total_len))
+            conn.endheaders()
+
+            if prefix:
+                conn.send(prefix)
+
+            remaining = body_len
+            aborted = False
+            while remaining > 0:
+                chunk = self.rfile.read(min(CHUNK, remaining))
+                if not chunk:
+                    aborted = True  # client (plugin) closed the body early
+                    break
+                conn.send(chunk)
+                remaining -= len(chunk)
+
+            if aborted:
+                # We promised Content-Length bytes we can no longer deliver. Reset
+                # the upstream connection so whisper-server stops waiting and frees
+                # its context instead of blocking the next request.
+                conn.close()
+                self._send_json(400, '{"error":"client closed request body"}', close=True)
+                return
+
+            resp = conn.getresponse()
+            payload = resp.read()  # SRT / JSON responses are small text bodies
+            resp_ctype = resp.getheader("Content-Type", "text/plain; charset=utf-8")
+            conn.close()
+        except (socket.timeout, ConnectionError, OSError, http.client.HTTPException) as exc:
+            log("upstream error: %r" % exc)
+            self._send_json(502, '{"error":"upstream whisper-server unavailable"}', close=True)
+            return
+
+        # Relay upstream status + body back to the plugin verbatim.
+        self.send_response(resp.status)
+        self.send_header("Content-Type", resp_ctype)
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        try:
+            self.wfile.write(payload)
+        except Exception:
+            pass
+
+
+def _extract_boundary(content_type):
+    # e.g. 'multipart/form-data; boundary=----XYZ' (boundary may be quoted).
+    if "multipart/form-data" not in content_type.lower():
+        return None
+    for part in content_type.split(";"):
+        part = part.strip()
+        if part.lower().startswith("boundary="):
+            b = part[len("boundary="):].strip()
+            if len(b) >= 2 and b[0] == '"' and b[-1] == '"':
+                b = b[1:-1]
+            return b
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# main
+# --------------------------------------------------------------------------- #
+def main():
+    def _term(signum, _frame):
+        log("received signal %s; stopping" % signum)
+        _terminate_child()
+        os._exit(0)
+
+    signal.signal(signal.SIGTERM, _term)
+    signal.signal(signal.SIGINT, _term)
+
+    spawn_whisper_server()
+
+    log("waiting for upstream model to load (timeout=%ds)..." % READY_TIMEOUT)
+    if not wait_until_ready(READY_TIMEOUT):
+        log("upstream not ready within %ds; continuing to serve (readiness=503 until loaded)" % READY_TIMEOUT)
+    else:
+        log("upstream ready; model loaded")
+
+    httpd = ThreadingHTTPServer((LISTEN_HOST, LISTEN_PORT), Handler)
+    httpd.daemon_threads = True
+    log("listening on %s:%d -> upstream %s:%d%s (auth=%s, convert=%s)" % (
+        LISTEN_HOST, LISTEN_PORT, BACKEND_HOST, BACKEND_PORT, BACKEND_INFERENCE_PATH,
+        "on" if API_KEY else "off", "on" if WHISPER_CONVERT else "off",
+    ))
+    try:
+        httpd.serve_forever()
+    finally:
+        _terminate_child()
+
+
+if __name__ == "__main__":
+    main()

--- a/worker/adapter.py
+++ b/worker/adapter.py
@@ -46,6 +46,7 @@
 # We therefore launch it with `--language auto`; an explicit `language` field in a
 # request still overrides per-call. (See entrypoint / adapter spawn below.)
 
+import hmac
 import http.client
 import os
 import shlex
@@ -88,6 +89,15 @@ WHISPER_CONVERT = _env("CONVERT", "false").lower() in ("1", "true", "yes", "y")
 WHISPER_EXTRA_ARGS = _env("WHISPER_EXTRA_ARGS", "")
 
 READY_TIMEOUT = int(_env("WHISPER_READY_TIMEOUT", "600"))  # seconds to first-ready
+
+# Drop a stalled-but-open client after this many seconds so one slow/silent
+# connection can't hold the single whisper-server inference slot forever (M2).
+SOCKET_TIMEOUT = float(_env("WHISPER_SOCKET_TIMEOUT", "120"))
+
+# Reject an absurd Content-Length outright (M2). A 2h film's 16 kHz mono WAV is
+# ~260 MB; the default 8 GiB ceiling is generous but bounds a memory/disk-abuse
+# upload. Set WHISPER_MAX_BODY_BYTES=0 to disable the cap.
+MAX_BODY_BYTES = int(_env("WHISPER_MAX_BODY_BYTES", str(8 * 1024 * 1024 * 1024)))
 
 CHUNK = 256 * 1024
 
@@ -185,6 +195,8 @@ def wait_until_ready(timeout):
 class Handler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
     server_version = "whisper-subs-worker"
+    # Drop a stalled socket (slow-loris / silent client) so it can't wedge the GPU slot (M2).
+    timeout = SOCKET_TIMEOUT
 
     # Quieter, single-line access log.
     def log_message(self, fmt, *args):
@@ -214,7 +226,8 @@ class Handler(BaseHTTPRequestHandler):
     def _authorized(self):
         if not API_KEY:
             return True
-        return self.headers.get("Authorization", "") == "Bearer " + API_KEY
+        # Constant-time compare so the key can't be recovered byte-by-byte via response timing (L1).
+        return hmac.compare_digest(self.headers.get("Authorization", ""), "Bearer " + API_KEY)
 
     # -- verbs ------------------------------------------------------------- #
     def do_HEAD(self):
@@ -257,18 +270,29 @@ class Handler(BaseHTTPRequestHandler):
             return
 
         content_type = self.headers.get("Content-Type", "")
-        content_length = self.headers.get("Content-Length")
 
-        if content_length is None:
-            # We stream by Content-Length; the plugin always sends one. Chunked
-            # uploads are rejected rather than silently buffered.
-            self._send_json(411, '{"error":"length required"}', close=True)
+        # This adapter frames the body strictly by Content-Length. Reject Transfer-Encoding outright
+        # (501) so a `Content-Length` + `Transfer-Encoding: chunked` pair can't desync a front proxy
+        # against this origin (TE.CL request smuggling, M3).
+        if self.headers.get("Transfer-Encoding"):
+            self._send_json(501, '{"error":"transfer-encoding not supported"}', close=True)
             return
 
-        try:
-            body_len = int(content_length)
-        except ValueError:
-            self._send_json(400, '{"error":"bad content-length"}', close=True)
+        # Exactly one Content-Length, strictly a non-negative decimal. int() is too lenient (it accepts
+        # " 10 ", "+10", "-5", "1_000"); reject duplicates/garbage to avoid a CL.CL desync (M3).
+        cl_values = self.headers.get_all("Content-Length") or []
+        if len(cl_values) != 1 or not cl_values[0].strip().isdigit():
+            self._send_json(
+                400 if cl_values else 411,
+                '{"error":"a single non-negative Content-Length is required"}',
+                close=True,
+            )
+            return
+        body_len = int(cl_values[0].strip())
+
+        # Reject an absurd upload before streaming it anywhere (M2).
+        if MAX_BODY_BYTES and body_len > MAX_BODY_BYTES:
+            self._send_json(413, '{"error":"request body too large"}', close=True)
             return
 
         prefix = b""
@@ -293,6 +317,7 @@ class Handler(BaseHTTPRequestHandler):
             ).encode("latin-1")
             total_len = body_len + len(prefix)
 
+        conn = None
         try:
             conn = http.client.HTTPConnection(
                 BACKEND_HOST, BACKEND_PORT, timeout=BACKEND_TIMEOUT
@@ -319,21 +344,23 @@ class Handler(BaseHTTPRequestHandler):
                 remaining -= len(chunk)
 
             if aborted:
-                # We promised Content-Length bytes we can no longer deliver. Reset
-                # the upstream connection so whisper-server stops waiting and frees
-                # its context instead of blocking the next request.
-                conn.close()
+                # We promised Content-Length bytes we can no longer deliver. The finally resets the
+                # upstream connection so whisper-server stops waiting and frees its context.
                 self._send_json(400, '{"error":"client closed request body"}', close=True)
                 return
 
             resp = conn.getresponse()
             payload = resp.read()  # SRT / JSON responses are small text bodies
             resp_ctype = resp.getheader("Content-Type", "text/plain; charset=utf-8")
-            conn.close()
         except (socket.timeout, ConnectionError, OSError, http.client.HTTPException) as exc:
             log("upstream error: %r" % exc)
             self._send_json(502, '{"error":"upstream whisper-server unavailable"}', close=True)
             return
+        finally:
+            # Always release the upstream socket — including the exception path, which previously
+            # relied on GC to close it (L4). close() is safe to call more than once.
+            if conn is not None:
+                conn.close()
 
         # Relay upstream status + body back to the plugin verbatim.
         self.send_response(resp.status)
@@ -379,6 +406,11 @@ def main():
         log("upstream not ready within %ds; continuing to serve (readiness=503 until loaded)" % READY_TIMEOUT)
     else:
         log("upstream ready; model loaded")
+
+    if not API_KEY and LISTEN_HOST not in ("127.0.0.1", "localhost", "::1"):
+        log("WARNING: serving on %s with NO API_KEY — this transcription endpoint is UNAUTHENTICATED. "
+            "Run it only on a trusted network; set API_KEY (and put TLS in front) before exposing it "
+            "to any untrusted network or the internet (M1)." % LISTEN_HOST)
 
     httpd = ThreadingHTTPServer((LISTEN_HOST, LISTEN_PORT), Handler)
     httpd.daemon_threads = True

--- a/worker/docker-compose.example.yml
+++ b/worker/docker-compose.example.yml
@@ -54,6 +54,19 @@ services:
       # Model cache -- survives restarts so the model is downloaded only once.
       - whisper-models:/models
 
+    # Container hardening. The image already runs non-root (uid 1000); these drop the
+    # rest of the ambient privilege so an exposed/compromised worker is contained.
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    # Read-only root filesystem: only the model cache (/models volume) and a small tmpfs
+    # need to be writable. Comment this pair out if a model download ever needs to write
+    # elsewhere on first run.
+    read_only: true
+    tmpfs:
+      - /tmp
+
     # Cap RAM. large-v3-turbo-q5_0 is light; raise to ~10g for full large-v3.
     mem_limit: 6g
 

--- a/worker/docker-compose.example.yml
+++ b/worker/docker-compose.example.yml
@@ -1,0 +1,71 @@
+# whisper-subs worker -- Intel / AMD iGPU (Vulkan) example.
+#
+# 1. Start it:            docker compose -f docker-compose.example.yml up -d
+#    (first boot downloads the model into the `whisper-models` volume; be patient.)
+# 2. Point the plugin at it: Dashboard > Plugins > WhisperSubs > Workers ->
+#    add a worker with Endpoint http://<this-host>:9010  (NO /v1 suffix),
+#    the API key below if set, and MaxConcurrency = 1 (one iGPU ~= one stream).
+#
+# NB: never use the :latest tag -- pin a semver image tag.
+
+services:
+  whisper-subs-worker:
+    image: drumsergio/whisper-subs-worker:0.1.0
+    # To build locally instead of pulling, comment out `image:` above and uncomment:
+    # build:
+    #   context: .
+    #   dockerfile: Dockerfile
+    container_name: whisper-subs-worker
+    restart: unless-stopped
+
+    ports:
+      # host:container -- the plugin connects to http://<host>:9010
+      - "9010:8080"
+
+    environment:
+      # Served whisper model. whisper-server serves exactly ONE model; the plugin's
+      # per-worker "Model" field is sent but ignored by this backend -- set it HERE.
+      WHISPER_MODEL: large-v3-turbo-q5_0
+      # Optional Bearer token. If set, configure the SAME key on the plugin worker.
+      # API_KEY: "change-me-to-a-long-random-string"
+      # Accept non-WAV audio from other OpenAI clients (needs an image built with
+      # --build-arg INSTALL_FFMPEG=true). The plugin always sends 16kHz WAV, so off.
+      # CONVERT: "false"
+      # WHISPER_THREADS: "4"           # CPU threads for whisper.cpp (default: its own)
+      # WHISPER_EXTRA_ARGS: "--flash-attn"   # extra whisper-server flags
+      # Pin a specific Vulkan ICD only if auto-discovery picks the wrong GPU. The
+      # exact filename varies (Debian/Mesa often uses the *.x86_64.json form); leave
+      # UNSET to auto-discover. Verify with: docker exec ... ls /usr/share/vulkan/icd.d/
+      # VK_ICD_FILENAMES: /usr/share/vulkan/icd.d/intel_icd.x86_64.json   # Intel
+      # VK_ICD_FILENAMES: /usr/share/vulkan/icd.d/radeon_icd.x86_64.json  # AMD
+
+    devices:
+      # Intel/AMD iGPU passthrough.
+      - /dev/dri:/dev/dri
+
+    group_add:
+      # The non-root container user needs the host's `render` (and sometimes
+      # `video`) group to open /dev/dri/renderD128. Find the numeric GID with
+      #   getent group render     (e.g. 993, 104, ...)
+      # and replace "render" below with that number if the name does not resolve.
+      - "render"
+
+    volumes:
+      # Model cache -- survives restarts so the model is downloaded only once.
+      - whisper-models:/models
+
+    # Cap RAM. large-v3-turbo-q5_0 is light; raise to ~10g for full large-v3.
+    mem_limit: 6g
+
+    healthcheck:
+      # /health reports 200 only once the model is loaded (same backend that
+      # serves /v1/audio/transcriptions). Unauthenticated by design.
+      test: ["CMD", "curl", "-fsS", "-o", "/dev/null", "http://127.0.0.1:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      # Generous: the first start downloads the model before it can report healthy.
+      start_period: 600s
+
+volumes:
+  whisper-models:

--- a/worker/entrypoint.sh
+++ b/worker/entrypoint.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Container entrypoint for the whisper-subs worker image.
+#   1. Resolve + (first run) download the requested GGML model into the cache volume.
+#   2. Self-heal a stale VK_ICD_FILENAMES so Vulkan can always fall back to auto-discovery.
+#   3. Hand off (exec) to the Python adapter, which spawns and supervises whisper-server.
+set -eu
+
+MODEL_DIR="${WHISPER_MODEL_DIR:-/models}"
+MODEL_NAME="${WHISPER_MODEL:-large-v3-turbo-q5_0}"
+MODEL_FILE="${MODEL_DIR}/ggml-${MODEL_NAME}.bin"
+
+mkdir -p "$MODEL_DIR"
+
+if [ ! -f "$MODEL_FILE" ]; then
+    echo "[entrypoint] model '${MODEL_NAME}' not present; downloading into ${MODEL_DIR} ..."
+    # download-ggml-model.sh validates the name against whisper.cpp's known list and
+    # fetches ggml-<model>.bin from huggingface.co/ggerganov/whisper.cpp.
+    download-ggml-model.sh "$MODEL_NAME" "$MODEL_DIR"
+fi
+
+if [ ! -f "$MODEL_FILE" ]; then
+    echo "[entrypoint] FATAL: model file still missing after download: ${MODEL_FILE}" >&2
+    echo "[entrypoint] check WHISPER_MODEL is a valid whisper.cpp model name." >&2
+    exit 1
+fi
+
+# Vulkan: if a specific ICD was pinned but does not exist in this image/host, drop
+# it so the loader auto-discovers whatever driver IS present (Intel ANV, AMD RADV, ...).
+if [ -n "${VK_ICD_FILENAMES:-}" ] && [ ! -e "${VK_ICD_FILENAMES}" ]; then
+    echo "[entrypoint] WARN: VK_ICD_FILENAMES='${VK_ICD_FILENAMES}' not found; unsetting for Vulkan auto-discovery." >&2
+    unset VK_ICD_FILENAMES
+fi
+
+export WHISPER_MODEL_FILE="$MODEL_FILE"
+echo "[entrypoint] serving model: ${MODEL_FILE}"
+
+exec python3 /opt/whisper-adapter/adapter.py


### PR DESCRIPTION
## What

v4.0 PR-4 — an example **whisper.cpp + Vulkan** OpenAI-compatible transcription **worker image** the plugin's worker pool can transcribe against, plus docs for other backends. Additive: only `worker/` files + a one-line root-README pointer (disjoint from PR-3; merges cleanly).

Targets `v4-dev`.

## Design: why a thin adapter (not `whisper-server` directly)

Verified against whisper.cpp **v1.8.4** `examples/server/server.cpp`: `whisper-server` is **not** OpenAI-compatible on both paths — it serves one `/inference` route (translate is a form *field*, not a path) and defaults `language=en`. The plugin (`RemoteWhisperProvider`) instead selects translation by **path** (`/v1/audio/translations`). A pure reverse proxy can rewrite the path but can't inject a multipart field into a streamed body. So a **~300-line stdlib-only Python adapter** maps both OpenAI paths → `/inference`, **prepends** a streamed `translate=true` part on the translations route, enforces optional Bearer auth, exposes unauthenticated readiness probes, and supervises the child (launched with `--language auto`).

## Files (`worker/`)

- `Dockerfile` — multi-stage; builds `whisper-server` with the plugin's exact Vulkan flags + `-DBUILD_SHARED_LIBS=OFF` static; slim `debian:trixie-slim` runtime, **non-root uid 1000**, tini PID 1; model downloaded at **runtime** (small image); ARGs for version/flags/ffmpeg.
- `adapter.py` — the OpenAI↔`/inference` adapter (zero pip deps).
- `entrypoint.sh` — model download + Vulkan ICD self-heal.
- `docker-compose.example.yml` — Intel/AMD iGPU passthrough (`/dev/dri` + `render` group), model-cache volume, healthcheck, `mem_limit`, optional `API_KEY`, hardening (`no-new-privileges`, `cap_drop: ALL`, read-only rootfs).
- `README.md` — general for Intel/AMD/NVIDIA/CPU; contract table; plugin wiring; alternative backends (Speaches for CPU/NVIDIA); model table; smoke tests.

## Security

Adversarially reviewed → **no Critical/High** (auth bypass, SSRF, header/multipart injection, command injection, secret exposure all cleared by construction). Hardening fixes applied (`bc18210`): startup warning + docs for unauthenticated exposure (M1), socket timeout + body-size cap so a slow client can't wedge the GPU slot (M2), reject `Transfer-Encoding`/lenient/duplicate `Content-Length` request smuggling (M3), compose hardening (M4), constant-time auth (L1), always-close upstream socket (L4).

## Verification

Not `docker build`-tested here (no Vulkan hardware). `adapter.py` compiles; `entrypoint.sh` passes `sh -n`; compose YAML validated; a mock-backend functional test passes **10/10** (happy transcribe with no translate injection, translate injection preserved + file part intact, 401 wrong-key, 501 TE, 400 bad-CL, 413 oversize, open readiness). The image is built/pushed by CI per repo conventions.

## Open questions (your call — not blockers, sensible defaults chosen)

1. **whisper.cpp version** — pinned **v1.8.4** to match the plugin's CI/CLAUDE.md (output parity). Latest is v1.8.6 — one-line `WHISPER_VERSION` bump if you want it.
2. **Default model** — `large-v3-turbo-q5_0` (~547 MB): the speed/quality/size sweet spot for an iGPU.
3. **CI image publish** — I did **not** add a workflow to build+push `drumsergio/whisper-subs-worker` to Docker Hub (the existing `build-release.yml` is plugin-only). Follow-up PR when you want the image actually published.
