### PR TITLE
feat(ui+api): worker-pool config UI + queue inbound/outbound visibility (v4.0 PR-5)

### DIFF
--- a/Api/SubtitleController.cs
+++ b/Api/SubtitleController.cs
@@ -332,6 +332,86 @@ namespace WhisperSubs.Api
         }
 
         /// <summary>
+        /// Tests a worker endpoint (v4.0 config UI): POSTs a tiny silent WAV to its transcription route so
+        /// the admin can confirm reachability + auth + a working transcribe path before saving the worker,
+        /// without touching the media library. Never throws — always returns a shaped {ok, message} result.
+        /// </summary>
+        [HttpPost("Workers/TestConnection")]
+        public async Task<ActionResult> TestWorkerConnection([FromBody] WorkerTestRequest request)
+        {
+            if (request == null)
+            {
+                return BadRequest(new { ok = false, message = "Missing request body." });
+            }
+
+            var worker = new Configuration.WhisperWorker
+            {
+                ApiUrl = request.ApiUrl ?? "",
+                ApiKey = request.ApiKey ?? "",
+                Model = request.Model ?? "",
+                MaxConcurrency = 1,
+                CostWeight = 0
+            };
+            var (valid, error) = Controller.Workers.WorkerConfigValidation.Validate(worker);
+            if (!valid)
+            {
+                return Ok(new { ok = false, message = error });
+            }
+
+            var url = worker.ApiUrl.TrimEnd('/') + "/v1/audio/transcriptions";
+            var model = string.IsNullOrWhiteSpace(worker.Model) ? "Systran/faster-whisper-large-v3" : worker.Model.Trim();
+            var wav = Controller.Workers.SyntheticAudio.SilentWav16kMono(100);
+
+            using var content = new System.Net.Http.MultipartFormDataContent();
+            var fileContent = new System.Net.Http.ByteArrayContent(wav);
+            fileContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("audio/wav");
+            content.Add(fileContent, "file", "test.wav");
+            content.Add(new System.Net.Http.StringContent(model), "model");
+            content.Add(new System.Net.Http.StringContent("srt"), "response_format");
+
+            using var probe = new System.Net.Http.HttpRequestMessage(System.Net.Http.HttpMethod.Post, url) { Content = content };
+            if (!string.IsNullOrWhiteSpace(worker.ApiKey))
+            {
+                probe.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", worker.ApiKey.Trim());
+            }
+
+            var http = _httpClientFactory.CreateClient();
+            http.Timeout = TimeSpan.FromSeconds(20);
+
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            try
+            {
+                using var resp = await http.SendAsync(probe);
+                sw.Stop();
+                if (resp.IsSuccessStatusCode)
+                {
+                    return Ok(new
+                    {
+                        ok = true,
+                        status = (int)resp.StatusCode,
+                        latencyMs = sw.ElapsedMilliseconds,
+                        message = $"OK — transcribed a test clip in {sw.ElapsedMilliseconds} ms."
+                    });
+                }
+
+                var body = await resp.Content.ReadAsStringAsync();
+                var snippet = body.Length > 200 ? body.Substring(0, 200) : body;
+                return Ok(new
+                {
+                    ok = false,
+                    status = (int)resp.StatusCode,
+                    latencyMs = sw.ElapsedMilliseconds,
+                    message = $"HTTP {(int)resp.StatusCode}: {snippet}"
+                });
+            }
+            catch (Exception ex)
+            {
+                sw.Stop();
+                return Ok(new { ok = false, latencyMs = sw.ElapsedMilliseconds, message = $"Unreachable: {ex.Message}" });
+            }
+        }
+
+        /// <summary>
         /// Lists all user subtitle requests (admin), newest first — for the config-page approval panel.
         /// Returns item names + state only; never a filesystem path. (Issue #112.)
         /// </summary>
@@ -998,6 +1078,14 @@ namespace WhisperSubs.Api
         public List<ItemInfo> Items { get; set; } = new List<ItemInfo>();
         public int TotalCount { get; set; }
         public int StartIndex { get; set; }
+    }
+
+    /// <summary>Body for the worker "Test connection" probe (v4.0): the endpoint + optional key/model to try.</summary>
+    public class WorkerTestRequest
+    {
+        public string? ApiUrl { get; set; }
+        public string? ApiKey { get; set; }
+        public string? Model { get; set; }
     }
 }
 

--- a/Api/SubtitleController.cs
+++ b/Api/SubtitleController.cs
@@ -309,7 +309,25 @@ namespace WhisperSubs.Api
                 library = queue.TaskCurrentItemLibrary,
                 // Named-tier breakdown of what's queued + how many user requests await approval (#112).
                 tiers = queue.CountsByTier().ToDictionary(kv => kv.Key.ToString(), kv => kv.Value),
-                pendingRequests = SubtitleRequestStore.Instance.GetAll().Count(r => r.State == RequestState.Pending)
+                pendingRequests = SubtitleRequestStore.Instance.GetAll().Count(r => r.State == RequestState.Pending),
+                // Inbound: the items waiting, in the order they'll run (capped; the full total is `remaining`). (v4.0)
+                pending = queue.PendingItems().Select(p => new
+                {
+                    name = p.Name,
+                    tier = p.Tier.ToString(),
+                    language = p.Language
+                }),
+                // Outbound: which worker/endpoint is transcribing which item right now. (v4.0)
+                workers = queue.SnapshotWorkers().Select(w => new
+                {
+                    id = w.Id,
+                    name = w.Name,
+                    isLocal = w.IsLocal,
+                    inFlight = w.InFlight,
+                    maxConcurrency = w.MaxConcurrency,
+                    costWeight = w.CostWeight,
+                    current = w.CurrentItems
+                })
             });
         }
 

--- a/Controller/SubtitleQueueService.cs
+++ b/Controller/SubtitleQueueService.cs
@@ -120,6 +120,20 @@ namespace WhisperSubs.Controller
         /// </summary>
         public void MarkTaskStarted() => Interlocked.CompareExchange(ref _taskIsRunning, 1, 0);
 
+        /// <summary>
+        /// A live snapshot of the current worker pool for the admin status panel (v4.0), or an empty list
+        /// when no pool has been built yet (nothing has dispatched since startup). Thin accessor over the
+        /// unit-tested <see cref="WorkerPool.Snapshot"/>.
+        /// </summary>
+        [ExcludeFromCodeCoverage(Justification = "Thin accessor over the unit-tested WorkerPool.Snapshot; depends on live pool state")]
+        public IReadOnlyList<WorkerStatus> SnapshotWorkers()
+        {
+            lock (_poolGate)
+            {
+                return _pool?.Snapshot() ?? (IReadOnlyList<WorkerStatus>)System.Array.Empty<WorkerStatus>();
+            }
+        }
+
         // ── Scheduled task progress tracking ─────────────────────
         private string? _taskCurrentItemName;
         private int _taskTotal;
@@ -487,6 +501,7 @@ namespace WhisperSubs.Controller
                     var wi = workItem;
                     var l = lease;
                     _currentItemName = wi.Item.Name;
+                    pool.SetCurrent(l.Key, wi.Item.Name);   // "what's running where" — surfaced in the status panel
                     logger.LogInformation("[Dispatch] Processing {ItemName} [{Tier}] on {Worker} ({Remaining} remaining)",
                         wi.Item.Name, wi.Tier, l.Worker.Name, _lanes.Count);
 
@@ -517,7 +532,7 @@ namespace WhisperSubs.Controller
                         finally
                         {
                             Release(IdentityKey(wi.Item.Id, wi.Language));
-                            pool.Release(l.Key);
+                            pool.Release(l.Key, wi.Item.Name);
                         }
                     }));
 

--- a/Controller/SubtitleQueueService.cs
+++ b/Controller/SubtitleQueueService.cs
@@ -156,6 +156,19 @@ namespace WhisperSubs.Controller
         public Dictionary<PriorityTier, int> CountsByTier()
             => _lanes.CountsByTier().ToDictionary(kv => (PriorityTier)kv.Key, kv => kv.Value);
 
+        /// <summary>
+        /// The waiting ("inbound") queue for the admin panel, in the exact order it will run (strongest tier
+        /// first, then FIFO): each item's name, tier and language. Capped at <paramref name="max"/> so a
+        /// library-wide Generate-All doesn't return thousands of names to a polled endpoint — the full total
+        /// is <see cref="PriorityCount"/>. (v4.0.)
+        /// </summary>
+        [ExcludeFromCodeCoverage(Justification = "Reads BaseItem.Name off queued items; the lane ordering it projects is unit-tested in PriorityLanesTests")]
+        public IReadOnlyList<(string Name, PriorityTier Tier, string Language)> PendingItems(int max = 200)
+            => _lanes.Snapshot()
+                     .Take(max < 0 ? 0 : max)
+                     .Select(e => (e.Value.Item.Name, (PriorityTier)e.Tier, e.Value.Language))
+                     .ToList();
+
         // ── Per-file progress (updated by WhisperProvider stderr) ──
         private int _currentFileProgress;
 

--- a/Controller/Workers/SyntheticAudio.cs
+++ b/Controller/Workers/SyntheticAudio.cs
@@ -1,0 +1,59 @@
+using System;
+
+namespace WhisperSubs.Controller.Workers
+{
+    /// <summary>
+    /// Builds a tiny in-memory 16 kHz mono s16le WAV of silence for the worker "Test connection" probe
+    /// (v4.0). Every OpenAI-compatible endpoint can transcribe it, so the test exercises the real
+    /// transcribe path (URL + auth + model) without shipping a fixture file or touching the media library.
+    /// Pure + unit-testable — the HTTP POST that sends it lives in the (excluded) controller.
+    /// </summary>
+    public static class SyntheticAudio
+    {
+        private const int SampleRate = 16000;   // matches the plugin's ffmpeg extraction
+        private const short Channels = 1;
+        private const short BitsPerSample = 16;
+
+        /// <summary>
+        /// A canonical 44-byte-header WAV containing <paramref name="milliseconds"/> of silence
+        /// (clamped to 10..2000 ms). Layout is little-endian PCM, exactly what whisper.cpp / faster-whisper
+        /// expect.
+        /// </summary>
+        public static byte[] SilentWav16kMono(int milliseconds = 100)
+        {
+            if (milliseconds < 10) milliseconds = 10;
+            if (milliseconds > 2000) milliseconds = 2000;
+
+            var samples = SampleRate * milliseconds / 1000;
+            var dataBytes = samples * Channels * (BitsPerSample / 8);
+            var buffer = new byte[44 + dataBytes];
+
+            void PutAscii(int offset, string s)
+            {
+                for (var i = 0; i < s.Length; i++) buffer[offset + i] = (byte)s[i];
+            }
+            void PutInt32(int offset, int value) => BitConverter.GetBytes(value).CopyTo(buffer, offset);
+            void PutInt16(int offset, short value) => BitConverter.GetBytes(value).CopyTo(buffer, offset);
+
+            var byteRate = SampleRate * Channels * (BitsPerSample / 8);
+            var blockAlign = (short)(Channels * (BitsPerSample / 8));
+
+            PutAscii(0, "RIFF");
+            PutInt32(4, 36 + dataBytes);      // ChunkSize = 36 + Subchunk2Size
+            PutAscii(8, "WAVE");
+            PutAscii(12, "fmt ");
+            PutInt32(16, 16);                 // Subchunk1Size (PCM)
+            PutInt16(20, 1);                  // AudioFormat = PCM
+            PutInt16(22, Channels);
+            PutInt32(24, SampleRate);
+            PutInt32(28, byteRate);
+            PutInt16(32, blockAlign);
+            PutInt16(34, BitsPerSample);
+            PutAscii(36, "data");
+            PutInt32(40, dataBytes);          // Subchunk2Size
+            // Samples are left zeroed = silence.
+
+            return buffer;
+        }
+    }
+}

--- a/Controller/Workers/WorkerConfigValidation.cs
+++ b/Controller/Workers/WorkerConfigValidation.cs
@@ -1,0 +1,31 @@
+using System;
+using WhisperSubs.Configuration;
+
+namespace WhisperSubs.Controller.Workers
+{
+    /// <summary>
+    /// Pure validation for a configured <see cref="WhisperWorker"/> row (v4.0 config UI). Returns the first
+    /// problem (or ok) so the config page and the Test-connection endpoint can reject a malformed worker
+    /// before it ever reaches the pool. Kept free of Jellyfin/HTTP types so it is unit-testable, mirroring
+    /// the codebase's other pure decision helpers.
+    /// </summary>
+    public static class WorkerConfigValidation
+    {
+        /// <summary>Validates a worker row. <c>Ok=false</c> carries a user-facing reason (first failure wins).</summary>
+        public static (bool Ok, string? Error) Validate(WhisperWorker worker)
+        {
+            if (worker is null)
+                return (false, "Worker is missing.");
+            if (string.IsNullOrWhiteSpace(worker.ApiUrl))
+                return (false, "Endpoint URL is required.");
+            if (!Uri.TryCreate(worker.ApiUrl.Trim(), UriKind.Absolute, out var uri)
+                || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+                return (false, "Endpoint must be an absolute http(s) URL.");
+            if (worker.MaxConcurrency < 1)
+                return (false, "Max concurrency must be at least 1.");
+            if (worker.CostWeight < 0)
+                return (false, "Cost weight cannot be negative.");
+            return (true, null);
+        }
+    }
+}

--- a/Controller/Workers/WorkerModel.cs
+++ b/Controller/Workers/WorkerModel.cs
@@ -33,6 +33,14 @@ namespace WhisperSubs.Controller.Workers
     /// <summary>A live routing snapshot of one worker — a pure value (no Jellyfin/HTTP types), so selection is unit-testable.</summary>
     public readonly record struct WorkerSlot(string Id, bool Healthy, int InFlight, WorkerCapabilities Capabilities);
 
+    /// <summary>
+    /// A display snapshot of one worker for the admin queue/status panel (v4.0): identity + live load +
+    /// the static facts the UI shows. Distinct from <see cref="WorkerSlot"/> (routing) so the surfaced
+    /// shape is stable and independent of the scheduler's internal value.
+    /// </summary>
+    public readonly record struct WorkerStatus(
+        string Id, string Name, bool Healthy, int InFlight, int MaxConcurrency, bool IsLocal, double CostWeight);
+
     /// <summary>What a specific job needs from a worker (drives the hard capability filter).</summary>
     public readonly record struct JobRequirements(bool Translate, string? RequiredModel);
 }

--- a/Controller/Workers/WorkerModel.cs
+++ b/Controller/Workers/WorkerModel.cs
@@ -34,12 +34,14 @@ namespace WhisperSubs.Controller.Workers
     public readonly record struct WorkerSlot(string Id, bool Healthy, int InFlight, WorkerCapabilities Capabilities);
 
     /// <summary>
-    /// A display snapshot of one worker for the admin queue/status panel (v4.0): identity + live load +
-    /// the static facts the UI shows. Distinct from <see cref="WorkerSlot"/> (routing) so the surfaced
-    /// shape is stable and independent of the scheduler's internal value.
+    /// A display snapshot of one worker for the admin queue/status panel (v4.0): identity + live load + the
+    /// item(s) it is currently transcribing ("what's running where") + the static facts the UI shows.
+    /// Distinct from <see cref="WorkerSlot"/> (routing) so the surfaced shape is stable and independent of
+    /// the scheduler's internal value.
     /// </summary>
     public readonly record struct WorkerStatus(
-        string Id, string Name, bool Healthy, int InFlight, int MaxConcurrency, bool IsLocal, double CostWeight);
+        string Id, string Name, bool Healthy, int InFlight, int MaxConcurrency, bool IsLocal, double CostWeight,
+        IReadOnlyList<string> CurrentItems);
 
     /// <summary>What a specific job needs from a worker (drives the hard capability filter).</summary>
     public readonly record struct JobRequirements(bool Translate, string? RequiredModel);

--- a/Controller/Workers/WorkerPool.cs
+++ b/Controller/Workers/WorkerPool.cs
@@ -28,6 +28,9 @@ namespace WhisperSubs.Controller.Workers
         private readonly List<string> _keys = new();
         private readonly Dictionary<string, ITranscriptionWorker> _byKey = new();
         private readonly Dictionary<string, int> _inFlight = new();
+        // The item name(s) each worker is transcribing right now — surfaced in the status panel so the admin
+        // sees "what's running where" (a worker with MaxConcurrency > 1 can hold several). (v4.0.)
+        private readonly Dictionary<string, List<string>> _current = new();
         private readonly SemaphoreSlim _slots;
 
         public WorkerPool(IReadOnlyList<ITranscriptionWorker> workers)
@@ -46,6 +49,7 @@ namespace WhisperSubs.Controller.Workers
                 _keys.Add(key);
                 _byKey[key] = w;
                 _inFlight[key] = 0;
+                _current[key] = new List<string>();
                 capacity += w.Capabilities.MaxConcurrency < 1 ? 1 : w.Capabilities.MaxConcurrency;
             }
 
@@ -89,7 +93,8 @@ namespace WhisperSubs.Controller.Workers
                     var caps = w.Capabilities;
                     list.Add(new WorkerStatus(
                         w.Id, w.Name, Healthy: true, _inFlight[key],
-                        caps.MaxConcurrency < 1 ? 1 : caps.MaxConcurrency, caps.IsLocal, caps.CostWeight));
+                        caps.MaxConcurrency < 1 ? 1 : caps.MaxConcurrency, caps.IsLocal, caps.CostWeight,
+                        new List<string>(_current[key])));
                 }
                 return list;
             }
@@ -154,11 +159,31 @@ namespace WhisperSubs.Controller.Workers
             }
         }
 
-        /// <summary>Releases a slot after a job completes or fails, by the <see cref="WorkerLease.Key"/>. Pair each <see cref="AcquireAsync"/> with exactly one Release.</summary>
-        public void Release(string leaseKey)
+        /// <summary>
+        /// Records the item a leased worker is now transcribing, for the "what's running where" status
+        /// panel. Call once after <see cref="AcquireAsync"/>, before the transcription runs; pass the same
+        /// <paramref name="itemName"/> to <see cref="Release"/> so it is cleared when the job finishes.
+        /// </summary>
+        public void SetCurrent(string leaseKey, string itemName)
         {
             lock (_gate)
             {
+                if (_current.TryGetValue(leaseKey, out var items)) items.Add(itemName);
+            }
+        }
+
+        /// <summary>
+        /// Releases a slot after a job completes or fails, by the <see cref="WorkerLease.Key"/>. Pass the
+        /// <paramref name="currentItem"/> given to <see cref="SetCurrent"/> to clear it from the status
+        /// panel (omit on paths that acquired a slot but never dispatched an item). Pair each
+        /// <see cref="AcquireAsync"/> with exactly one Release.
+        /// </summary>
+        public void Release(string leaseKey, string? currentItem = null)
+        {
+            lock (_gate)
+            {
+                if (currentItem != null && _current.TryGetValue(leaseKey, out var items))
+                    items.Remove(currentItem);
                 if (_inFlight.TryGetValue(leaseKey, out var n) && n > 0)
                     _inFlight[leaseKey] = n - 1;
             }

--- a/Controller/Workers/WorkerPool.cs
+++ b/Controller/Workers/WorkerPool.cs
@@ -74,6 +74,28 @@ namespace WhisperSubs.Controller.Workers
         }
 
         /// <summary>
+        /// A live per-worker snapshot for the admin status panel (v4.0): each worker's identity, current
+        /// in-flight load, and the static facts the UI shows. Taken under the pool lock so counts are
+        /// consistent with each other.
+        /// </summary>
+        public IReadOnlyList<WorkerStatus> Snapshot()
+        {
+            lock (_gate)
+            {
+                var list = new List<WorkerStatus>(_keys.Count);
+                foreach (var key in _keys)
+                {
+                    var w = _byKey[key];
+                    var caps = w.Capabilities;
+                    list.Add(new WorkerStatus(
+                        w.Id, w.Name, Healthy: true, _inFlight[key],
+                        caps.MaxConcurrency < 1 ? 1 : caps.MaxConcurrency, caps.IsLocal, caps.CostWeight));
+                }
+                return list;
+            }
+        }
+
+        /// <summary>
         /// True if ANY worker could serve <paramref name="job"/>'s hard requirements ignoring current load —
         /// i.e. a capable worker exists (maybe busy). The dispatcher checks this before <see cref="AcquireAsync"/>
         /// so a job no worker can EVER serve is failed fast instead of blocking a slot forever.

--- a/ScheduledTasks/SubtitleGenerationTask.cs
+++ b/ScheduledTasks/SubtitleGenerationTask.cs
@@ -405,6 +405,7 @@ namespace WhisperSubs.ScheduledTasks
                     // one local worker this serialises exactly like the old lock; with N workers the sweep
                     // shares the pool with the background dispatcher up to ΣMaxConcurrency.
                     var lease = await pool.AcquireAsync(requirements, cancellationToken);
+                    pool.SetCurrent(lease.Key, item.Name);   // "what's running where" — surfaced in the status panel
                     try
                     {
                         if (config.PauseOnPlayback)
@@ -418,7 +419,7 @@ namespace WhisperSubs.ScheduledTasks
                     }
                     finally
                     {
-                        pool.Release(lease.Key);
+                        pool.Release(lease.Key, item.Name);
                     }
                 }
                 catch (OperationCanceledException)

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -420,6 +420,35 @@
                         </div>
                     </details>
 
+                    <!-- Worker Pool (Optional / Advanced) - simple by default, power-user opt-in (v4.0) -->
+                    <details style="margin-top:1.5em;">
+                        <summary style="cursor:pointer; font-size:1.2em; font-weight:bold; padding:0.5em 0;">Worker Pool (Optional / Advanced)</summary>
+
+                        <div class="fieldDescription" style="margin-bottom:0.75em;">
+                            Leave this empty to transcribe on this server (the default). Add remote
+                            OpenAI-compatible Whisper endpoints to spread the backlog across machines/GPUs
+                            &mdash; see the <code>worker/</code> image in the repo.
+                        </div>
+
+                        <div class="checkboxContainer checkboxContainer-withDescription">
+                            <label>
+                                <input is="emby-checkbox" type="checkbox" id="chkEnableLocalWorker" name="EnableLocalWorker" />
+                                <span>Also use this server as a worker</span>
+                            </label>
+                            <div class="fieldDescription">
+                                Keep this server's own whisper-cli in the pool. Only matters once you add
+                                remote workers below &mdash; with none, this server always does the work.
+                                <strong>On by default.</strong>
+                            </div>
+                        </div>
+
+                        <div id="workerRows"></div>
+
+                        <button is="emby-button" type="button" id="btnAddWorker" class="raised block" style="max-width:220px; margin-top:0.5em;">
+                            <span>+ Add worker</span>
+                        </button>
+                    </details>
+
                     <details style="margin-top:1.5em;">
                         <summary style="cursor:pointer; font-size:1.2em; font-weight:bold; padding:0.5em 0;">Advanced / Manual Install</summary>
 
@@ -595,6 +624,8 @@
                         <div id="transcriptionCurrentItem" class="fieldDescription" style="margin:0; flex:1; min-width:0; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;"></div>
                         <div id="transcriptionStats" class="fieldDescription" style="margin:0; white-space:nowrap; text-align:right;"></div>
                     </div>
+                    <div id="transcriptionPending" class="fieldDescription" style="margin:0.6em 0 0; white-space:normal;"></div>
+                    <div id="transcriptionWorkers" class="fieldDescription" style="margin:0.4em 0 0; white-space:normal; line-height:1.5;"></div>
                 </div>
                 <style>@keyframes wsQueueSpin{to{transform:rotate(360deg)}}</style>
 
@@ -1333,6 +1364,9 @@
                             page.querySelector('#numUserRequestActiveCap').value = (config.UserRequestActiveCap != null && config.UserRequestActiveCap >= 0) ? config.UserRequestActiveCap : 3;
                             page.querySelector('#numUserRequestMaxItemsPerRequest').value = (config.UserRequestMaxItemsPerRequest != null && config.UserRequestMaxItemsPerRequest >= 1) ? config.UserRequestMaxItemsPerRequest : 200;
                             page.querySelector('#numUserRequestGlobalCap').value = (config.UserRequestGlobalCap != null && config.UserRequestGlobalCap >= 0) ? config.UserRequestGlobalCap : 500;
+                            // Worker pool (v4.0). Absent/null Workers on older configs -> render nothing.
+                            page.querySelector('#chkEnableLocalWorker').checked = config.EnableLocalWorker !== false;
+                            WhisperSubsConfig.renderWorkers(config.Workers || []);
                             updateTranslationVisibility();
                         }
                             WhisperSubsConfig.loadLibraries();
@@ -1399,6 +1433,10 @@
                         config.UserRequestActiveCap = reqIntField('#numUserRequestActiveCap', 3, 0);
                         config.UserRequestMaxItemsPerRequest = reqIntField('#numUserRequestMaxItemsPerRequest', 200, 1);
                         config.UserRequestGlobalCap = reqIntField('#numUserRequestGlobalCap', 500, 0);
+
+                        // Worker pool (v4.0). Fully-blank rows are dropped; numbers are coerced.
+                        config.EnableLocalWorker = page.querySelector('#chkEnableLocalWorker').checked;
+                        config.Workers = WhisperSubsConfig.collectWorkers(page);
 
                         // Collect enabled libraries from checkboxes
                         var libraryCheckboxes = page.querySelectorAll('.chkLibrary');
@@ -1513,6 +1551,227 @@
                         if (action === 'Approve') WhisperSubsConfig.startQueuePolling();
                     }).catch(function () {
                         Dashboard.alert('Could not ' + action.toLowerCase() + ' the request.');
+                    });
+                },
+
+                // Worker pool (v4.0). Rows are built entirely in JS (mirrors the user-requests /
+                // library-selector panels): every server-provided string is rendered via
+                // textContent and input values are set as properties (never parsed as HTML), so
+                // it stays XSS-safe. No dynamic emby-select here (Model is a plain text input), so
+                // there is no pageshow-repopulate concern.
+                _workerSeq: 0,
+
+                genWorkerId: function () {
+                    return 'w' + Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+                },
+
+                renderWorkers: function (workers) {
+                    var container = document.querySelector('#workerRows');
+                    if (!container) return;
+                    container.innerHTML = '';
+                    if (workers && Array.isArray(workers)) {
+                        workers.forEach(function (w) {
+                            container.appendChild(WhisperSubsConfig.buildWorkerRow(w));
+                        });
+                    }
+                },
+
+                addWorkerRow: function () {
+                    var container = document.querySelector('#workerRows');
+                    if (!container) return;
+                    container.appendChild(WhisperSubsConfig.buildWorkerRow(null));
+                },
+
+                buildWorkerRow: function (w) {
+                    w = w || {};
+                    var row = document.createElement('div');
+                    row.className = 'workerRow';
+                    row.style.background = 'rgba(0,0,0,0.15)';
+                    row.style.borderRadius = '6px';
+                    row.style.padding = '1em';
+                    row.style.marginBottom = '1em';
+                    // Keep the stable Id (survives a rename); generate a short one for a new row.
+                    row.setAttribute('data-worker-id', w.Id || WhisperSubsConfig.genWorkerId());
+
+                    row.appendChild(WhisperSubsConfig._workerField(
+                        'Name', 'text', 'wkName', { placeholder: 'e.g. GPU box', maxlength: '128' },
+                        w.Name || '', 'A label to recognise this worker. Optional.'));
+                    row.appendChild(WhisperSubsConfig._workerField(
+                        'Endpoint URL', 'text', 'wkUrl', { placeholder: 'http://host:port' },
+                        w.ApiUrl || '', 'Base URL of an OpenAI-compatible Whisper server. No /v1 suffix.'));
+                    row.appendChild(WhisperSubsConfig._workerField(
+                        'API key (optional)', 'password', 'wkKey',
+                        { autocomplete: 'new-password', maxlength: '256', spellcheck: 'false' },
+                        w.ApiKey || '', 'Bearer token, if the server needs one. Leave blank for unauthenticated local servers.'));
+                    row.appendChild(WhisperSubsConfig._workerField(
+                        'Model (optional)', 'text', 'wkModel', { placeholder: 'server default', maxlength: '256' },
+                        w.Model || '', 'Model to request. Blank uses the worker default.'));
+                    row.appendChild(WhisperSubsConfig._workerField(
+                        'Max concurrency', 'number', 'wkConcurrency', { min: '1', max: '64', step: '1', placeholder: '1' },
+                        (w.MaxConcurrency != null && w.MaxConcurrency >= 1) ? w.MaxConcurrency : '',
+                        'How many files this worker transcribes at once. Default 1.'));
+                    row.appendChild(WhisperSubsConfig._workerField(
+                        'Cost weight', 'number', 'wkCost', { min: '0', step: '0.1', placeholder: '0' },
+                        (w.CostWeight != null && w.CostWeight >= 0) ? w.CostWeight : '',
+                        '0 = free/local, preferred; >0 = only used when local workers are busy.'));
+
+                    row.appendChild(WhisperSubsConfig._workerCheckbox('wkTranslate', 'Can translate to English', w.CanTranslate !== false));
+                    row.appendChild(WhisperSubsConfig._workerCheckbox('wkEnabled', 'Enabled', w.Enabled !== false));
+
+                    var btnBar = document.createElement('div');
+                    btnBar.style.display = 'flex';
+                    btnBar.style.gap = '0.6em';
+                    btnBar.style.alignItems = 'center';
+                    btnBar.style.flexWrap = 'wrap';
+                    btnBar.style.marginTop = '0.4em';
+
+                    var testBtn = document.createElement('button');
+                    testBtn.setAttribute('is', 'emby-button');
+                    testBtn.type = 'button';
+                    testBtn.className = 'raised';
+                    testBtn.innerHTML = '<span>Test</span>';
+                    testBtn.addEventListener('click', function () { WhisperSubsConfig.testWorker(row, testBtn); });
+                    btnBar.appendChild(testBtn);
+
+                    var removeBtn = document.createElement('button');
+                    removeBtn.setAttribute('is', 'emby-button');
+                    removeBtn.type = 'button';
+                    removeBtn.className = 'raised';
+                    removeBtn.innerHTML = '<span>Remove</span>';
+                    removeBtn.addEventListener('click', function () {
+                        if (row.parentNode) row.parentNode.removeChild(row);
+                    });
+                    btnBar.appendChild(removeBtn);
+
+                    var testResult = document.createElement('span');
+                    testResult.className = 'wkTestResult fieldDescription';
+                    testResult.style.margin = '0';
+                    btnBar.appendChild(testResult);
+
+                    row.appendChild(btnBar);
+                    return row;
+                },
+
+                // Builds one labelled input inside an .inputContainer (the file's standard field
+                // markup). Unique id/for so the emby floating label associates correctly.
+                _workerField: function (labelText, type, cls, attrs, value, descText) {
+                    var id = 'wk_' + (++WhisperSubsConfig._workerSeq);
+                    var container = document.createElement('div');
+                    container.className = 'inputContainer';
+                    var label = document.createElement('label');
+                    label.className = 'inputLabel inputLabelUnfocused';
+                    label.setAttribute('for', id);
+                    label.textContent = labelText;
+                    container.appendChild(label);
+                    var input = document.createElement('input');
+                    input.id = id;
+                    input.type = type;
+                    input.className = 'emby-input ' + cls;
+                    if (attrs) {
+                        Object.keys(attrs).forEach(function (k) { input.setAttribute(k, attrs[k]); });
+                    }
+                    input.value = (value != null) ? value : '';
+                    container.appendChild(input);
+                    if (descText) {
+                        var desc = document.createElement('div');
+                        desc.className = 'fieldDescription';
+                        desc.textContent = descText;
+                        container.appendChild(desc);
+                    }
+                    return container;
+                },
+
+                _workerCheckbox: function (cls, labelText, checked) {
+                    var container = document.createElement('div');
+                    container.className = 'checkboxContainer';
+                    container.style.padding = '0.2em 0';
+                    var label = document.createElement('label');
+                    var checkbox = document.createElement('input');
+                    checkbox.setAttribute('is', 'emby-checkbox');
+                    checkbox.type = 'checkbox';
+                    checkbox.className = cls;
+                    checkbox.checked = !!checked;
+                    label.appendChild(checkbox);
+                    var span = document.createElement('span');
+                    span.textContent = labelText;
+                    label.appendChild(span);
+                    container.appendChild(label);
+                    return container;
+                },
+
+                // Reads every row into config.Workers, skipping rows the user never filled in and
+                // coercing MaxConcurrency/CostWeight to numbers.
+                collectWorkers: function (page) {
+                    var rows = page.querySelectorAll('.workerRow');
+                    var workers = [];
+                    rows.forEach(function (row) {
+                        var name = (row.querySelector('.wkName').value || '').trim();
+                        var url = (row.querySelector('.wkUrl').value || '').trim();
+                        var key = (row.querySelector('.wkKey').value || '').trim();
+                        var model = (row.querySelector('.wkModel').value || '').trim();
+                        var concRaw = (row.querySelector('.wkConcurrency').value || '').trim();
+                        var costRaw = (row.querySelector('.wkCost').value || '').trim();
+                        var canTranslate = row.querySelector('.wkTranslate').checked;
+                        var enabled = row.querySelector('.wkEnabled').checked;
+
+                        // Skip a row the user never filled in (all text/number fields blank).
+                        if (!name && !url && !key && !model && concRaw === '' && costRaw === '') {
+                            return;
+                        }
+
+                        var conc = parseInt(concRaw, 10);
+                        if (isNaN(conc) || conc < 1) conc = 1;
+                        var cost = parseFloat(costRaw);
+                        if (isNaN(cost) || cost < 0) cost = 0;
+
+                        workers.push({
+                            Id: row.getAttribute('data-worker-id') || WhisperSubsConfig.genWorkerId(),
+                            Name: name,
+                            Enabled: enabled,
+                            ApiUrl: url,
+                            ApiKey: key,
+                            Model: model,
+                            MaxConcurrency: conc,
+                            CostWeight: cost,
+                            CanTranslate: canTranslate
+                        });
+                    });
+                    return workers;
+                },
+
+                // Probes one row's endpoint via POST Workers/TestConnection; shows the server's
+                // message inline (green when ok, red otherwise) via textContent.
+                testWorker: function (row, btn) {
+                    var result = row.querySelector('.wkTestResult');
+                    var url = (row.querySelector('.wkUrl').value || '').trim();
+                    var key = (row.querySelector('.wkKey').value || '').trim();
+                    var model = (row.querySelector('.wkModel').value || '').trim();
+                    if (!url) {
+                        if (result) { result.textContent = 'Enter an endpoint URL first.'; result.style.color = '#CC7B19'; }
+                        return;
+                    }
+                    if (btn) { btn.disabled = true; }
+                    if (result) { result.textContent = 'Testing…'; result.style.color = ''; }
+                    ApiClient.ajax({
+                        type: 'POST',
+                        url: ApiClient.getUrl('Plugins/WhisperSubs/Workers/TestConnection'),
+                        data: JSON.stringify({ apiUrl: url, apiKey: key, model: model }),
+                        contentType: 'application/json',
+                        dataType: 'json'
+                    }).then(function (response) {
+                        var r = typeof response === 'string' ? JSON.parse(response) : response;
+                        if (result) {
+                            // Server-provided message rendered via textContent (never innerHTML).
+                            result.textContent = (r && r.message) ? r.message : ((r && r.ok) ? 'OK' : 'Failed');
+                            result.style.color = (r && r.ok) ? '#52B54B' : '#CC3333';
+                        }
+                    }).catch(function (err) {
+                        if (result) {
+                            result.textContent = 'Test failed: ' + (err && err.message ? err.message : err);
+                            result.style.color = '#CC3333';
+                        }
+                    }).then(function () {
+                        if (btn) { btn.disabled = false; }
                     });
                 },
 
@@ -1692,9 +1951,13 @@
                             var stats = document.querySelector('#transcriptionStats');
                             var current = document.querySelector('#transcriptionCurrentItem');
                             var spinner = document.querySelector('#transcriptionSpinner');
+                            var pendingEl = document.querySelector('#transcriptionPending');
+                            var workersEl = document.querySelector('#transcriptionWorkers');
 
                             // ── Idle: hide or show "Finished" briefly ──
                             if (!q.isProcessing && q.remaining === 0) {
+                                if (pendingEl) pendingEl.textContent = '';
+                                if (workersEl) workersEl.textContent = '';
                                 if (banner.style.display !== 'none' && q.processed > 0) {
                                     var hadFailure = q.failed > 0;
                                     spinner.style.animation = 'none';
@@ -1781,6 +2044,45 @@
                             if (total > 0) parts.push(q.processed.toLocaleString() + ' of ' + total.toLocaleString() + ' items');
                             if (q.failed > 0) parts.push(q.failed + ' failed');
                             stats.textContent = parts.join(' \u00b7 ');
+
+                            // Inbound: the waiting queue (v4.0). Item names are server data, so the
+                            // whole line is assigned via textContent (never innerHTML) \u2014 XSS-safe.
+                            if (pendingEl) {
+                                var pend = Array.isArray(q.pending) ? q.pending : [];
+                                if (pend.length > 0) {
+                                    var pieces = pend.map(function (p) {
+                                        return (p.name || '') + (p.tier ? ' [' + p.tier + ']' : '');
+                                    });
+                                    var waitingTotal = (q.remaining != null) ? q.remaining : pend.length;
+                                    var pendingLine = 'Waiting (' + waitingTotal + '): ' + pieces.join(' \u00b7 ');
+                                    if (q.remaining != null && q.remaining > pend.length) {
+                                        pendingLine += '  (+' + (q.remaining - pend.length) + ' more)';
+                                    }
+                                    pendingEl.textContent = pendingLine;
+                                } else {
+                                    pendingEl.textContent = '';
+                                }
+                            }
+
+                            // Outbound: what's running where (v4.0). One line per worker; only shown
+                            // when a live pool exists, so single-server installs stay clean.
+                            if (workersEl) {
+                                var wks = Array.isArray(q.workers) ? q.workers : [];
+                                workersEl.textContent = '';
+                                if (wks.length > 0) {
+                                    wks.forEach(function (wk) {
+                                        var inF = (wk.inFlight != null) ? wk.inFlight : 0;
+                                        var maxC = (wk.maxConcurrency != null) ? wk.maxConcurrency : 1;
+                                        var cur = Array.isArray(wk.current) ? wk.current : [];
+                                        var running = cur.length > 0 ? cur.join(', ') : 'idle';
+                                        var lineEl = document.createElement('div');
+                                        lineEl.textContent = (wk.name || wk.id || 'worker') +
+                                            ' (' + inF + '/' + maxC + ')' +
+                                            (wk.isLocal ? ' (local)' : '') + ': ' + running;
+                                        workersEl.appendChild(lineEl);
+                                    });
+                                }
+                            }
                         })
                         .catch(function () { /* ignore transient errors */ });
                 },
@@ -1811,6 +2113,10 @@
                     resetBar.style.width = '0%';
                     resetBar.style.background = '#52B54B';
                     document.querySelector('#transcriptionProgressPct').textContent = '';
+                    var rbPending = document.querySelector('#transcriptionPending');
+                    if (rbPending) rbPending.textContent = '';
+                    var rbWorkers = document.querySelector('#transcriptionWorkers');
+                    if (rbWorkers) rbWorkers.textContent = '';
                 },
 
                 generateSubtitle: function (itemId, itemName, itemType) {
@@ -1918,6 +2224,10 @@
 
             document.querySelector('#btnRefreshRequests').addEventListener('click', function () {
                 WhisperSubsConfig.loadRequests();
+            });
+
+            document.querySelector('#btnAddWorker').addEventListener('click', function () {
+                WhisperSubsConfig.addWorkerRow();
             });
 
             document.querySelector('#btnEngineDownloadModel').addEventListener('click', function () {

--- a/WhisperSubs.Tests/SyntheticAudioTests.cs
+++ b/WhisperSubs.Tests/SyntheticAudioTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Text;
+using WhisperSubs.Controller.Workers;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+/// <summary>
+/// v4.0 worker "Test connection": the tiny silent WAV must be a byte-correct 16 kHz mono s16le file so any
+/// OpenAI-compatible endpoint accepts it.
+/// </summary>
+public class SyntheticAudioTests
+{
+    [Fact]
+    public void SilentWav_HasCanonicalHeader_AndCorrectLength()
+    {
+        var wav = SyntheticAudio.SilentWav16kMono(100);   // 100 ms @ 16 kHz mono 16-bit = 1600 samples
+        Assert.Equal(44 + 3200, wav.Length);              // 44-byte header + 1600*2 data
+        Assert.Equal("RIFF", Encoding.ASCII.GetString(wav, 0, 4));
+        Assert.Equal("WAVE", Encoding.ASCII.GetString(wav, 8, 4));
+        Assert.Equal("fmt ", Encoding.ASCII.GetString(wav, 12, 4));
+        Assert.Equal("data", Encoding.ASCII.GetString(wav, 36, 4));
+        Assert.Equal(1, BitConverter.ToInt16(wav, 20));   // PCM
+        Assert.Equal(1, BitConverter.ToInt16(wav, 22));   // mono
+        Assert.Equal(16000, BitConverter.ToInt32(wav, 24));
+        Assert.Equal(16, BitConverter.ToInt16(wav, 34));  // 16-bit
+        Assert.Equal(3200, BitConverter.ToInt32(wav, 40));       // data chunk size
+        Assert.Equal(36 + 3200, BitConverter.ToInt32(wav, 4));   // RIFF chunk size
+    }
+
+    [Theory]
+    [InlineData(0, 10)]        // clamped up to 10 ms
+    [InlineData(5000, 2000)]   // clamped down to 2000 ms
+    public void SilentWav_ClampsDuration(int requestedMs, int effectiveMs)
+    {
+        var wav = SyntheticAudio.SilentWav16kMono(requestedMs);
+        Assert.Equal(44 + 16000 * effectiveMs / 1000 * 2, wav.Length);
+    }
+
+    [Fact]
+    public void SilentWav_DataIsAllSilence()
+    {
+        var wav = SyntheticAudio.SilentWav16kMono(50);
+        for (var i = 44; i < wav.Length; i++) Assert.Equal(0, wav[i]);
+    }
+}

--- a/WhisperSubs.Tests/WorkerConfigValidationTests.cs
+++ b/WhisperSubs.Tests/WorkerConfigValidationTests.cs
@@ -1,0 +1,52 @@
+using WhisperSubs.Configuration;
+using WhisperSubs.Controller.Workers;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+/// <summary>
+/// v4.0 config UI: pure validation of a worker row, so a malformed endpoint/concurrency/cost is rejected
+/// before it reaches the pool.
+/// </summary>
+public class WorkerConfigValidationTests
+{
+    private static WhisperWorker W(string url = "https://gpu.lan:8000", int max = 1, double cost = 0)
+        => new WhisperWorker { ApiUrl = url, MaxConcurrency = max, CostWeight = cost };
+
+    [Fact]
+    public void ValidHttpsWorker_Ok()
+    {
+        var (ok, err) = WorkerConfigValidation.Validate(W());
+        Assert.True(ok);
+        Assert.Null(err);
+    }
+
+    [Fact]
+    public void HttpUrl_Ok()
+        => Assert.True(WorkerConfigValidation.Validate(W(url: "http://192.168.10.110:8000")).Ok);
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void BlankUrl_Fails(string url)
+    {
+        var (ok, err) = WorkerConfigValidation.Validate(W(url: url));
+        Assert.False(ok);
+        Assert.NotNull(err);
+    }
+
+    [Theory]
+    [InlineData("not-a-url")]
+    [InlineData("ftp://host/x")]
+    [InlineData("/relative/path")]
+    public void NonHttpUrl_Fails(string url)
+        => Assert.False(WorkerConfigValidation.Validate(W(url: url)).Ok);
+
+    [Fact]
+    public void MaxConcurrencyBelowOne_Fails()
+        => Assert.False(WorkerConfigValidation.Validate(W(max: 0)).Ok);
+
+    [Fact]
+    public void NegativeCostWeight_Fails()
+        => Assert.False(WorkerConfigValidation.Validate(W(cost: -1)).Ok);
+}

--- a/WhisperSubs.Tests/WorkerPoolTests.cs
+++ b/WhisperSubs.Tests/WorkerPoolTests.cs
@@ -115,6 +115,28 @@ public class WorkerPoolTests
     }
 
     [Fact]
+    public async Task Snapshot_ReflectsIdentityAndLiveLoad()
+    {
+        var pool = new WorkerPool(new[] { Worker("local", 2, cost: 0), Worker("cloud", 1, cost: 5) });
+
+        var idle = pool.Snapshot();
+        Assert.Equal(2, idle.Count);
+        var local = idle.Single(s => s.Id == "local");
+        Assert.Equal(2, local.MaxConcurrency);
+        Assert.True(local.IsLocal);
+        Assert.Equal(0, local.InFlight);
+        var cloud = idle.Single(s => s.Id == "cloud");
+        Assert.Equal(5, cloud.CostWeight);
+        Assert.False(cloud.IsLocal);
+
+        // Acquire one slot → the snapshot's InFlight reflects it (local is cheapest, so it's taken first).
+        var lease = await pool.AcquireAsync(AnyJob, default);
+        Assert.Equal(1, pool.Snapshot().Single(s => s.Id == "local").InFlight);
+        pool.Release(lease.Key);
+        Assert.Equal(0, pool.Snapshot().Single(s => s.Id == "local").InFlight);
+    }
+
+    [Fact]
     public async Task DuplicateWorkerIds_DoNotCollide_BothSlotsUsableAndReleasable()
     {
         // Two workers misconfigured with the SAME Id — the lease key must keep per-slot accounting distinct.

--- a/WhisperSubs.Tests/WorkerPoolTests.cs
+++ b/WhisperSubs.Tests/WorkerPoolTests.cs
@@ -131,9 +131,15 @@ public class WorkerPoolTests
 
         // Acquire one slot → the snapshot's InFlight reflects it (local is cheapest, so it's taken first).
         var lease = await pool.AcquireAsync(AnyJob, default);
-        Assert.Equal(1, pool.Snapshot().Single(s => s.Id == "local").InFlight);
-        pool.Release(lease.Key);
-        Assert.Equal(0, pool.Snapshot().Single(s => s.Id == "local").InFlight);
+        pool.SetCurrent(lease.Key, "The Movie S01E12");
+        var busy = pool.Snapshot().Single(s => s.Id == "local");
+        Assert.Equal(1, busy.InFlight);
+        Assert.Contains("The Movie S01E12", busy.CurrentItems);   // "what's running where"
+
+        pool.Release(lease.Key, "The Movie S01E12");
+        var freed = pool.Snapshot().Single(s => s.Id == "local");
+        Assert.Equal(0, freed.InFlight);
+        Assert.Empty(freed.CurrentItems);                          // cleared on release
     }
 
     [Fact]


### PR DESCRIPTION
## What

v4.0 PR-5 — the **config UI for the worker pool** + the **queue inbound/outbound + "what's running where" panels**. Makes the PR-3 dispatcher + PR-4 workers usable and observable. Targets `v4-dev`.

Simple by default: the whole worker pool is a **collapsed, empty** advanced section — single-server users see no new clutter.

## Backend (pure, unit-tested)

- **`WorkerConfigValidation`** — rejects a blank/non-http(s) endpoint, `MaxConcurrency < 1`, or negative `CostWeight`.
- **`WorkerStatus.CurrentItems` + `WorkerPool` tracking** (`SetCurrent`/`Release(key,item)`) — records the item each worker is transcribing, across the dispatcher and the scheduled task.
- **`/Queue` now returns** `pending[]` (the INBOUND waiting list in run order, capped 200; full total is `remaining`) and `workers[]` (the OUTBOUND view: each endpoint + its in-flight count + current item(s)).
- **`POST /Workers/TestConnection`** — POSTs a tiny silent 16 kHz WAV (`SyntheticAudio`, unit-tested) to a worker's `/v1/audio/transcriptions` and returns `{ok, status, latencyMs, message}` — verifies reachability + auth + transcribe without touching the library.

## UI (`Web/configPage.html`)

- A **"Worker Pool (Optional / Advanced)"** `<details>` (closed + empty by default): add/remove worker rows (name, endpoint, key, model, max-concurrency, cost-weight, can-translate, enabled), an "Also use this server as a worker" toggle, and a per-row **Test** button. Loads from / saves to `config.Workers` (PascalCase round-trip).
- The **queue banner** gains the **inbound** waiting list ("Waiting (N): item [tier] …") and the **outbound** "what's running where" lines (one per worker: `name (inFlight/max) (local): items | idle`), shown only when a live pool exists. All server strings via `textContent` (XSS-safe).

## Tests / review

`893` tests pass, 0 warnings. New pure logic (validation, WAV, per-worker tracking) is unit-tested. The config HTML was built by a subagent to exact contracts, then reviewed here (property casing, XSS, emby-component patterns, every load/save/poll integration point). The embedded HTML can't be unit-tested — it needs a **browser check on install**.

## Note

The scheduled auto-sweep is still one-worker-at-a-time; a follow-up (PR-3b) makes it a bounded producer so the *automatic* backlog parallelizes too. The headline "parallel across all workers" already works today via admin **Generate All** (it fans a whole library/season into the queue → the dispatcher runs it across every worker).
