### PR TITLE
release: v4.0.0.0 — distributed / pooled multi-worker transcription

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -11,6 +11,8 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
+    base_branches:
+      - "v4-dev"
     ignore_title_keywords:
       - "WIP"
       - "DO NOT REVIEW"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ name: CI
 on:
   workflow_dispatch:
   push:
-    branches: [main]
+    branches: [main, v4-dev]
   pull_request:
-    branches: [main]
+    branches: [main, v4-dev]
 
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}

--- a/Api/SubtitleController.cs
+++ b/Api/SubtitleController.cs
@@ -193,8 +193,7 @@ namespace WhisperSubs.Api
 
                 // Ensure the background drain worker is running
                 var manager = GetSubtitleManager();
-                var provider = SubtitleProviderFactory.Create(config, _loggerFactory);
-                queue.EnsureDraining(manager, provider, _logger, CancellationToken.None);
+                queue.EnsureDispatching(manager, config, _loggerFactory, _logger, CancellationToken.None);
 
                 return Accepted(new
                 {
@@ -264,8 +263,7 @@ namespace WhisperSubs.Api
 
                 // Ensure the background drain worker is running
                 var manager = GetSubtitleManager();
-                var provider = SubtitleProviderFactory.Create(config, _loggerFactory);
-                queue.EnsureDraining(manager, provider, _logger, CancellationToken.None);
+                queue.EnsureDispatching(manager, config, _loggerFactory, _logger, CancellationToken.None);
 
                 return Accepted(new
                 {

--- a/Api/SubtitleController.cs
+++ b/Api/SubtitleController.cs
@@ -309,8 +309,106 @@ namespace WhisperSubs.Api
                 library = queue.TaskCurrentItemLibrary,
                 // Named-tier breakdown of what's queued + how many user requests await approval (#112).
                 tiers = queue.CountsByTier().ToDictionary(kv => kv.Key.ToString(), kv => kv.Value),
-                pendingRequests = SubtitleRequestStore.Instance.GetAll().Count(r => r.State == RequestState.Pending)
+                pendingRequests = SubtitleRequestStore.Instance.GetAll().Count(r => r.State == RequestState.Pending),
+                // Inbound: the items waiting, in the order they'll run (capped; the full total is `remaining`). (v4.0)
+                pending = queue.PendingItems().Select(p => new
+                {
+                    name = p.Name,
+                    tier = p.Tier.ToString(),
+                    language = p.Language
+                }),
+                // Outbound: which worker/endpoint is transcribing which item right now. (v4.0)
+                workers = queue.SnapshotWorkers().Select(w => new
+                {
+                    id = w.Id,
+                    name = w.Name,
+                    isLocal = w.IsLocal,
+                    inFlight = w.InFlight,
+                    maxConcurrency = w.MaxConcurrency,
+                    costWeight = w.CostWeight,
+                    current = w.CurrentItems
+                })
             });
+        }
+
+        /// <summary>
+        /// Tests a worker endpoint (v4.0 config UI): POSTs a tiny silent WAV to its transcription route so
+        /// the admin can confirm reachability + auth + a working transcribe path before saving the worker,
+        /// without touching the media library. Never throws — always returns a shaped {ok, message} result.
+        /// </summary>
+        [HttpPost("Workers/TestConnection")]
+        public async Task<ActionResult> TestWorkerConnection([FromBody] WorkerTestRequest request)
+        {
+            if (request == null)
+            {
+                return BadRequest(new { ok = false, message = "Missing request body." });
+            }
+
+            var worker = new Configuration.WhisperWorker
+            {
+                ApiUrl = request.ApiUrl ?? "",
+                ApiKey = request.ApiKey ?? "",
+                Model = request.Model ?? "",
+                MaxConcurrency = 1,
+                CostWeight = 0
+            };
+            var (valid, error) = Controller.Workers.WorkerConfigValidation.Validate(worker);
+            if (!valid)
+            {
+                return Ok(new { ok = false, message = error });
+            }
+
+            var url = worker.ApiUrl.TrimEnd('/') + "/v1/audio/transcriptions";
+            var model = string.IsNullOrWhiteSpace(worker.Model) ? "Systran/faster-whisper-large-v3" : worker.Model.Trim();
+            var wav = Controller.Workers.SyntheticAudio.SilentWav16kMono(100);
+
+            using var content = new System.Net.Http.MultipartFormDataContent();
+            var fileContent = new System.Net.Http.ByteArrayContent(wav);
+            fileContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("audio/wav");
+            content.Add(fileContent, "file", "test.wav");
+            content.Add(new System.Net.Http.StringContent(model), "model");
+            content.Add(new System.Net.Http.StringContent("srt"), "response_format");
+
+            using var probe = new System.Net.Http.HttpRequestMessage(System.Net.Http.HttpMethod.Post, url) { Content = content };
+            if (!string.IsNullOrWhiteSpace(worker.ApiKey))
+            {
+                probe.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", worker.ApiKey.Trim());
+            }
+
+            var http = _httpClientFactory.CreateClient();
+            http.Timeout = TimeSpan.FromSeconds(20);
+
+            var sw = System.Diagnostics.Stopwatch.StartNew();
+            try
+            {
+                using var resp = await http.SendAsync(probe);
+                sw.Stop();
+                if (resp.IsSuccessStatusCode)
+                {
+                    return Ok(new
+                    {
+                        ok = true,
+                        status = (int)resp.StatusCode,
+                        latencyMs = sw.ElapsedMilliseconds,
+                        message = $"OK — transcribed a test clip in {sw.ElapsedMilliseconds} ms."
+                    });
+                }
+
+                var body = await resp.Content.ReadAsStringAsync();
+                var snippet = body.Length > 200 ? body.Substring(0, 200) : body;
+                return Ok(new
+                {
+                    ok = false,
+                    status = (int)resp.StatusCode,
+                    latencyMs = sw.ElapsedMilliseconds,
+                    message = $"HTTP {(int)resp.StatusCode}: {snippet}"
+                });
+            }
+            catch (Exception ex)
+            {
+                sw.Stop();
+                return Ok(new { ok = false, latencyMs = sw.ElapsedMilliseconds, message = $"Unreachable: {ex.Message}" });
+            }
         }
 
         /// <summary>
@@ -980,6 +1078,14 @@ namespace WhisperSubs.Api
         public List<ItemInfo> Items { get; set; } = new List<ItemInfo>();
         public int TotalCount { get; set; }
         public int StartIndex { get; set; }
+    }
+
+    /// <summary>Body for the worker "Test connection" probe (v4.0): the endpoint + optional key/model to try.</summary>
+    public class WorkerTestRequest
+    {
+        public string? ApiUrl { get; set; }
+        public string? ApiKey { get; set; }
+        public string? Model { get; set; }
     }
 }
 

--- a/Configuration/PluginConfiguration.cs
+++ b/Configuration/PluginConfiguration.cs
@@ -287,6 +287,24 @@ namespace WhisperSubs.Configuration
         /// <summary>Absolute cap for the per-call deadline in hours — a genuinely long film's worst case still fits under it. Default 12.</summary>
         public int JobMaxTimeoutHours { get; set; } = 12;
 
+        // ── Worker pool (v4.0; power-user feature, empty by default) ─────────
+        // Simple by default: a normal single-server install leaves Workers empty and EnableLocalWorker on,
+        // so the plugin behaves exactly as today (the host's own whisper, one job at a time). Power users
+        // add extra OpenAI-compatible endpoints below to transcribe in parallel across machines.
+
+        /// <summary>
+        /// Extra OpenAI-compatible transcription workers to pool alongside the local one. EMPTY for the
+        /// common single-server install. Power users add a second box, a NAS, or a cloud endpoint here.
+        /// </summary>
+        public List<WhisperWorker> Workers { get; set; } = new List<WhisperWorker>();
+
+        /// <summary>
+        /// Whether the Jellyfin host's own local whisper participates as a worker. Default true (the normal
+        /// case). Set false to transcribe ONLY on the configured remote workers — e.g. a weak NAS offloading
+        /// entirely to a beefier box (the pre-v4 behaviour when only a single remote URL was set).
+        /// </summary>
+        public bool EnableLocalWorker { get; set; } = true;
+
         public PluginConfiguration()
         {
         }

--- a/Configuration/WhisperWorker.cs
+++ b/Configuration/WhisperWorker.cs
@@ -1,0 +1,37 @@
+namespace WhisperSubs.Configuration
+{
+    /// <summary>
+    /// One configured extra transcription worker (v4.0 worker pool). This list is EMPTY for a normal
+    /// single-server install — the plugin then just uses the host's own local whisper, exactly as today.
+    /// A power user adds entries here to pool additional OpenAI-compatible endpoints (a second box, a NAS,
+    /// a cloud API). Plain mutable class so it round-trips through the plugin's XML config.
+    /// </summary>
+    public class WhisperWorker
+    {
+        /// <summary>Stable id (dispatch/dedup key); survives a rename.</summary>
+        public string Id { get; set; } = "";
+
+        /// <summary>Display label, e.g. "nas-igpu".</summary>
+        public string Name { get; set; } = "";
+
+        public bool Enabled { get; set; } = true;
+
+        /// <summary>OpenAI-compatible base URL, e.g. <c>http://192.168.1.10:8080</c>.</summary>
+        public string ApiUrl { get; set; } = "";
+
+        /// <summary>Optional bearer token for this worker.</summary>
+        public string ApiKey { get; set; } = "";
+
+        /// <summary>Model to request; empty = the worker's own default / any.</summary>
+        public string Model { get; set; } = "";
+
+        /// <summary>Simultaneous jobs this worker runs; keep 1 per single GPU. Default 1.</summary>
+        public int MaxConcurrency { get; set; } = 1;
+
+        /// <summary>Selection cost: 0 = free/local-priced (preferred); &gt;0 = paid, used only to burst. Default 0.</summary>
+        public double CostWeight { get; set; } = 0;
+
+        /// <summary>Whether this worker can translate to English. Default true.</summary>
+        public bool CanTranslate { get; set; } = true;
+    }
+}

--- a/Controller/PriorityLanes.cs
+++ b/Controller/PriorityLanes.cs
@@ -109,6 +109,34 @@ namespace WhisperSubs.Controller
             }
         }
 
+        /// <summary>
+        /// Removes and returns the highest-priority entry whose value satisfies <paramref name="canDequeue"/>,
+        /// scanning lanes in priority order then FIFO within a lane. Strict tier order is preserved: a
+        /// lower-priority entry is returned only when no acceptable higher-priority one exists. Used by the
+        /// worker-pool dispatcher to skip a head job that no currently-free worker can serve (v4.0).
+        /// </summary>
+        public bool TryDequeue(Func<T, bool> canDequeue, out T value)
+        {
+            lock (_gate)
+            {
+                foreach (var lane in _lanes.Values)
+                {
+                    for (var node = lane.First; node != null; node = node.Next)
+                    {
+                        if (canDequeue(node.Value.Value))
+                        {
+                            value = node.Value.Value;
+                            RemoveNode(node);
+                            return true;
+                        }
+                    }
+                }
+
+                value = default!;
+                return false;
+            }
+        }
+
         /// <summary>Removes a specific key if queued. Returns true if it was present.</summary>
         public bool Remove(string key)
         {

--- a/Controller/SubtitleQueueService.cs
+++ b/Controller/SubtitleQueueService.cs
@@ -120,6 +120,20 @@ namespace WhisperSubs.Controller
         /// </summary>
         public void MarkTaskStarted() => Interlocked.CompareExchange(ref _taskIsRunning, 1, 0);
 
+        /// <summary>
+        /// A live snapshot of the current worker pool for the admin status panel (v4.0), or an empty list
+        /// when no pool has been built yet (nothing has dispatched since startup). Thin accessor over the
+        /// unit-tested <see cref="WorkerPool.Snapshot"/>.
+        /// </summary>
+        [ExcludeFromCodeCoverage(Justification = "Thin accessor over the unit-tested WorkerPool.Snapshot; depends on live pool state")]
+        public IReadOnlyList<WorkerStatus> SnapshotWorkers()
+        {
+            lock (_poolGate)
+            {
+                return _pool?.Snapshot() ?? (IReadOnlyList<WorkerStatus>)System.Array.Empty<WorkerStatus>();
+            }
+        }
+
         // ── Scheduled task progress tracking ─────────────────────
         private string? _taskCurrentItemName;
         private int _taskTotal;
@@ -141,6 +155,19 @@ namespace WhisperSubs.Controller
         /// <summary>Queued item counts by named tier (#112) — for the admin queue view.</summary>
         public Dictionary<PriorityTier, int> CountsByTier()
             => _lanes.CountsByTier().ToDictionary(kv => (PriorityTier)kv.Key, kv => kv.Value);
+
+        /// <summary>
+        /// The waiting ("inbound") queue for the admin panel, in the exact order it will run (strongest tier
+        /// first, then FIFO): each item's name, tier and language. Capped at <paramref name="max"/> so a
+        /// library-wide Generate-All doesn't return thousands of names to a polled endpoint — the full total
+        /// is <see cref="PriorityCount"/>. (v4.0.)
+        /// </summary>
+        [ExcludeFromCodeCoverage(Justification = "Reads BaseItem.Name off queued items; the lane ordering it projects is unit-tested in PriorityLanesTests")]
+        public IReadOnlyList<(string Name, PriorityTier Tier, string Language)> PendingItems(int max = 200)
+            => _lanes.Snapshot()
+                     .Take(max < 0 ? 0 : max)
+                     .Select(e => (e.Value.Item.Name, (PriorityTier)e.Tier, e.Value.Language))
+                     .ToList();
 
         // ── Per-file progress (updated by WhisperProvider stderr) ──
         private int _currentFileProgress;
@@ -487,6 +514,7 @@ namespace WhisperSubs.Controller
                     var wi = workItem;
                     var l = lease;
                     _currentItemName = wi.Item.Name;
+                    pool.SetCurrent(l.Key, wi.Item.Name);   // "what's running where" — surfaced in the status panel
                     logger.LogInformation("[Dispatch] Processing {ItemName} [{Tier}] on {Worker} ({Remaining} remaining)",
                         wi.Item.Name, wi.Tier, l.Worker.Name, _lanes.Count);
 
@@ -517,7 +545,7 @@ namespace WhisperSubs.Controller
                         finally
                         {
                             Release(IdentityKey(wi.Item.Id, wi.Language));
-                            pool.Release(l.Key);
+                            pool.Release(l.Key, wi.Item.Name);
                         }
                     }));
 

--- a/Controller/SubtitleQueueService.cs
+++ b/Controller/SubtitleQueueService.cs
@@ -6,7 +6,9 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using WhisperSubs.Configuration;
 using WhisperSubs.Providers;
+using WhisperSubs.Controller.Workers;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Library;
 using Microsoft.Extensions.Logging;
@@ -66,6 +68,13 @@ namespace WhisperSubs.Controller
         // queued set so a re-request while an item is mid-transcription does not double-queue it.
         private readonly ConcurrentDictionary<string, byte> _inFlight = new();
 
+        // Serialises the queue↔in-flight transition so the invariant "an identity is queued XOR in-flight"
+        // holds atomically: the dispatcher's dequeue+reserve and Enqueue's in-flight-check+lane-add run
+        // under this one lock. Without it (the two touch _lanes and _inFlight under different locks) a
+        // concurrent enqueue in the dequeue→reserve window could re-add an identity that is about to run,
+        // letting the pool dispatch the SAME (item,language) twice — two workers writing one .srt (v4.0).
+        private readonly object _dispatchGate = new();
+
         private int _isDraining;
         private string? _currentItemName;
         private int _processedCount;
@@ -73,11 +82,43 @@ namespace WhisperSubs.Controller
         private string? _lastError;
         private static readonly object _fileLock = new();
 
+        // The single shared worker pool (v4.0) — the concurrency gate for ALL transcription, replacing the
+        // former global TranscriptionLock(1,1). Built lazily from config and rebuilt (see GetPool) only at a
+        // session start when the other consumer is idle and no jobs are in flight, so adding/removing a worker
+        // takes effect between drain sessions without ever corrupting a live session's slot accounting. Both
+        // the background dispatcher and the scheduled task fetch it via GetPool and converge on this one pool
+        // — with the default one local worker of MaxConcurrency 1 it admits exactly one job at a time
+        // (byte-identical to the old lock); with N workers it dispatches up to ΣMaxConcurrency concurrently.
+        private WorkerPool? _pool;
+        private readonly object _poolGate = new();
+
         /// <summary>
-        /// Global lock — only one whisper transcription at a time.
-        /// Must be acquired by both the drain loop and the scheduled task.
+        /// The shared worker pool for the current (or next) drain session, (re)built from config. Rebuilt at a
+        /// session start only when the OTHER consumer is idle AND no jobs are in flight, so a rebuild never
+        /// splits the concurrency gate (any live holder keeps its captured pool). <paramref name="forTask"/>
+        /// excludes the caller's own just-set running flag (the scheduled task vs the background dispatcher).
+        /// Picks up config changes (added worker, changed model path) on the next idle session — matching the
+        /// old per-call provider construction, without staleness, and without over-rebuilding (once per session).
         /// </summary>
-        public static readonly SemaphoreSlim TranscriptionLock = new(1, 1);
+        [ExcludeFromCodeCoverage(Justification = "Builds providers from config via WorkerRegistry (Plugin.Instance) — orchestration")]
+        internal WorkerPool GetPool(PluginConfiguration config, ILoggerFactory loggerFactory, bool forTask)
+        {
+            lock (_poolGate)
+            {
+                var otherConsumerIdle = forTask ? _isDraining == 0 : _taskIsRunning == 0;
+                if (_pool == null || (otherConsumerIdle && _pool.ActiveJobs == 0))
+                {
+                    _pool = new WorkerPool(WorkerRegistry.BuildWorkers(config, loggerFactory));
+                }
+                return _pool;
+            }
+        }
+
+        /// <summary>
+        /// Marks the scheduled task as running so <see cref="GetPool"/> will not rebuild the shared pool
+        /// underneath it during its startup window (before the first progress report). Idempotent.
+        /// </summary>
+        public void MarkTaskStarted() => Interlocked.CompareExchange(ref _taskIsRunning, 1, 0);
 
         // ── Scheduled task progress tracking ─────────────────────
         private string? _taskCurrentItemName;
@@ -209,35 +250,52 @@ namespace WhisperSubs.Controller
         {
             var key = IdentityKey(item.Id, language);
 
-            // If the same unit is mid-transcription, don't queue a duplicate — the running pass covers it.
-            if (_inFlight.ContainsKey(key)) return false;
-
-            var outcome = _lanes.Enqueue(key, (int)tier, new SubtitleWorkItem
+            // Under _dispatchGate so the in-flight check and the lane-add are atomic with the dispatcher's
+            // dequeue+reserve — otherwise a re-add landing in the dequeue→reserve window double-dispatches.
+            lock (_dispatchGate)
             {
-                Item = item,
-                Language = language,
-                Completion = null,
-                Force = force,
-                Tier = tier
-            }, MergeWork);
+                // If the same unit is mid-transcription, don't queue a duplicate — the running pass covers it.
+                if (_inFlight.ContainsKey(key)) return false;
 
-            // Always persist: even a Duplicate outcome can have OR-merged Force or promoted the tier onto
-            // the existing entry via MergeWork, so queue.json must be rewritten to survive a restart —
-            // otherwise an explicit forced re-request could silently revert to non-forced on restore (#112).
-            PersistQueue();
-            return outcome == LaneEnqueueOutcome.Added;
+                var outcome = _lanes.Enqueue(key, (int)tier, new SubtitleWorkItem
+                {
+                    Item = item,
+                    Language = language,
+                    Completion = null,
+                    Force = force,
+                    Tier = tier
+                }, MergeWork);
+
+                // Always persist: even a Duplicate outcome can have OR-merged Force or promoted the tier onto
+                // the existing entry via MergeWork, so queue.json must be rewritten to survive a restart —
+                // otherwise an explicit forced re-request could silently revert to non-forced on restore (#112).
+                PersistQueue();
+                return outcome == LaneEnqueueOutcome.Added;
+            }
         }
 
         [ExcludeFromCodeCoverage(Justification = "Requires Plugin.Instance for persistence")]
         public bool TryDequeuePriority(out SubtitleWorkItem? item)
         {
-            if (_lanes.TryDequeue(out var dequeued) && dequeued != null)
+            // Dequeue + reserve atomically (see _dispatchGate): moving an identity from the lanes to the
+            // in-flight set in one critical section is what guarantees the pool never dispatches the same
+            // (item,language) twice.
+            lock (_dispatchGate)
             {
-                // Mark in-flight so a concurrent re-request doesn't double-queue while it transcribes.
-                TryReserve(IdentityKey(dequeued.Item.Id, dequeued.Language));
-                PersistQueue();
-                item = dequeued;
-                return true;
+                if (_lanes.TryDequeue(out var dequeued) && dequeued != null)
+                {
+                    // Reserve it in-flight. Honour the result: TryReserve returns false only if the identity
+                    // is already in-flight, which under _dispatchGate cannot happen for a freshly-dequeued
+                    // item — but if it ever did, drop this copy rather than double-dispatch. queue.json is
+                    // persisted either way (the item left the lanes).
+                    var reserved = TryReserve(IdentityKey(dequeued.Item.Id, dequeued.Language));
+                    PersistQueue();
+                    if (reserved)
+                    {
+                        item = dequeued;
+                        return true;
+                    }
+                }
             }
             item = null;
             return false;
@@ -321,144 +379,181 @@ namespace WhisperSubs.Controller
         }
 
         /// <summary>
-        /// Starts the background drain loop if not already running.
-        /// Safe to call multiple times — only one drain runs at a time.
-        /// Re-checks queue after draining to avoid race with late enqueues.
+        /// Starts the background dispatch loop if not already running (only one at a time), building the
+        /// shared worker pool from config. Safe to call multiple times. Re-checks the queue after draining
+        /// to avoid a race with late enqueues. Replaces the former single-worker EnsureDraining: with the
+        /// default one local worker it behaves identically (one job at a time); with N configured workers it
+        /// dispatches up to ΣMaxConcurrency jobs concurrently across the pool.
         /// </summary>
-        [ExcludeFromCodeCoverage(Justification = "Orchestrates async drain loop with external processes")]
-        public void EnsureDraining(
+        [ExcludeFromCodeCoverage(Justification = "Orchestrates the async dispatch loop with external processes")]
+        public void EnsureDispatching(
             SubtitleManager manager,
-            ISubtitleProvider provider,
+            PluginConfiguration config,
+            ILoggerFactory loggerFactory,
             ILogger logger,
             CancellationToken cancellationToken)
         {
             if (Interlocked.CompareExchange(ref _isDraining, 1, 0) == 0)
             {
+                var pool = GetPool(config, loggerFactory, forTask: false);
+                var requirements = WorkerJob.Requirements(config.SubtitleMode, config.EnableTranslation);
                 _ = Task.Run(async () =>
                 {
                     try
                     {
-                        await DrainLoopAsync(manager, provider, logger, cancellationToken);
+                        await DispatchDrainAsync(manager, pool, requirements, countProcessed: true, logger, cancellationToken);
                     }
                     finally
                     {
                         _currentItemName = null;
                         Interlocked.Exchange(ref _isDraining, 0);
 
-                        // Re-check: if items were enqueued during the finally block, restart the drain to
+                        // Re-check: if items were enqueued during the finally block, restart the loop to
                         // avoid stuck items — but never on an already-cancelled token, which would set
                         // _isDraining=1 while Task.Run skips the delegate, wedging the queue forever (#112).
                         if (!_lanes.IsEmpty && !cancellationToken.IsCancellationRequested)
                         {
-                            EnsureDraining(manager, provider, logger, cancellationToken);
+                            EnsureDispatching(manager, config, loggerFactory, logger, cancellationToken);
                         }
                     }
-                }, cancellationToken);
+                    // Task.Run is deliberately NOT given the cancellation token: if it were and the token were
+                    // already cancelled, the delegate would be skipped and the finally above would never reset
+                    // _isDraining — wedging the queue forever. Cancellation is observed INSIDE via the captured
+                    // token (DispatchDrainAsync checks it), so the finally always runs. (Matches the per-job
+                    // Task.Run, which is un-tokened for the same reason.)
+                });
             }
         }
 
-        [ExcludeFromCodeCoverage(Justification = "Orchestrates async drain with external processes")]
-        private async Task DrainLoopAsync(
+        /// <summary>
+        /// The core N-slot dispatcher: pulls the highest-priority item, waits for a free worker slot
+        /// (backpressure at ΣMaxConcurrency), routes it to the cheapest capable worker, and runs it
+        /// concurrently — up to the pool's capacity in flight at once. On completion or failure both the
+        /// worker slot and the in-flight (item,language) reservation are released. Shared by the background
+        /// loop (fire-and-forget via EnsureDispatching) and the scheduled task's priority drain (awaited via
+        /// DrainPriorityAsync); both use the SAME pool so the global concurrency limit always holds. At one
+        /// worker of MaxConcurrency 1 the slot serialises exactly like the old TranscriptionLock.
+        /// </summary>
+        [ExcludeFromCodeCoverage(Justification = "Orchestrates concurrent async transcription with external processes")]
+        private async Task DispatchDrainAsync(
             SubtitleManager manager,
-            ISubtitleProvider provider,
+            WorkerPool pool,
+            JobRequirements requirements,
+            bool countProcessed,
             ILogger logger,
             CancellationToken cancellationToken)
         {
-            while (TryDequeuePriority(out var workItem) && workItem != null)
+            // The job requirements are uniform across a drain session, so feasibility is decided once: if no
+            // worker can EVER serve them (e.g. translation enabled but every configured worker is
+            // transcribe-only) fail the whole queue fast rather than block a slot forever. A misconfig then
+            // surfaces loudly (every item errors with a clear message) instead of the queue hanging.
+            if (!pool.HasCapableWorker(requirements))
             {
-                try
+                while (TryDequeuePriority(out var unservable) && unservable != null)
                 {
-                    // Inside the try so the finally still releases the in-flight reservation on cancel (#112).
-                    cancellationToken.ThrowIfCancellationRequested();
-                    _currentItemName = workItem.Item.Name;
-                    logger.LogInformation("[Queue] Processing {ItemName} [{Tier}] ({Remaining} remaining)",
-                        workItem.Item.Name, workItem.Tier, _lanes.Count);
-
-                    await TranscriptionLock.WaitAsync(cancellationToken);
-                    try
-                    {
-                        await manager.GenerateSubtitleAsync(
-                            workItem.Item, provider, workItem.Language, cancellationToken, workItem.Force);
-                    }
-                    finally
-                    {
-                        TranscriptionLock.Release();
-                    }
-
-                    Interlocked.Increment(ref _processedCount);
-                    workItem.Completion?.TrySetResult(true);
-                }
-                catch (System.OperationCanceledException)
-                {
-                    workItem.Completion?.TrySetCanceled();
-                    throw;
-                }
-                catch (System.Exception ex)
-                {
-                    Interlocked.Increment(ref _processedCount);
+                    // Match the old counting: the background loop counted a failure toward `processed`,
+                    // the scheduled task's priority drain did not (countProcessed distinguishes them).
+                    if (countProcessed) Interlocked.Increment(ref _processedCount);
                     Interlocked.Increment(ref _failedCount);
-                    _lastError = $"{workItem.Item.Name}: {ex.Message}";
-                    workItem.Completion?.TrySetException(ex);
-                    logger.LogError(ex, "[Queue] Failed: {ItemName}", workItem.Item.Name);
+                    _lastError = $"{unservable.Item.Name}: no configured worker can serve this job";
+                    unservable.Completion?.TrySetException(
+                        new System.InvalidOperationException("No configured worker can serve this job"));
+                    Release(IdentityKey(unservable.Item.Id, unservable.Language));
+                    logger.LogError("[Dispatch] No capable worker for {ItemName} — skipping", unservable.Item.Name);
                 }
-                finally
+                _currentItemName = null;
+                return;
+            }
+
+            var running = new List<Task>();
+            try
+            {
+                while (!_lanes.IsEmpty)
                 {
-                    Release(IdentityKey(workItem.Item.Id, workItem.Language));
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    // Acquire a free slot FIRST (backpressure at ΣMaxConcurrency), THEN dequeue the current
+                    // highest-priority item — so an item leaves the persisted queue only when a worker is
+                    // ready to run it now (same crash-durability as the old single-lock loop), and each pick
+                    // sees the freshest priority state.
+                    var lease = await pool.AcquireAsync(requirements, cancellationToken);
+                    if (!TryDequeuePriority(out var workItem) || workItem == null)
+                    {
+                        // Emptied by a concurrent consumer between the check and the dequeue — release, re-check.
+                        pool.Release(lease.Key);
+                        continue;
+                    }
+
+                    var wi = workItem;
+                    var l = lease;
+                    _currentItemName = wi.Item.Name;
+                    logger.LogInformation("[Dispatch] Processing {ItemName} [{Tier}] on {Worker} ({Remaining} remaining)",
+                        wi.Item.Name, wi.Tier, l.Worker.Name, _lanes.Count);
+
+                    // Fire the job WITHOUT gating Task.Run on the token: a cancelled token must not skip the
+                    // delegate, or the finally (which frees the slot + reservation) would never run and leak
+                    // the slot. Cancellation is observed INSIDE, via the token passed to the transcription.
+                    running.Add(Task.Run(async () =>
+                    {
+                        try
+                        {
+                            await manager.GenerateSubtitleAsync(
+                                wi.Item, l.Worker.Provider, wi.Language, cancellationToken, wi.Force);
+                            if (countProcessed) Interlocked.Increment(ref _processedCount);
+                            wi.Completion?.TrySetResult(true);
+                        }
+                        catch (System.OperationCanceledException)
+                        {
+                            wi.Completion?.TrySetCanceled();
+                        }
+                        catch (System.Exception ex)
+                        {
+                            if (countProcessed) Interlocked.Increment(ref _processedCount);
+                            Interlocked.Increment(ref _failedCount);
+                            _lastError = $"{wi.Item.Name}: {ex.Message}";
+                            wi.Completion?.TrySetException(ex);
+                            logger.LogError(ex, "[Dispatch] Failed: {ItemName}", wi.Item.Name);
+                        }
+                        finally
+                        {
+                            Release(IdentityKey(wi.Item.Id, wi.Language));
+                            pool.Release(l.Key);
+                        }
+                    }));
+
+                    // Reap finished tasks so the list can't grow unbounded on a long backlog.
+                    running.RemoveAll(t => t.IsCompleted);
                 }
             }
-            logger.LogInformation("[Queue] Drain complete. Processed {Count} items total ({Failed} failed).",
+            finally
+            {
+                // Wait for every dispatched job to finish before returning, so the caller (and _isDraining)
+                // only sees "drained" once the pool is truly idle. Individual job errors are handled above.
+                try { await Task.WhenAll(running); } catch { /* per-job exceptions already handled */ }
+            }
+
+            logger.LogInformation("[Dispatch] Drain complete. Processed {Count} items total ({Failed} failed).",
                 _processedCount, _failedCount);
         }
 
         /// <summary>
-        /// Process all pending priority items. Called by scheduled task.
+        /// Processes all currently-queued priority items across the worker pool and awaits their completion.
+        /// Called by the scheduled task to clear manual/user requests (which outrank the background sweep)
+        /// before and between its own items. Uses the SAME shared pool as the background dispatcher, so the
+        /// two together never exceed the global concurrency limit. With the default one local worker this is
+        /// a sequential drain (identical to the old single-lock behaviour); with N workers it runs in parallel.
         /// </summary>
-        [ExcludeFromCodeCoverage(Justification = "Orchestrates async drain with external processes")]
-        public async Task DrainPriorityAsync(
+        [ExcludeFromCodeCoverage(Justification = "Orchestrates concurrent async transcription with external processes")]
+        internal async Task DrainPriorityAsync(
             SubtitleManager manager,
-            ISubtitleProvider provider,
+            WorkerPool pool,
+            JobRequirements requirements,
             ILogger logger,
             CancellationToken cancellationToken)
         {
-            while (TryDequeuePriority(out var workItem) && workItem != null)
-            {
-                try
-                {
-                    // Inside the try so the finally still releases the in-flight reservation on cancel (#112).
-                    cancellationToken.ThrowIfCancellationRequested();
-                    _currentItemName = workItem.Item.Name;
-                    logger.LogInformation("[Priority] Processing {ItemName} [{Tier}]", workItem.Item.Name, workItem.Tier);
-
-                    await TranscriptionLock.WaitAsync(cancellationToken);
-                    try
-                    {
-                        await manager.GenerateSubtitleAsync(
-                            workItem.Item, provider, workItem.Language, cancellationToken, workItem.Force);
-                    }
-                    finally
-                    {
-                        TranscriptionLock.Release();
-                    }
-
-                    workItem.Completion?.TrySetResult(true);
-                }
-                catch (System.OperationCanceledException)
-                {
-                    workItem.Completion?.TrySetCanceled();
-                    throw;
-                }
-                catch (System.Exception ex)
-                {
-                    Interlocked.Increment(ref _failedCount);
-                    _lastError = $"{workItem.Item.Name}: {ex.Message}";
-                    workItem.Completion?.TrySetException(ex);
-                    logger.LogError(ex, "[Priority] Failed: {ItemName}", workItem.Item.Name);
-                }
-                finally
-                {
-                    Release(IdentityKey(workItem.Item.Id, workItem.Language));
-                }
-            }
+            // countProcessed:false — the old priority drain did not add to _processedCount (only the
+            // background loop did), so the /Queue `processed` stat stays byte-identical to pre-v4.
+            await DispatchDrainAsync(manager, pool, requirements, countProcessed: false, logger, cancellationToken);
             _currentItemName = null;
         }
     }

--- a/Controller/SubtitleRequestService.cs
+++ b/Controller/SubtitleRequestService.cs
@@ -46,8 +46,7 @@ namespace WhisperSubs.Controller
             }
 
             var manager = new SubtitleManager(libraryManager, loggerFactory.CreateLogger<SubtitleManager>());
-            var provider = SubtitleProviderFactory.Create(config, loggerFactory);
-            queue.EnsureDraining(manager, provider, logger, CancellationToken.None);
+            queue.EnsureDispatching(manager, config, loggerFactory, logger, CancellationToken.None);
 
             logger.LogInformation("[Request] Enqueued {Queued} of {Total} item(s) for {ItemId} [{Tier}]",
                 queued, leaves.Count, itemId, tier);

--- a/Controller/Workers/ITranscriptionWorker.cs
+++ b/Controller/Workers/ITranscriptionWorker.cs
@@ -1,0 +1,23 @@
+using WhisperSubs.Providers;
+
+namespace WhisperSubs.Controller.Workers
+{
+    /// <summary>
+    /// A transcription worker (v4.0 pool): a stable identity + advertised <see cref="WorkerCapabilities"/>
+    /// + the <see cref="ISubtitleProvider"/> that does the actual work — the host's own local whisper-cli
+    /// or any remote OpenAI-compatible endpoint. The dispatcher (PR-3) tracks live in-flight load
+    /// separately and snapshots each worker into a <see cref="WorkerSlot"/> for routing, so this stays a
+    /// thin, immutable descriptor.
+    /// </summary>
+    public interface ITranscriptionWorker
+    {
+        string Id { get; }
+        string Name { get; }
+        ISubtitleProvider Provider { get; }
+        WorkerCapabilities Capabilities { get; }
+    }
+
+    /// <summary>Default worker: an id/name + the provider that transcribes + its advertised capabilities.</summary>
+    public sealed record TranscriptionWorker(
+        string Id, string Name, ISubtitleProvider Provider, WorkerCapabilities Capabilities) : ITranscriptionWorker;
+}

--- a/Controller/Workers/SyntheticAudio.cs
+++ b/Controller/Workers/SyntheticAudio.cs
@@ -1,0 +1,59 @@
+using System;
+
+namespace WhisperSubs.Controller.Workers
+{
+    /// <summary>
+    /// Builds a tiny in-memory 16 kHz mono s16le WAV of silence for the worker "Test connection" probe
+    /// (v4.0). Every OpenAI-compatible endpoint can transcribe it, so the test exercises the real
+    /// transcribe path (URL + auth + model) without shipping a fixture file or touching the media library.
+    /// Pure + unit-testable — the HTTP POST that sends it lives in the (excluded) controller.
+    /// </summary>
+    public static class SyntheticAudio
+    {
+        private const int SampleRate = 16000;   // matches the plugin's ffmpeg extraction
+        private const short Channels = 1;
+        private const short BitsPerSample = 16;
+
+        /// <summary>
+        /// A canonical 44-byte-header WAV containing <paramref name="milliseconds"/> of silence
+        /// (clamped to 10..2000 ms). Layout is little-endian PCM, exactly what whisper.cpp / faster-whisper
+        /// expect.
+        /// </summary>
+        public static byte[] SilentWav16kMono(int milliseconds = 100)
+        {
+            if (milliseconds < 10) milliseconds = 10;
+            if (milliseconds > 2000) milliseconds = 2000;
+
+            var samples = SampleRate * milliseconds / 1000;
+            var dataBytes = samples * Channels * (BitsPerSample / 8);
+            var buffer = new byte[44 + dataBytes];
+
+            void PutAscii(int offset, string s)
+            {
+                for (var i = 0; i < s.Length; i++) buffer[offset + i] = (byte)s[i];
+            }
+            void PutInt32(int offset, int value) => BitConverter.GetBytes(value).CopyTo(buffer, offset);
+            void PutInt16(int offset, short value) => BitConverter.GetBytes(value).CopyTo(buffer, offset);
+
+            var byteRate = SampleRate * Channels * (BitsPerSample / 8);
+            var blockAlign = (short)(Channels * (BitsPerSample / 8));
+
+            PutAscii(0, "RIFF");
+            PutInt32(4, 36 + dataBytes);      // ChunkSize = 36 + Subchunk2Size
+            PutAscii(8, "WAVE");
+            PutAscii(12, "fmt ");
+            PutInt32(16, 16);                 // Subchunk1Size (PCM)
+            PutInt16(20, 1);                  // AudioFormat = PCM
+            PutInt16(22, Channels);
+            PutInt32(24, SampleRate);
+            PutInt32(28, byteRate);
+            PutInt16(32, blockAlign);
+            PutInt16(34, BitsPerSample);
+            PutAscii(36, "data");
+            PutInt32(40, dataBytes);          // Subchunk2Size
+            // Samples are left zeroed = silence.
+
+            return buffer;
+        }
+    }
+}

--- a/Controller/Workers/WorkerConfigValidation.cs
+++ b/Controller/Workers/WorkerConfigValidation.cs
@@ -1,0 +1,31 @@
+using System;
+using WhisperSubs.Configuration;
+
+namespace WhisperSubs.Controller.Workers
+{
+    /// <summary>
+    /// Pure validation for a configured <see cref="WhisperWorker"/> row (v4.0 config UI). Returns the first
+    /// problem (or ok) so the config page and the Test-connection endpoint can reject a malformed worker
+    /// before it ever reaches the pool. Kept free of Jellyfin/HTTP types so it is unit-testable, mirroring
+    /// the codebase's other pure decision helpers.
+    /// </summary>
+    public static class WorkerConfigValidation
+    {
+        /// <summary>Validates a worker row. <c>Ok=false</c> carries a user-facing reason (first failure wins).</summary>
+        public static (bool Ok, string? Error) Validate(WhisperWorker worker)
+        {
+            if (worker is null)
+                return (false, "Worker is missing.");
+            if (string.IsNullOrWhiteSpace(worker.ApiUrl))
+                return (false, "Endpoint URL is required.");
+            if (!Uri.TryCreate(worker.ApiUrl.Trim(), UriKind.Absolute, out var uri)
+                || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+                return (false, "Endpoint must be an absolute http(s) URL.");
+            if (worker.MaxConcurrency < 1)
+                return (false, "Max concurrency must be at least 1.");
+            if (worker.CostWeight < 0)
+                return (false, "Cost weight cannot be negative.");
+            return (true, null);
+        }
+    }
+}

--- a/Controller/Workers/WorkerJob.cs
+++ b/Controller/Workers/WorkerJob.cs
@@ -1,0 +1,32 @@
+using WhisperSubs.Configuration;
+
+namespace WhisperSubs.Controller.Workers
+{
+    /// <summary>
+    /// Pure mapping from plugin config to the dispatcher's per-job <see cref="JobRequirements"/> (v4.0).
+    /// Kept free of Jellyfin runtime types (only the POCO config) so it is unit-testable, mirroring the
+    /// codebase's other pure decision helpers (<see cref="PriorityScheduling"/>, <see cref="WorkerPlan"/>).
+    /// </summary>
+    public static class WorkerJob
+    {
+        /// <summary>
+        /// Whether the current config may require an English-translation pass for some item — the same
+        /// condition the scheduled task uses for its <c>needsTranslation</c> gate: TranslationOnly always,
+        /// or EnableTranslation in a mode that runs the full pass (Full / FullAndForced).
+        /// </summary>
+        public static bool TranslationPossible(SubtitleMode mode, bool enableTranslation)
+            => mode == SubtitleMode.TranslationOnly
+               || (enableTranslation && (mode == SubtitleMode.Full || mode == SubtitleMode.FullAndForced));
+
+        /// <summary>
+        /// The capability a dispatched worker must advertise. Whole media items are dispatched and the
+        /// manager decides per item whether to also run a translation pass, so this is conservative: when
+        /// translation is possible for the config every job requires a translate-capable worker, guaranteeing
+        /// a translate pass never lands on a transcribe-only worker. A worker that cannot translate is simply
+        /// not chosen while translation is enabled — the common case (all workers translate) is unaffected.
+        /// <c>RequiredModel</c> is null: the manager does not pin a per-job model, so any model serves.
+        /// </summary>
+        public static JobRequirements Requirements(SubtitleMode mode, bool enableTranslation)
+            => new JobRequirements(TranslationPossible(mode, enableTranslation), null);
+    }
+}

--- a/Controller/Workers/WorkerModel.cs
+++ b/Controller/Workers/WorkerModel.cs
@@ -33,6 +33,16 @@ namespace WhisperSubs.Controller.Workers
     /// <summary>A live routing snapshot of one worker — a pure value (no Jellyfin/HTTP types), so selection is unit-testable.</summary>
     public readonly record struct WorkerSlot(string Id, bool Healthy, int InFlight, WorkerCapabilities Capabilities);
 
+    /// <summary>
+    /// A display snapshot of one worker for the admin queue/status panel (v4.0): identity + live load + the
+    /// item(s) it is currently transcribing ("what's running where") + the static facts the UI shows.
+    /// Distinct from <see cref="WorkerSlot"/> (routing) so the surfaced shape is stable and independent of
+    /// the scheduler's internal value.
+    /// </summary>
+    public readonly record struct WorkerStatus(
+        string Id, string Name, bool Healthy, int InFlight, int MaxConcurrency, bool IsLocal, double CostWeight,
+        IReadOnlyList<string> CurrentItems);
+
     /// <summary>What a specific job needs from a worker (drives the hard capability filter).</summary>
     public readonly record struct JobRequirements(bool Translate, string? RequiredModel);
 }

--- a/Controller/Workers/WorkerModel.cs
+++ b/Controller/Workers/WorkerModel.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+
+namespace WhisperSubs.Controller.Workers
+{
+    /// <summary>
+    /// Static, slow-changing facts a transcription worker advertises so the scheduler can route a job to it
+    /// without any backend-specific conditionals (v4.0 worker pool). A "worker" is the host's own local
+    /// whisper-cli OR any remote OpenAI-compatible endpoint (CPU faster-whisper, NVIDIA/CUDA, AMD/ROCm, a
+    /// NAS, a cloud API — the user's choice). This model is deliberately backend-agnostic so the pool serves
+    /// any user's topology, not one reference setup.
+    /// </summary>
+    public sealed record WorkerCapabilities
+    {
+        /// <summary>Max jobs this worker runs at once. Default 1 — a single GPU saturates on one whisper stream.</summary>
+        public int MaxConcurrency { get; init; } = 1;
+
+        /// <summary>Whether the worker can translate to English (OpenAI /v1/audio/translations, or whisper-cli --translate).</summary>
+        public bool CanTranslate { get; init; } = true;
+
+        /// <summary>Models the worker can serve; empty = "any" (the common homelab case, and the local worker).</summary>
+        public IReadOnlySet<string> Models { get; init; } = new HashSet<string>();
+
+        /// <summary>A free local worker (the host's own CPU/GPU, or a LAN box) vs a paid/remote one.</summary>
+        public bool IsLocal { get; init; } = true;
+
+        /// <summary>Selection cost: 0 = free local (always preferred); &gt;0 = paid/cloud, used only to burst when locals are full.</summary>
+        public double CostWeight { get; init; }
+
+        /// <summary>Stable tiebreak among otherwise-equal workers. Lower = preferred.</summary>
+        public int Priority { get; init; }
+    }
+
+    /// <summary>A live routing snapshot of one worker — a pure value (no Jellyfin/HTTP types), so selection is unit-testable.</summary>
+    public readonly record struct WorkerSlot(string Id, bool Healthy, int InFlight, WorkerCapabilities Capabilities);
+
+    /// <summary>What a specific job needs from a worker (drives the hard capability filter).</summary>
+    public readonly record struct JobRequirements(bool Translate, string? RequiredModel);
+}

--- a/Controller/Workers/WorkerPlan.cs
+++ b/Controller/Workers/WorkerPlan.cs
@@ -1,0 +1,35 @@
+namespace WhisperSubs.Controller.Workers
+{
+    /// <summary>Which set of workers the pool should be built from (backward-compatibility).</summary>
+    public enum WorkerSource
+    {
+        /// <summary>The admin configured an explicit <c>Workers</c> list.</summary>
+        ExplicitList,
+        /// <summary>No list, but a legacy single <c>RemoteWhisperApiUrl</c> is set — remote-only, as pre-v4.</summary>
+        LegacyRemote,
+        /// <summary>Nothing configured — the host's own local whisper only (today's default).</summary>
+        LocalOnly
+    }
+
+    /// <summary>
+    /// Pure backward-compatibility decision for composing the worker pool (v4.0). Guarantees that a normal
+    /// single-server install with no new config behaves EXACTLY as today, and that an existing legacy
+    /// single-remote-URL install stays remote-only (the host's local whisper is not silently activated — a
+    /// behaviour change that would otherwise surprise an upgrading remote-offload user).
+    /// </summary>
+    public static class WorkerPlan
+    {
+        /// <summary>
+        /// Decide the worker composition. An explicit <c>Workers</c> list wins, plus the local worker when
+        /// <paramref name="enableLocalWorker"/>. Otherwise a legacy <c>RemoteWhisperApiUrl</c> means
+        /// remote-ONLY (local not added, exactly the pre-v4 behaviour). Otherwise: local only.
+        /// </summary>
+        public static (WorkerSource Source, bool AddLocal) Decide(
+            int explicitWorkerCount, bool hasLegacyRemoteUrl, bool enableLocalWorker)
+        {
+            if (explicitWorkerCount > 0) return (WorkerSource.ExplicitList, enableLocalWorker);
+            if (hasLegacyRemoteUrl) return (WorkerSource.LegacyRemote, false);
+            return (WorkerSource.LocalOnly, true);
+        }
+    }
+}

--- a/Controller/Workers/WorkerPool.cs
+++ b/Controller/Workers/WorkerPool.cs
@@ -28,6 +28,9 @@ namespace WhisperSubs.Controller.Workers
         private readonly List<string> _keys = new();
         private readonly Dictionary<string, ITranscriptionWorker> _byKey = new();
         private readonly Dictionary<string, int> _inFlight = new();
+        // The item name(s) each worker is transcribing right now — surfaced in the status panel so the admin
+        // sees "what's running where" (a worker with MaxConcurrency > 1 can hold several). (v4.0.)
+        private readonly Dictionary<string, List<string>> _current = new();
         private readonly SemaphoreSlim _slots;
 
         public WorkerPool(IReadOnlyList<ITranscriptionWorker> workers)
@@ -46,6 +49,7 @@ namespace WhisperSubs.Controller.Workers
                 _keys.Add(key);
                 _byKey[key] = w;
                 _inFlight[key] = 0;
+                _current[key] = new List<string>();
                 capacity += w.Capabilities.MaxConcurrency < 1 ? 1 : w.Capabilities.MaxConcurrency;
             }
 
@@ -70,6 +74,29 @@ namespace WhisperSubs.Controller.Workers
                     foreach (var n in _inFlight.Values) sum += n;
                     return sum;
                 }
+            }
+        }
+
+        /// <summary>
+        /// A live per-worker snapshot for the admin status panel (v4.0): each worker's identity, current
+        /// in-flight load, and the static facts the UI shows. Taken under the pool lock so counts are
+        /// consistent with each other.
+        /// </summary>
+        public IReadOnlyList<WorkerStatus> Snapshot()
+        {
+            lock (_gate)
+            {
+                var list = new List<WorkerStatus>(_keys.Count);
+                foreach (var key in _keys)
+                {
+                    var w = _byKey[key];
+                    var caps = w.Capabilities;
+                    list.Add(new WorkerStatus(
+                        w.Id, w.Name, Healthy: true, _inFlight[key],
+                        caps.MaxConcurrency < 1 ? 1 : caps.MaxConcurrency, caps.IsLocal, caps.CostWeight,
+                        new List<string>(_current[key])));
+                }
+                return list;
             }
         }
 
@@ -132,11 +159,31 @@ namespace WhisperSubs.Controller.Workers
             }
         }
 
-        /// <summary>Releases a slot after a job completes or fails, by the <see cref="WorkerLease.Key"/>. Pair each <see cref="AcquireAsync"/> with exactly one Release.</summary>
-        public void Release(string leaseKey)
+        /// <summary>
+        /// Records the item a leased worker is now transcribing, for the "what's running where" status
+        /// panel. Call once after <see cref="AcquireAsync"/>, before the transcription runs; pass the same
+        /// <paramref name="itemName"/> to <see cref="Release"/> so it is cleared when the job finishes.
+        /// </summary>
+        public void SetCurrent(string leaseKey, string itemName)
         {
             lock (_gate)
             {
+                if (_current.TryGetValue(leaseKey, out var items)) items.Add(itemName);
+            }
+        }
+
+        /// <summary>
+        /// Releases a slot after a job completes or fails, by the <see cref="WorkerLease.Key"/>. Pass the
+        /// <paramref name="currentItem"/> given to <see cref="SetCurrent"/> to clear it from the status
+        /// panel (omit on paths that acquired a slot but never dispatched an item). Pair each
+        /// <see cref="AcquireAsync"/> with exactly one Release.
+        /// </summary>
+        public void Release(string leaseKey, string? currentItem = null)
+        {
+            lock (_gate)
+            {
+                if (currentItem != null && _current.TryGetValue(leaseKey, out var items))
+                    items.Remove(currentItem);
                 if (_inFlight.TryGetValue(leaseKey, out var n) && n > 0)
                     _inFlight[leaseKey] = n - 1;
             }

--- a/Controller/Workers/WorkerPool.cs
+++ b/Controller/Workers/WorkerPool.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace WhisperSubs.Controller.Workers
+{
+    /// <summary>
+    /// A reserved worker slot handed out by <see cref="WorkerPool.AcquireAsync"/>: the chosen worker plus
+    /// the pool-internal <see cref="Key"/> to release it by. Releasing by the key (not the worker's own Id)
+    /// keeps slot accounting correct even if two configured workers collide on Id.
+    /// </summary>
+    internal readonly record struct WorkerLease(string Key, ITranscriptionWorker Worker);
+
+    /// <summary>
+    /// The live transcription worker pool (v4.0): the immutable <see cref="ITranscriptionWorker"/>
+    /// descriptors plus their mutable in-flight counts, behind one lock, gated by a ΣMaxConcurrency
+    /// backpressure semaphore. It replaces the single global <c>TranscriptionLock(1,1)</c> — with the
+    /// default one local worker of MaxConcurrency 1 it admits exactly one job at a time (byte-identical to
+    /// the old lock); with N workers it admits up to the summed capacity and routes each job to the cheapest
+    /// free worker via the pure <see cref="WorkerScheduling"/>. ALL transcription paths (queue drain, user
+    /// request, scheduled sweep) share ONE pool, so the global concurrency limit holds no matter which path
+    /// started the work — never two whisper runs on a single-slot worker.
+    /// </summary>
+    internal sealed class WorkerPool
+    {
+        private readonly object _gate = new();
+        private readonly List<string> _keys = new();
+        private readonly Dictionary<string, ITranscriptionWorker> _byKey = new();
+        private readonly Dictionary<string, int> _inFlight = new();
+        private readonly SemaphoreSlim _slots;
+
+        public WorkerPool(IReadOnlyList<ITranscriptionWorker> workers)
+        {
+            if (workers == null) throw new ArgumentNullException(nameof(workers));
+
+            var capacity = 0;
+            for (var i = 0; i < workers.Count; i++)
+            {
+                var w = workers[i];
+                // Guarantee a unique routing key even if two configured workers collide on Id — a
+                // duplicate would otherwise make the reverse Id→worker lookup ambiguous. The key is only
+                // used internally for slot accounting; WorkerSlot.Id still carries it for the deterministic
+                // ordinal tiebreak in WorkerScheduling.Pick.
+                var key = _byKey.ContainsKey(w.Id) ? $"{w.Id}#{i}" : w.Id;
+                _keys.Add(key);
+                _byKey[key] = w;
+                _inFlight[key] = 0;
+                capacity += w.Capabilities.MaxConcurrency < 1 ? 1 : w.Capabilities.MaxConcurrency;
+            }
+
+            TotalCapacity = capacity < 1 ? 1 : capacity;
+            _slots = new SemaphoreSlim(TotalCapacity, TotalCapacity);
+        }
+
+        /// <summary>Summed MaxConcurrency across all workers (≥1): how many jobs may run at once.</summary>
+        public int TotalCapacity { get; }
+
+        /// <summary>Number of workers in the pool.</summary>
+        public int WorkerCount => _keys.Count;
+
+        /// <summary>Jobs currently running across all workers (0 when fully idle).</summary>
+        public int ActiveJobs
+        {
+            get
+            {
+                lock (_gate)
+                {
+                    var sum = 0;
+                    foreach (var n in _inFlight.Values) sum += n;
+                    return sum;
+                }
+            }
+        }
+
+        /// <summary>
+        /// True if ANY worker could serve <paramref name="job"/>'s hard requirements ignoring current load —
+        /// i.e. a capable worker exists (maybe busy). The dispatcher checks this before <see cref="AcquireAsync"/>
+        /// so a job no worker can EVER serve is failed fast instead of blocking a slot forever.
+        /// </summary>
+        public bool HasCapableWorker(JobRequirements job)
+        {
+            lock (_gate)
+            {
+                foreach (var key in _keys)
+                {
+                    // InFlight 0 ⇒ CanServe reduces to the pure capability filter (translate/model), no load.
+                    if (WorkerScheduling.CanServe(new WorkerSlot(key, true, 0, _byKey[key].Capabilities), job))
+                        return true;
+                }
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Waits for a free slot (backpressure at <see cref="TotalCapacity"/>), then reserves the cheapest
+        /// worker that can serve <paramref name="job"/> and returns a <see cref="WorkerLease"/>. The caller
+        /// MUST call <see cref="Release"/> with the lease's key exactly once when the job finishes. Assumes a
+        /// capable worker EXISTS (guard with <see cref="HasCapableWorker"/>): if every free slot is on an
+        /// incapable worker it hands the slot back and retries after a short backoff until a capable one
+        /// frees, so it always returns a lease unless cancelled.
+        /// </summary>
+        public async Task<WorkerLease> AcquireAsync(JobRequirements job, CancellationToken cancellationToken)
+        {
+            // Defense-in-depth: the callers already fail-fast on !HasCapableWorker, but if a call site ever
+            // skipped that, the retry loop below would spin forever (acquire slot → PickLocked fails →
+            // release → delay). Fail deterministically instead so a misuse surfaces as an exception, not a
+            // hung job. When a capable worker EXISTS but is busy, this passes and the loop waits for it.
+            if (!HasCapableWorker(job))
+            {
+                throw new System.InvalidOperationException(
+                    "No worker in the pool can serve this job's requirements.");
+            }
+
+            while (true)
+            {
+                await _slots.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+                WorkerLease? lease;
+                lock (_gate)
+                {
+                    lease = PickLocked(job);
+                }
+
+                if (lease is not null) return lease.Value;
+
+                // A slot freed but only incapable workers are free (heterogeneous-capability case). Give the
+                // slot back and wait briefly for the capable-but-busy worker to free — the HasCapableWorker
+                // guard guarantees one exists, so this terminates.
+                _slots.Release();
+                await Task.Delay(100, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>Releases a slot after a job completes or fails, by the <see cref="WorkerLease.Key"/>. Pair each <see cref="AcquireAsync"/> with exactly one Release.</summary>
+        public void Release(string leaseKey)
+        {
+            lock (_gate)
+            {
+                if (_inFlight.TryGetValue(leaseKey, out var n) && n > 0)
+                    _inFlight[leaseKey] = n - 1;
+            }
+            _slots.Release();
+        }
+
+        // Caller holds _gate. Snapshots each worker as a WorkerSlot (keyed by the unique routing key), asks
+        // WorkerScheduling for the cheapest capable free one, marks it in-flight, and returns a lease
+        // carrying that key. Null if none is free-and-capable right now.
+        private WorkerLease? PickLocked(JobRequirements job)
+        {
+            var slots = new List<WorkerSlot>(_keys.Count);
+            foreach (var key in _keys)
+                slots.Add(new WorkerSlot(key, true, _inFlight[key], _byKey[key].Capabilities));
+
+            var pick = WorkerScheduling.Pick(slots, job);
+            if (pick is null) return null;
+
+            var chosenKey = pick.Value.Id;   // WorkerSlot.Id is the unique routing key set above
+            _inFlight[chosenKey]++;
+            return new WorkerLease(chosenKey, _byKey[chosenKey]);
+        }
+    }
+}

--- a/Controller/Workers/WorkerRegistry.cs
+++ b/Controller/Workers/WorkerRegistry.cs
@@ -1,0 +1,94 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using WhisperSubs.Configuration;
+using WhisperSubs.Providers;
+using Microsoft.Extensions.Logging;
+
+namespace WhisperSubs.Controller.Workers
+{
+    /// <summary>
+    /// Builds the transcription worker pool from config (v4.0), backward-compatible via
+    /// <see cref="WorkerPlan"/>: no config → one local worker (identical to today); a legacy single
+    /// <c>RemoteWhisperApiUrl</c> → one remote worker (remote-only); an explicit <c>Workers</c> list →
+    /// those + optionally the local host. Excluded from coverage — it news up providers from config, the
+    /// same rationale as <see cref="SubtitleProviderFactory"/>. The composition decision (WorkerPlan) and
+    /// the routing (WorkerScheduling) are the tested, pure parts.
+    /// </summary>
+    [ExcludeFromCodeCoverage(Justification = "Orchestration: constructs providers from config, like SubtitleProviderFactory")]
+    public static class WorkerRegistry
+    {
+        public static IReadOnlyList<ITranscriptionWorker> BuildWorkers(PluginConfiguration config, ILoggerFactory loggerFactory)
+        {
+            var workers = new List<ITranscriptionWorker>();
+            var plan = WorkerPlan.Decide(
+                config.Workers?.Count ?? 0,
+                !string.IsNullOrWhiteSpace(config.RemoteWhisperApiUrl),
+                config.EnableLocalWorker);
+
+            switch (plan.Source)
+            {
+                case WorkerSource.ExplicitList:
+                    // ExplicitList is only returned by WorkerPlan.Decide when Workers.Count > 0, so it is non-null here.
+                    foreach (var w in config.Workers!.Where(x => x.Enabled && !string.IsNullOrWhiteSpace(x.ApiUrl)))
+                    {
+                        workers.Add(BuildRemote(
+                            id: string.IsNullOrWhiteSpace(w.Id) ? w.ApiUrl : w.Id,
+                            name: string.IsNullOrWhiteSpace(w.Name) ? w.ApiUrl : w.Name,
+                            url: w.ApiUrl,
+                            key: w.ApiKey ?? string.Empty,
+                            model: string.IsNullOrWhiteSpace(w.Model) ? config.RemoteWhisperModel : w.Model,
+                            maxConcurrency: w.MaxConcurrency,
+                            costWeight: w.CostWeight,
+                            canTranslate: w.CanTranslate,
+                            config: config,
+                            loggerFactory: loggerFactory));
+                    }
+                    break;
+
+                case WorkerSource.LegacyRemote:
+                    // A pre-v4 single remote URL = the whole "remote" worker, remote-only.
+                    workers.Add(BuildRemote(
+                        id: "remote", name: "Remote",
+                        url: config.RemoteWhisperApiUrl,
+                        key: (config.RemoteWhisperApiKey ?? string.Empty).Trim(),
+                        model: config.RemoteWhisperModel,
+                        maxConcurrency: 1, costWeight: 0, canTranslate: true,
+                        config: config, loggerFactory: loggerFactory));
+                    break;
+            }
+
+            // Add the host's own local whisper unless the plan says otherwise. The fallback guarantees the
+            // pool is never empty (e.g. an explicit list of all-disabled/blank workers with local off).
+            if (plan.AddLocal || workers.Count == 0)
+            {
+                workers.Add(new TranscriptionWorker(
+                    "local", "Local (this server)",
+                    SubtitleProviderFactory.CreateLocal(config, loggerFactory),
+                    new WorkerCapabilities { IsLocal = true, CostWeight = 0, MaxConcurrency = 1, CanTranslate = true }));
+            }
+
+            return workers;
+        }
+
+        private static ITranscriptionWorker BuildRemote(
+            string id, string name, string url, string key, string model,
+            int maxConcurrency, double costWeight, bool canTranslate,
+            PluginConfiguration config, ILoggerFactory loggerFactory)
+        {
+            var resolvedModel = string.IsNullOrWhiteSpace(model) ? "Systran/faster-whisper-large-v3" : model.Trim();
+            var provider = new RemoteWhisperProvider(
+                loggerFactory.CreateLogger<RemoteWhisperProvider>(),
+                url, resolvedModel, key,
+                config.JobTimeoutRealtimeFactor, config.JobMinTimeoutSeconds, config.JobMaxTimeoutHours);
+
+            return new TranscriptionWorker(id, name, provider, new WorkerCapabilities
+            {
+                IsLocal = false,
+                CostWeight = costWeight,
+                MaxConcurrency = maxConcurrency < 1 ? 1 : maxConcurrency,
+                CanTranslate = canTranslate
+            });
+        }
+    }
+}

--- a/Controller/Workers/WorkerScheduling.cs
+++ b/Controller/Workers/WorkerScheduling.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+
+namespace WhisperSubs.Controller.Workers
+{
+    /// <summary>
+    /// Pure worker-selection policy (v4.0), mirroring the codebase's other unit-tested decision helpers
+    /// (<see cref="PriorityScheduling"/>). Given the highest-priority job already chosen by the queue, it
+    /// picks the cheapest capable worker with a free slot. "Prefer local, burst to a paid worker only when
+    /// every local one is saturated" falls out of the cost-weighted score — no special-casing, no backend
+    /// names in the logic.
+    /// </summary>
+    public static class WorkerScheduling
+    {
+        /// <summary>Hard constraints — can this worker serve this job right now?</summary>
+        public static bool CanServe(WorkerSlot s, JobRequirements job)
+            => s.Healthy
+               && s.InFlight < s.Capabilities.MaxConcurrency
+               && (!job.Translate || s.Capabilities.CanTranslate)
+               && (job.RequiredModel is null
+                   || s.Capabilities.Models.Count == 0            // empty = serves any model
+                   || s.Capabilities.Models.Contains(job.RequiredModel));
+
+        /// <summary>
+        /// Soft preference — lower is better. A local worker's <c>CostWeight</c> is 0, so its score is
+        /// dominated by load and it always beats any paid worker; a paid worker (CostWeight &gt; 0) is only
+        /// ever the minimum when no local worker can serve the job.
+        /// </summary>
+        public static double Score(WorkerSlot s)
+            => s.Capabilities.CostWeight * 1_000_000.0   // 0 for local ⇒ strictly beats any paid worker
+               + s.InFlight * 1000.0                     // spread load: prefer the least-busy
+               + s.Capabilities.Priority;                // stable, admin-tunable tiebreak
+
+        /// <summary>
+        /// The best worker for a job: the minimum-<see cref="Score"/> worker that <see cref="CanServe"/>s it,
+        /// ties broken by ordinal Id for determinism. Null means nothing is feasible right now — the caller
+        /// re-queues the job (never fails it).
+        /// </summary>
+        public static WorkerSlot? Pick(IReadOnlyList<WorkerSlot> slots, JobRequirements job)
+        {
+            WorkerSlot? best = null;
+            double bestScore = double.MaxValue;
+            foreach (var s in slots)
+            {
+                if (!CanServe(s, job)) continue;
+                var score = Score(s);
+                bool better = best is null
+                    || score < bestScore
+                    || (score == bestScore && string.CompareOrdinal(s.Id, best.Value.Id) < 0);
+                if (better)
+                {
+                    best = s;
+                    bestScore = score;
+                }
+            }
+            return best;
+        }
+    }
+}

--- a/Providers/SubtitleProviderFactory.cs
+++ b/Providers/SubtitleProviderFactory.cs
@@ -26,6 +26,17 @@ namespace WhisperSubs.Providers
                     config.JobMaxTimeoutHours);
             }
 
+            return CreateLocal(config, loggerFactory);
+        }
+
+        /// <summary>
+        /// Builds the host's local in-process whisper-cli provider (VAD + detection-model resolution).
+        /// Extracted from <see cref="Create"/> so the v4.0 worker pool can construct the local worker
+        /// directly, without the remote-vs-local switch.
+        /// </summary>
+        [ExcludeFromCodeCoverage(Justification = "Orchestration: news up WhisperProvider + WhisperSetupService, File.Exists, TryAcquire — same rationale as Create.")]
+        public static ISubtitleProvider CreateLocal(PluginConfiguration config, ILoggerFactory loggerFactory)
+        {
             var setup = new WhisperSetupService(
                 loggerFactory.CreateLogger<WhisperSetupService>(),
                 Plugin.Instance?.DataFolderPath ?? "");

--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ docker exec jellyfin /opt/whisper/whisper-cli --help
 
 whisper.cpp supports GPU offloading via **Vulkan** (Intel, AMD, and some NVIDIA GPUs), **CUDA** (NVIDIA), and **ROCm** (AMD). GPU acceleration dramatically reduces transcription time, especially with larger models.
 
+> **Offloading to another machine?** You can run transcription on a separate host as an OpenAI-compatible worker and point the plugin at it over HTTP — see [`worker/`](worker/README.md) for a ready-to-run whisper.cpp + Vulkan worker image (plus notes for CPU/NVIDIA/AMD backends).
+
 > **Docker users:** Passing the GPU device (e.g., `/dev/dri`) to a container is **not enough** -- the container also needs the matching userspace libraries installed. The auto-setup wizard detects both the device and the library and will fall back to CPU if the library is missing.
 >
 > | Backend | Device | Required library | Install command (Debian/Ubuntu) |

--- a/ScheduledTasks/SubtitleGenerationTask.cs
+++ b/ScheduledTasks/SubtitleGenerationTask.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using WhisperSubs.Controller;
+using WhisperSubs.Controller.Workers;
 using WhisperSubs.Providers;
 using Jellyfin.Data.Enums;
 using MediaBrowser.Controller.Entities;
@@ -78,17 +79,40 @@ namespace WhisperSubs.ScheduledTasks
                 return;
             }
 
-            var manager = new SubtitleManager(_libraryManager, _loggerFactory.CreateLogger<SubtitleManager>());
-            var provider = SubtitleProviderFactory.Create(config, _loggerFactory);
-            var language = config.DefaultLanguage;
             var queue = SubtitleQueueService.Instance;
+
+            // Mark the task running up front so the shared worker pool isn't rebuilt underneath it (v4.0),
+            // then run the generation inside a try/finally that ALWAYS clears the flag — even if setup
+            // (GetPool, library enumeration, the restored-items drain) throws before the main loop — so a
+            // stuck flag never freezes the pool-rebuild gate or the queue UI. ReportTaskComplete is idempotent.
+            queue.MarkTaskStarted();
+            try
+            {
+                await RunGenerationAsync(config, queue, progress, cancellationToken);
+            }
+            finally
+            {
+                queue.ReportTaskComplete();
+            }
+        }
+
+        private async Task RunGenerationAsync(
+            Configuration.PluginConfiguration config,
+            SubtitleQueueService queue,
+            IProgress<double> progress,
+            CancellationToken cancellationToken)
+        {
+            var manager = new SubtitleManager(_libraryManager, _loggerFactory.CreateLogger<SubtitleManager>());
+            var language = config.DefaultLanguage;
+            var pool = queue.GetPool(config, _loggerFactory, forTask: true);
+            var requirements = WorkerJob.Requirements(config.SubtitleMode, config.EnableTranslation);
 
             // Restore persisted queue from disk (survives restarts)
             var restored = queue.RestoreQueue(_libraryManager, _logger);
             if (restored > 0)
             {
                 _logger.LogInformation("Draining {Count} restored priority items before auto-generation", restored);
-                await queue.DrainPriorityAsync(manager, provider, _logger, cancellationToken);
+                await queue.DrainPriorityAsync(manager, pool, requirements, _logger, cancellationToken);
             }
 
             // Collect items — the query is fast (DB lookup), no bulk in-memory storage needed
@@ -196,7 +220,7 @@ namespace WhisperSubs.ScheduledTasks
                 if (queue.PriorityCount > 0)
                 {
                     _logger.LogInformation("Pausing auto-generation to process {Count} priority request(s)", queue.PriorityCount);
-                    await queue.DrainPriorityAsync(manager, provider, _logger, cancellationToken);
+                    await queue.DrainPriorityAsync(manager, pool, requirements, _logger, cancellationToken);
                 }
 
                 var (item, libName) = allItems[i];
@@ -369,21 +393,32 @@ namespace WhisperSubs.ScheduledTasks
                     queue.ResetFileProgress();
                     queue.ReportTaskProgress(item.Name, completed, allItems.Count, failed, itemType, libName);
 
-                    await SubtitleQueueService.TranscriptionLock.WaitAsync(cancellationToken);
+                    // No worker can serve this job's requirements (e.g. translation enabled but every
+                    // configured worker is transcribe-only) — surface it via the same failure path below.
+                    if (!pool.HasCapableWorker(requirements))
+                    {
+                        throw new InvalidOperationException("No configured worker can serve this job");
+                    }
+
+                    // Acquire a slot on the shared worker pool (the global concurrency gate that replaced the
+                    // old TranscriptionLock) and run this swept item on the chosen worker. With the default
+                    // one local worker this serialises exactly like the old lock; with N workers the sweep
+                    // shares the pool with the background dispatcher up to ΣMaxConcurrency.
+                    var lease = await pool.AcquireAsync(requirements, cancellationToken);
                     try
                     {
                         if (config.PauseOnPlayback)
                         {
-                            await TranscribeWithPlaybackMonitorAsync(manager, item, provider, language, cancellationToken);
+                            await TranscribeWithPlaybackMonitorAsync(manager, item, lease.Worker.Provider, language, cancellationToken);
                         }
                         else
                         {
-                            await manager.GenerateSubtitleAsync(item, provider, language, cancellationToken);
+                            await manager.GenerateSubtitleAsync(item, lease.Worker.Provider, language, cancellationToken);
                         }
                     }
                     finally
                     {
-                        SubtitleQueueService.TranscriptionLock.Release();
+                        pool.Release(lease.Key);
                     }
                 }
                 catch (OperationCanceledException)
@@ -411,6 +446,7 @@ namespace WhisperSubs.ScheduledTasks
                 // Persist even on cancellation / pause-timeout so the run keeps the progress it made.
                 // Prune to the enumerated candidate set (not the reached set) so items not yet visited
                 // this run keep their prior entry — the reason per-item state beats a global watermark.
+                // (The task-running flag is cleared by ExecuteAsync's outer finally.)
                 if (skipCache != null)
                 {
                     skipCache.PruneTo(candidateIds);

--- a/ScheduledTasks/SubtitleGenerationTask.cs
+++ b/ScheduledTasks/SubtitleGenerationTask.cs
@@ -405,6 +405,7 @@ namespace WhisperSubs.ScheduledTasks
                     // one local worker this serialises exactly like the old lock; with N workers the sweep
                     // shares the pool with the background dispatcher up to ΣMaxConcurrency.
                     var lease = await pool.AcquireAsync(requirements, cancellationToken);
+                    pool.SetCurrent(lease.Key, item.Name);   // "what's running where" — surfaced in the status panel
                     try
                     {
                         if (config.PauseOnPlayback)
@@ -418,7 +419,7 @@ namespace WhisperSubs.ScheduledTasks
                     }
                     finally
                     {
-                        pool.Release(lease.Key);
+                        pool.Release(lease.Key, item.Name);
                     }
                 }
                 catch (OperationCanceledException)

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -420,6 +420,35 @@
                         </div>
                     </details>
 
+                    <!-- Worker Pool (Optional / Advanced) - simple by default, power-user opt-in (v4.0) -->
+                    <details style="margin-top:1.5em;">
+                        <summary style="cursor:pointer; font-size:1.2em; font-weight:bold; padding:0.5em 0;">Worker Pool (Optional / Advanced)</summary>
+
+                        <div class="fieldDescription" style="margin-bottom:0.75em;">
+                            Leave this empty to transcribe on this server (the default). Add remote
+                            OpenAI-compatible Whisper endpoints to spread the backlog across machines/GPUs
+                            &mdash; see the <code>worker/</code> image in the repo.
+                        </div>
+
+                        <div class="checkboxContainer checkboxContainer-withDescription">
+                            <label>
+                                <input is="emby-checkbox" type="checkbox" id="chkEnableLocalWorker" name="EnableLocalWorker" />
+                                <span>Also use this server as a worker</span>
+                            </label>
+                            <div class="fieldDescription">
+                                Keep this server's own whisper-cli in the pool. Only matters once you add
+                                remote workers below &mdash; with none, this server always does the work.
+                                <strong>On by default.</strong>
+                            </div>
+                        </div>
+
+                        <div id="workerRows"></div>
+
+                        <button is="emby-button" type="button" id="btnAddWorker" class="raised block" style="max-width:220px; margin-top:0.5em;">
+                            <span>+ Add worker</span>
+                        </button>
+                    </details>
+
                     <details style="margin-top:1.5em;">
                         <summary style="cursor:pointer; font-size:1.2em; font-weight:bold; padding:0.5em 0;">Advanced / Manual Install</summary>
 
@@ -595,6 +624,8 @@
                         <div id="transcriptionCurrentItem" class="fieldDescription" style="margin:0; flex:1; min-width:0; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;"></div>
                         <div id="transcriptionStats" class="fieldDescription" style="margin:0; white-space:nowrap; text-align:right;"></div>
                     </div>
+                    <div id="transcriptionPending" class="fieldDescription" style="margin:0.6em 0 0; white-space:normal;"></div>
+                    <div id="transcriptionWorkers" class="fieldDescription" style="margin:0.4em 0 0; white-space:normal; line-height:1.5;"></div>
                 </div>
                 <style>@keyframes wsQueueSpin{to{transform:rotate(360deg)}}</style>
 
@@ -1333,6 +1364,9 @@
                             page.querySelector('#numUserRequestActiveCap').value = (config.UserRequestActiveCap != null && config.UserRequestActiveCap >= 0) ? config.UserRequestActiveCap : 3;
                             page.querySelector('#numUserRequestMaxItemsPerRequest').value = (config.UserRequestMaxItemsPerRequest != null && config.UserRequestMaxItemsPerRequest >= 1) ? config.UserRequestMaxItemsPerRequest : 200;
                             page.querySelector('#numUserRequestGlobalCap').value = (config.UserRequestGlobalCap != null && config.UserRequestGlobalCap >= 0) ? config.UserRequestGlobalCap : 500;
+                            // Worker pool (v4.0). Absent/null Workers on older configs -> render nothing.
+                            page.querySelector('#chkEnableLocalWorker').checked = config.EnableLocalWorker !== false;
+                            WhisperSubsConfig.renderWorkers(config.Workers || []);
                             updateTranslationVisibility();
                         }
                             WhisperSubsConfig.loadLibraries();
@@ -1399,6 +1433,10 @@
                         config.UserRequestActiveCap = reqIntField('#numUserRequestActiveCap', 3, 0);
                         config.UserRequestMaxItemsPerRequest = reqIntField('#numUserRequestMaxItemsPerRequest', 200, 1);
                         config.UserRequestGlobalCap = reqIntField('#numUserRequestGlobalCap', 500, 0);
+
+                        // Worker pool (v4.0). Fully-blank rows are dropped; numbers are coerced.
+                        config.EnableLocalWorker = page.querySelector('#chkEnableLocalWorker').checked;
+                        config.Workers = WhisperSubsConfig.collectWorkers(page);
 
                         // Collect enabled libraries from checkboxes
                         var libraryCheckboxes = page.querySelectorAll('.chkLibrary');
@@ -1513,6 +1551,227 @@
                         if (action === 'Approve') WhisperSubsConfig.startQueuePolling();
                     }).catch(function () {
                         Dashboard.alert('Could not ' + action.toLowerCase() + ' the request.');
+                    });
+                },
+
+                // Worker pool (v4.0). Rows are built entirely in JS (mirrors the user-requests /
+                // library-selector panels): every server-provided string is rendered via
+                // textContent and input values are set as properties (never parsed as HTML), so
+                // it stays XSS-safe. No dynamic emby-select here (Model is a plain text input), so
+                // there is no pageshow-repopulate concern.
+                _workerSeq: 0,
+
+                genWorkerId: function () {
+                    return 'w' + Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+                },
+
+                renderWorkers: function (workers) {
+                    var container = document.querySelector('#workerRows');
+                    if (!container) return;
+                    container.innerHTML = '';
+                    if (workers && Array.isArray(workers)) {
+                        workers.forEach(function (w) {
+                            container.appendChild(WhisperSubsConfig.buildWorkerRow(w));
+                        });
+                    }
+                },
+
+                addWorkerRow: function () {
+                    var container = document.querySelector('#workerRows');
+                    if (!container) return;
+                    container.appendChild(WhisperSubsConfig.buildWorkerRow(null));
+                },
+
+                buildWorkerRow: function (w) {
+                    w = w || {};
+                    var row = document.createElement('div');
+                    row.className = 'workerRow';
+                    row.style.background = 'rgba(0,0,0,0.15)';
+                    row.style.borderRadius = '6px';
+                    row.style.padding = '1em';
+                    row.style.marginBottom = '1em';
+                    // Keep the stable Id (survives a rename); generate a short one for a new row.
+                    row.setAttribute('data-worker-id', w.Id || WhisperSubsConfig.genWorkerId());
+
+                    row.appendChild(WhisperSubsConfig._workerField(
+                        'Name', 'text', 'wkName', { placeholder: 'e.g. GPU box', maxlength: '128' },
+                        w.Name || '', 'A label to recognise this worker. Optional.'));
+                    row.appendChild(WhisperSubsConfig._workerField(
+                        'Endpoint URL', 'text', 'wkUrl', { placeholder: 'http://host:port' },
+                        w.ApiUrl || '', 'Base URL of an OpenAI-compatible Whisper server. No /v1 suffix.'));
+                    row.appendChild(WhisperSubsConfig._workerField(
+                        'API key (optional)', 'password', 'wkKey',
+                        { autocomplete: 'new-password', maxlength: '256', spellcheck: 'false' },
+                        w.ApiKey || '', 'Bearer token, if the server needs one. Leave blank for unauthenticated local servers.'));
+                    row.appendChild(WhisperSubsConfig._workerField(
+                        'Model (optional)', 'text', 'wkModel', { placeholder: 'server default', maxlength: '256' },
+                        w.Model || '', 'Model to request. Blank uses the worker default.'));
+                    row.appendChild(WhisperSubsConfig._workerField(
+                        'Max concurrency', 'number', 'wkConcurrency', { min: '1', max: '64', step: '1', placeholder: '1' },
+                        (w.MaxConcurrency != null && w.MaxConcurrency >= 1) ? w.MaxConcurrency : '',
+                        'How many files this worker transcribes at once. Default 1.'));
+                    row.appendChild(WhisperSubsConfig._workerField(
+                        'Cost weight', 'number', 'wkCost', { min: '0', step: '0.1', placeholder: '0' },
+                        (w.CostWeight != null && w.CostWeight >= 0) ? w.CostWeight : '',
+                        '0 = free/local, preferred; >0 = only used when local workers are busy.'));
+
+                    row.appendChild(WhisperSubsConfig._workerCheckbox('wkTranslate', 'Can translate to English', w.CanTranslate !== false));
+                    row.appendChild(WhisperSubsConfig._workerCheckbox('wkEnabled', 'Enabled', w.Enabled !== false));
+
+                    var btnBar = document.createElement('div');
+                    btnBar.style.display = 'flex';
+                    btnBar.style.gap = '0.6em';
+                    btnBar.style.alignItems = 'center';
+                    btnBar.style.flexWrap = 'wrap';
+                    btnBar.style.marginTop = '0.4em';
+
+                    var testBtn = document.createElement('button');
+                    testBtn.setAttribute('is', 'emby-button');
+                    testBtn.type = 'button';
+                    testBtn.className = 'raised';
+                    testBtn.innerHTML = '<span>Test</span>';
+                    testBtn.addEventListener('click', function () { WhisperSubsConfig.testWorker(row, testBtn); });
+                    btnBar.appendChild(testBtn);
+
+                    var removeBtn = document.createElement('button');
+                    removeBtn.setAttribute('is', 'emby-button');
+                    removeBtn.type = 'button';
+                    removeBtn.className = 'raised';
+                    removeBtn.innerHTML = '<span>Remove</span>';
+                    removeBtn.addEventListener('click', function () {
+                        if (row.parentNode) row.parentNode.removeChild(row);
+                    });
+                    btnBar.appendChild(removeBtn);
+
+                    var testResult = document.createElement('span');
+                    testResult.className = 'wkTestResult fieldDescription';
+                    testResult.style.margin = '0';
+                    btnBar.appendChild(testResult);
+
+                    row.appendChild(btnBar);
+                    return row;
+                },
+
+                // Builds one labelled input inside an .inputContainer (the file's standard field
+                // markup). Unique id/for so the emby floating label associates correctly.
+                _workerField: function (labelText, type, cls, attrs, value, descText) {
+                    var id = 'wk_' + (++WhisperSubsConfig._workerSeq);
+                    var container = document.createElement('div');
+                    container.className = 'inputContainer';
+                    var label = document.createElement('label');
+                    label.className = 'inputLabel inputLabelUnfocused';
+                    label.setAttribute('for', id);
+                    label.textContent = labelText;
+                    container.appendChild(label);
+                    var input = document.createElement('input');
+                    input.id = id;
+                    input.type = type;
+                    input.className = 'emby-input ' + cls;
+                    if (attrs) {
+                        Object.keys(attrs).forEach(function (k) { input.setAttribute(k, attrs[k]); });
+                    }
+                    input.value = (value != null) ? value : '';
+                    container.appendChild(input);
+                    if (descText) {
+                        var desc = document.createElement('div');
+                        desc.className = 'fieldDescription';
+                        desc.textContent = descText;
+                        container.appendChild(desc);
+                    }
+                    return container;
+                },
+
+                _workerCheckbox: function (cls, labelText, checked) {
+                    var container = document.createElement('div');
+                    container.className = 'checkboxContainer';
+                    container.style.padding = '0.2em 0';
+                    var label = document.createElement('label');
+                    var checkbox = document.createElement('input');
+                    checkbox.setAttribute('is', 'emby-checkbox');
+                    checkbox.type = 'checkbox';
+                    checkbox.className = cls;
+                    checkbox.checked = !!checked;
+                    label.appendChild(checkbox);
+                    var span = document.createElement('span');
+                    span.textContent = labelText;
+                    label.appendChild(span);
+                    container.appendChild(label);
+                    return container;
+                },
+
+                // Reads every row into config.Workers, skipping rows the user never filled in and
+                // coercing MaxConcurrency/CostWeight to numbers.
+                collectWorkers: function (page) {
+                    var rows = page.querySelectorAll('.workerRow');
+                    var workers = [];
+                    rows.forEach(function (row) {
+                        var name = (row.querySelector('.wkName').value || '').trim();
+                        var url = (row.querySelector('.wkUrl').value || '').trim();
+                        var key = (row.querySelector('.wkKey').value || '').trim();
+                        var model = (row.querySelector('.wkModel').value || '').trim();
+                        var concRaw = (row.querySelector('.wkConcurrency').value || '').trim();
+                        var costRaw = (row.querySelector('.wkCost').value || '').trim();
+                        var canTranslate = row.querySelector('.wkTranslate').checked;
+                        var enabled = row.querySelector('.wkEnabled').checked;
+
+                        // Skip a row the user never filled in (all text/number fields blank).
+                        if (!name && !url && !key && !model && concRaw === '' && costRaw === '') {
+                            return;
+                        }
+
+                        var conc = parseInt(concRaw, 10);
+                        if (isNaN(conc) || conc < 1) conc = 1;
+                        var cost = parseFloat(costRaw);
+                        if (isNaN(cost) || cost < 0) cost = 0;
+
+                        workers.push({
+                            Id: row.getAttribute('data-worker-id') || WhisperSubsConfig.genWorkerId(),
+                            Name: name,
+                            Enabled: enabled,
+                            ApiUrl: url,
+                            ApiKey: key,
+                            Model: model,
+                            MaxConcurrency: conc,
+                            CostWeight: cost,
+                            CanTranslate: canTranslate
+                        });
+                    });
+                    return workers;
+                },
+
+                // Probes one row's endpoint via POST Workers/TestConnection; shows the server's
+                // message inline (green when ok, red otherwise) via textContent.
+                testWorker: function (row, btn) {
+                    var result = row.querySelector('.wkTestResult');
+                    var url = (row.querySelector('.wkUrl').value || '').trim();
+                    var key = (row.querySelector('.wkKey').value || '').trim();
+                    var model = (row.querySelector('.wkModel').value || '').trim();
+                    if (!url) {
+                        if (result) { result.textContent = 'Enter an endpoint URL first.'; result.style.color = '#CC7B19'; }
+                        return;
+                    }
+                    if (btn) { btn.disabled = true; }
+                    if (result) { result.textContent = 'Testing…'; result.style.color = ''; }
+                    ApiClient.ajax({
+                        type: 'POST',
+                        url: ApiClient.getUrl('Plugins/WhisperSubs/Workers/TestConnection'),
+                        data: JSON.stringify({ apiUrl: url, apiKey: key, model: model }),
+                        contentType: 'application/json',
+                        dataType: 'json'
+                    }).then(function (response) {
+                        var r = typeof response === 'string' ? JSON.parse(response) : response;
+                        if (result) {
+                            // Server-provided message rendered via textContent (never innerHTML).
+                            result.textContent = (r && r.message) ? r.message : ((r && r.ok) ? 'OK' : 'Failed');
+                            result.style.color = (r && r.ok) ? '#52B54B' : '#CC3333';
+                        }
+                    }).catch(function (err) {
+                        if (result) {
+                            result.textContent = 'Test failed: ' + (err && err.message ? err.message : err);
+                            result.style.color = '#CC3333';
+                        }
+                    }).then(function () {
+                        if (btn) { btn.disabled = false; }
                     });
                 },
 
@@ -1692,9 +1951,13 @@
                             var stats = document.querySelector('#transcriptionStats');
                             var current = document.querySelector('#transcriptionCurrentItem');
                             var spinner = document.querySelector('#transcriptionSpinner');
+                            var pendingEl = document.querySelector('#transcriptionPending');
+                            var workersEl = document.querySelector('#transcriptionWorkers');
 
                             // ── Idle: hide or show "Finished" briefly ──
                             if (!q.isProcessing && q.remaining === 0) {
+                                if (pendingEl) pendingEl.textContent = '';
+                                if (workersEl) workersEl.textContent = '';
                                 if (banner.style.display !== 'none' && q.processed > 0) {
                                     var hadFailure = q.failed > 0;
                                     spinner.style.animation = 'none';
@@ -1781,6 +2044,45 @@
                             if (total > 0) parts.push(q.processed.toLocaleString() + ' of ' + total.toLocaleString() + ' items');
                             if (q.failed > 0) parts.push(q.failed + ' failed');
                             stats.textContent = parts.join(' \u00b7 ');
+
+                            // Inbound: the waiting queue (v4.0). Item names are server data, so the
+                            // whole line is assigned via textContent (never innerHTML) \u2014 XSS-safe.
+                            if (pendingEl) {
+                                var pend = Array.isArray(q.pending) ? q.pending : [];
+                                if (pend.length > 0) {
+                                    var pieces = pend.map(function (p) {
+                                        return (p.name || '') + (p.tier ? ' [' + p.tier + ']' : '');
+                                    });
+                                    var waitingTotal = (q.remaining != null) ? q.remaining : pend.length;
+                                    var pendingLine = 'Waiting (' + waitingTotal + '): ' + pieces.join(' \u00b7 ');
+                                    if (q.remaining != null && q.remaining > pend.length) {
+                                        pendingLine += '  (+' + (q.remaining - pend.length) + ' more)';
+                                    }
+                                    pendingEl.textContent = pendingLine;
+                                } else {
+                                    pendingEl.textContent = '';
+                                }
+                            }
+
+                            // Outbound: what's running where (v4.0). One line per worker; only shown
+                            // when a live pool exists, so single-server installs stay clean.
+                            if (workersEl) {
+                                var wks = Array.isArray(q.workers) ? q.workers : [];
+                                workersEl.textContent = '';
+                                if (wks.length > 0) {
+                                    wks.forEach(function (wk) {
+                                        var inF = (wk.inFlight != null) ? wk.inFlight : 0;
+                                        var maxC = (wk.maxConcurrency != null) ? wk.maxConcurrency : 1;
+                                        var cur = Array.isArray(wk.current) ? wk.current : [];
+                                        var running = cur.length > 0 ? cur.join(', ') : 'idle';
+                                        var lineEl = document.createElement('div');
+                                        lineEl.textContent = (wk.name || wk.id || 'worker') +
+                                            ' (' + inF + '/' + maxC + ')' +
+                                            (wk.isLocal ? ' (local)' : '') + ': ' + running;
+                                        workersEl.appendChild(lineEl);
+                                    });
+                                }
+                            }
                         })
                         .catch(function () { /* ignore transient errors */ });
                 },
@@ -1811,6 +2113,10 @@
                     resetBar.style.width = '0%';
                     resetBar.style.background = '#52B54B';
                     document.querySelector('#transcriptionProgressPct').textContent = '';
+                    var rbPending = document.querySelector('#transcriptionPending');
+                    if (rbPending) rbPending.textContent = '';
+                    var rbWorkers = document.querySelector('#transcriptionWorkers');
+                    if (rbWorkers) rbWorkers.textContent = '';
                 },
 
                 generateSubtitle: function (itemId, itemName, itemType) {
@@ -1918,6 +2224,10 @@
 
             document.querySelector('#btnRefreshRequests').addEventListener('click', function () {
                 WhisperSubsConfig.loadRequests();
+            });
+
+            document.querySelector('#btnAddWorker').addEventListener('click', function () {
+                WhisperSubsConfig.addWorkerRow();
             });
 
             document.querySelector('#btnEngineDownloadModel').addEventListener('click', function () {

--- a/WhisperSubs.Tests/ConfigurationTests.cs
+++ b/WhisperSubs.Tests/ConfigurationTests.cs
@@ -18,6 +18,26 @@ public class ConfigurationTests
     }
 
     [Fact]
+    public void WorkerPoolDefaults_AreSimpleAndEmpty()
+    {
+        // Simple by default: no extra workers + local worker on ⇒ today's single-server behaviour (v4.0).
+        var config = new PluginConfiguration();
+        Assert.NotNull(config.Workers);
+        Assert.Empty(config.Workers);
+        Assert.True(config.EnableLocalWorker);
+    }
+
+    [Fact]
+    public void WhisperWorker_Defaults()
+    {
+        var w = new WhisperWorker();
+        Assert.True(w.Enabled);
+        Assert.Equal(1, w.MaxConcurrency);
+        Assert.Equal(0, w.CostWeight);
+        Assert.True(w.CanTranslate);
+    }
+
+    [Fact]
     public void RequestQueueDefaults_AreSafeAndOptIn()
     {
         var config = new PluginConfiguration();

--- a/WhisperSubs.Tests/PriorityLanesTests.cs
+++ b/WhisperSubs.Tests/PriorityLanesTests.cs
@@ -150,4 +150,43 @@ public class PriorityLanesTests
         Assert.Equal(0, lanes.Count);
         Assert.False(lanes.CountsByTier().ContainsKey(Medium)); // lane pruned
     }
+
+    // ── predicate dequeue (v4.0 dispatcher: skip a head job no free worker can serve) ──
+
+    [Fact]
+    public void TryDequeuePredicate_ReturnsHighestPriorityAcceptable()
+    {
+        var lanes = new PriorityLanes<string>();
+        lanes.Enqueue("c", Critical, "crit");
+        lanes.Enqueue("h", High, "high");
+        // Accept everything → same as the plain head (strongest tier).
+        Assert.True(lanes.TryDequeue(_ => true, out var v));
+        Assert.Equal("crit", v);
+    }
+
+    [Fact]
+    public void TryDequeuePredicate_SkipsRejectedHead_PreservesTierOrder()
+    {
+        var lanes = new PriorityLanes<string>();
+        lanes.Enqueue("c", Critical, "crit");   // rejected by the predicate
+        lanes.Enqueue("h1", High, "high1");
+        lanes.Enqueue("h2", High, "high2");
+        // Skip "crit" → the next acceptable is the FIFO head of the next-strongest lane.
+        Assert.True(lanes.TryDequeue(v => v != "crit", out var v1));
+        Assert.Equal("high1", v1);
+        // "crit" is still queued (only skipped, not removed).
+        Assert.True(lanes.ContainsKey("c"));
+        Assert.Equal(2, lanes.Count);
+    }
+
+    [Fact]
+    public void TryDequeuePredicate_FalseWhenNoneAcceptable()
+    {
+        var lanes = new PriorityLanes<string>();
+        lanes.Enqueue("a", Medium, "a");
+        lanes.Enqueue("b", Low, "b");
+        Assert.False(lanes.TryDequeue(_ => false, out var v));
+        Assert.Null(v);
+        Assert.Equal(2, lanes.Count); // nothing removed
+    }
 }

--- a/WhisperSubs.Tests/SubtitleQueueServiceTests.cs
+++ b/WhisperSubs.Tests/SubtitleQueueServiceTests.cs
@@ -98,12 +98,15 @@ public class SubtitleQueueServiceTests
     }
 
     [Fact]
-    public void TranscriptionLock_IsAvailable()
+    public void MarkTaskStarted_SetsRunning_And_ReportTaskComplete_Clears()
     {
-        Assert.NotNull(SubtitleQueueService.TranscriptionLock);
-        // Should be able to acquire and release
-        Assert.True(SubtitleQueueService.TranscriptionLock.Wait(0));
-        SubtitleQueueService.TranscriptionLock.Release();
+        var queue = SubtitleQueueService.Instance;
+        // The v4.0 pool-rebuild gate: MarkTaskStarted must set the task-running flag so GetPool won't
+        // rebuild underneath the scheduled task; ReportTaskComplete (run in the task's finally) clears it.
+        queue.MarkTaskStarted();
+        Assert.True(queue.IsTaskRunning);
+        queue.ReportTaskComplete();
+        Assert.False(queue.IsTaskRunning);
     }
 
     [Fact]

--- a/WhisperSubs.Tests/SyntheticAudioTests.cs
+++ b/WhisperSubs.Tests/SyntheticAudioTests.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Text;
+using WhisperSubs.Controller.Workers;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+/// <summary>
+/// v4.0 worker "Test connection": the tiny silent WAV must be a byte-correct 16 kHz mono s16le file so any
+/// OpenAI-compatible endpoint accepts it.
+/// </summary>
+public class SyntheticAudioTests
+{
+    [Fact]
+    public void SilentWav_HasCanonicalHeader_AndCorrectLength()
+    {
+        var wav = SyntheticAudio.SilentWav16kMono(100);   // 100 ms @ 16 kHz mono 16-bit = 1600 samples
+        Assert.Equal(44 + 3200, wav.Length);              // 44-byte header + 1600*2 data
+        Assert.Equal("RIFF", Encoding.ASCII.GetString(wav, 0, 4));
+        Assert.Equal("WAVE", Encoding.ASCII.GetString(wav, 8, 4));
+        Assert.Equal("fmt ", Encoding.ASCII.GetString(wav, 12, 4));
+        Assert.Equal("data", Encoding.ASCII.GetString(wav, 36, 4));
+        Assert.Equal(1, BitConverter.ToInt16(wav, 20));   // PCM
+        Assert.Equal(1, BitConverter.ToInt16(wav, 22));   // mono
+        Assert.Equal(16000, BitConverter.ToInt32(wav, 24));
+        Assert.Equal(16, BitConverter.ToInt16(wav, 34));  // 16-bit
+        Assert.Equal(3200, BitConverter.ToInt32(wav, 40));       // data chunk size
+        Assert.Equal(36 + 3200, BitConverter.ToInt32(wav, 4));   // RIFF chunk size
+    }
+
+    [Theory]
+    [InlineData(0, 10)]        // clamped up to 10 ms
+    [InlineData(5000, 2000)]   // clamped down to 2000 ms
+    public void SilentWav_ClampsDuration(int requestedMs, int effectiveMs)
+    {
+        var wav = SyntheticAudio.SilentWav16kMono(requestedMs);
+        Assert.Equal(44 + 16000 * effectiveMs / 1000 * 2, wav.Length);
+    }
+
+    [Fact]
+    public void SilentWav_DataIsAllSilence()
+    {
+        var wav = SyntheticAudio.SilentWav16kMono(50);
+        for (var i = 44; i < wav.Length; i++) Assert.Equal(0, wav[i]);
+    }
+}

--- a/WhisperSubs.Tests/WorkerConfigValidationTests.cs
+++ b/WhisperSubs.Tests/WorkerConfigValidationTests.cs
@@ -1,0 +1,52 @@
+using WhisperSubs.Configuration;
+using WhisperSubs.Controller.Workers;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+/// <summary>
+/// v4.0 config UI: pure validation of a worker row, so a malformed endpoint/concurrency/cost is rejected
+/// before it reaches the pool.
+/// </summary>
+public class WorkerConfigValidationTests
+{
+    private static WhisperWorker W(string url = "https://gpu.lan:8000", int max = 1, double cost = 0)
+        => new WhisperWorker { ApiUrl = url, MaxConcurrency = max, CostWeight = cost };
+
+    [Fact]
+    public void ValidHttpsWorker_Ok()
+    {
+        var (ok, err) = WorkerConfigValidation.Validate(W());
+        Assert.True(ok);
+        Assert.Null(err);
+    }
+
+    [Fact]
+    public void HttpUrl_Ok()
+        => Assert.True(WorkerConfigValidation.Validate(W(url: "http://192.168.10.110:8000")).Ok);
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void BlankUrl_Fails(string url)
+    {
+        var (ok, err) = WorkerConfigValidation.Validate(W(url: url));
+        Assert.False(ok);
+        Assert.NotNull(err);
+    }
+
+    [Theory]
+    [InlineData("not-a-url")]
+    [InlineData("ftp://host/x")]
+    [InlineData("/relative/path")]
+    public void NonHttpUrl_Fails(string url)
+        => Assert.False(WorkerConfigValidation.Validate(W(url: url)).Ok);
+
+    [Fact]
+    public void MaxConcurrencyBelowOne_Fails()
+        => Assert.False(WorkerConfigValidation.Validate(W(max: 0)).Ok);
+
+    [Fact]
+    public void NegativeCostWeight_Fails()
+        => Assert.False(WorkerConfigValidation.Validate(W(cost: -1)).Ok);
+}

--- a/WhisperSubs.Tests/WorkerJobTests.cs
+++ b/WhisperSubs.Tests/WorkerJobTests.cs
@@ -1,0 +1,39 @@
+using WhisperSubs.Configuration;
+using WhisperSubs.Controller.Workers;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+/// <summary>
+/// v4.0 dispatcher: the pure config→job-requirements mapping. Pins that "which jobs need a translate-capable
+/// worker" matches the scheduled task's own needsTranslation gate, so a translate pass never routes to a
+/// transcribe-only worker, and that the common (translation-off) case requires nothing special.
+/// </summary>
+public class WorkerJobTests
+{
+    [Theory]
+    [InlineData(SubtitleMode.TranslationOnly, false, true)]  // TranslationOnly always runs a translate pass
+    [InlineData(SubtitleMode.TranslationOnly, true, true)]
+    [InlineData(SubtitleMode.Full, true, true)]              // full pass + translation enabled
+    [InlineData(SubtitleMode.FullAndForced, true, true)]
+    [InlineData(SubtitleMode.Full, false, false)]            // translation off ⇒ no translate requirement
+    [InlineData(SubtitleMode.FullAndForced, false, false)]
+    [InlineData(SubtitleMode.ForcedOnly, true, false)]       // forced-only never runs a full/translate pass
+    [InlineData(SubtitleMode.ForcedOnly, false, false)]
+    public void TranslationPossible_MatchesTaskGate(SubtitleMode mode, bool enableTranslation, bool expected)
+    {
+        Assert.Equal(expected, WorkerJob.TranslationPossible(mode, enableTranslation));
+    }
+
+    [Fact]
+    public void Requirements_TranslateFollowsTranslationPossible_ModelAlwaysNull()
+    {
+        var needsTranslate = WorkerJob.Requirements(SubtitleMode.TranslationOnly, false);
+        Assert.True(needsTranslate.Translate);
+        Assert.Null(needsTranslate.RequiredModel);
+
+        var noTranslate = WorkerJob.Requirements(SubtitleMode.Full, false);
+        Assert.False(noTranslate.Translate);
+        Assert.Null(noTranslate.RequiredModel);
+    }
+}

--- a/WhisperSubs.Tests/WorkerPlanTests.cs
+++ b/WhisperSubs.Tests/WorkerPlanTests.cs
@@ -1,0 +1,42 @@
+using WhisperSubs.Controller.Workers;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+/// <summary>
+/// v4.0 worker pool backward-compatibility. The composition decision must keep a normal single-server
+/// install identical to today, and a legacy remote-offload install remote-only.
+/// </summary>
+public class WorkerPlanTests
+{
+    [Fact]
+    public void NoConfig_IsLocalOnly()
+    {
+        // The overwhelming common case: no workers, no remote URL ⇒ the host's own whisper, exactly as today.
+        var (source, addLocal) = WorkerPlan.Decide(explicitWorkerCount: 0, hasLegacyRemoteUrl: false, enableLocalWorker: true);
+        Assert.Equal(WorkerSource.LocalOnly, source);
+        Assert.True(addLocal);
+    }
+
+    [Fact]
+    public void LegacyRemoteUrl_IsRemoteOnly_NeverAddsLocal()
+    {
+        // Pre-v4, setting a remote URL sent ALL work remote and never touched the local whisper. Preserve
+        // that: even with EnableLocalWorker at its default true, a legacy remote install stays remote-only.
+        var (source, addLocal) = WorkerPlan.Decide(explicitWorkerCount: 0, hasLegacyRemoteUrl: true, enableLocalWorker: true);
+        Assert.Equal(WorkerSource.LegacyRemote, source);
+        Assert.False(addLocal);
+    }
+
+    [Fact]
+    public void ExplicitList_UsesList_PlusLocalWhenEnabled()
+    {
+        var withLocal = WorkerPlan.Decide(explicitWorkerCount: 2, hasLegacyRemoteUrl: false, enableLocalWorker: true);
+        Assert.Equal(WorkerSource.ExplicitList, withLocal.Source);
+        Assert.True(withLocal.AddLocal);
+
+        var withoutLocal = WorkerPlan.Decide(explicitWorkerCount: 2, hasLegacyRemoteUrl: true, enableLocalWorker: false);
+        Assert.Equal(WorkerSource.ExplicitList, withoutLocal.Source);   // explicit list wins even over a legacy URL
+        Assert.False(withoutLocal.AddLocal);
+    }
+}

--- a/WhisperSubs.Tests/WorkerPoolTests.cs
+++ b/WhisperSubs.Tests/WorkerPoolTests.cs
@@ -1,0 +1,133 @@
+using System.Threading;
+using System.Threading.Tasks;
+using WhisperSubs.Controller.Workers;
+using WhisperSubs.Providers;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+/// <summary>
+/// v4.0 dispatcher: the live worker pool that replaced the global TranscriptionLock. Pins the concurrency
+/// gate (ΣMaxConcurrency, one-slot serialisation at the default), cost-weighted local-first routing, the
+/// fail-fast capability check, and — the subtle one — that releasing by the lease key keeps accounting
+/// correct even when two workers collide on Id.
+/// </summary>
+public class WorkerPoolTests
+{
+    private sealed class FakeProvider : ISubtitleProvider
+    {
+        public string Name => "fake";
+        public bool UsesVad => false;
+        public Task<string> TranscribeAsync(string audioPath, string language, CancellationToken ct, bool translate = false)
+            => Task.FromResult(string.Empty);
+        public Task<(string Language, float Probability)> DetectLanguageAsync(string audioPath, CancellationToken ct)
+            => Task.FromResult(("en", 1f));
+    }
+
+    private static ITranscriptionWorker Worker(string id, int maxConcurrency = 1, double cost = 0, bool canTranslate = true)
+        => new TranscriptionWorker(id, id, new FakeProvider(), new WorkerCapabilities
+        {
+            MaxConcurrency = maxConcurrency,
+            CostWeight = cost,
+            CanTranslate = canTranslate,
+            IsLocal = cost == 0
+        });
+
+    private static readonly JobRequirements AnyJob = new(Translate: false, RequiredModel: null);
+
+    [Fact]
+    public void TotalCapacity_IsSumOfMaxConcurrency_AtLeastOne()
+    {
+        var pool = new WorkerPool(new[] { Worker("a", 1), Worker("b", 3) });
+        Assert.Equal(4, pool.TotalCapacity);
+        Assert.Equal(2, pool.WorkerCount);
+
+        // A worker with a nonsense concurrency still contributes at least one slot.
+        var floored = new WorkerPool(new[] { Worker("z", 0) });
+        Assert.Equal(1, floored.TotalCapacity);
+    }
+
+    [Fact]
+    public async Task SingleWorkerSingleSlot_SerialisesLikeTheOldLock()
+    {
+        var pool = new WorkerPool(new[] { Worker("local", 1) });
+
+        var first = await pool.AcquireAsync(AnyJob, default);
+        Assert.Equal(1, pool.ActiveJobs);
+
+        // The only slot is taken — a second acquire must block (not complete).
+        var second = pool.AcquireAsync(AnyJob, default);
+        Assert.False(second.IsCompleted);
+
+        pool.Release(first.Key);                    // frees the slot
+        var unblocked = await second;
+        Assert.Equal(1, pool.ActiveJobs);
+
+        pool.Release(unblocked.Key);
+        Assert.Equal(0, pool.ActiveJobs);
+    }
+
+    [Fact]
+    public async Task ConcurrentAcquires_UpToCapacity_ThenBlockUntilRelease()
+    {
+        var pool = new WorkerPool(new[] { Worker("a", 1), Worker("b", 1) }); // capacity 2
+        var a = await pool.AcquireAsync(AnyJob, default);
+        var b = await pool.AcquireAsync(AnyJob, default);
+        Assert.Equal(2, pool.ActiveJobs);
+
+        var third = pool.AcquireAsync(AnyJob, default);
+        Assert.False(third.IsCompleted);            // capacity reached ⇒ blocks
+
+        pool.Release(a.Key);
+        var c = await third;                         // a freed ⇒ unblocks
+        Assert.Equal(2, pool.ActiveJobs);
+
+        pool.Release(b.Key);
+        pool.Release(c.Key);
+        Assert.Equal(0, pool.ActiveJobs);
+    }
+
+    [Fact]
+    public async Task Acquire_PrefersLocalOverPaid_ByCostWeight()
+    {
+        var pool = new WorkerPool(new[] { Worker("cloud", 1, cost: 5), Worker("local", 1, cost: 0) });
+        var lease = await pool.AcquireAsync(AnyJob, default);
+        Assert.Equal("local", lease.Worker.Id);      // cost 0 strictly beats cost 5
+        pool.Release(lease.Key);
+    }
+
+    [Fact]
+    public void HasCapableWorker_FalseWhenTranslateNeededButNoneTranslate()
+    {
+        var pool = new WorkerPool(new[] { Worker("t", 1, canTranslate: false) });
+        Assert.False(pool.HasCapableWorker(new JobRequirements(Translate: true, RequiredModel: null)));
+        Assert.True(pool.HasCapableWorker(new JobRequirements(Translate: false, RequiredModel: null)));
+    }
+
+    [Fact]
+    public async Task AcquireAsync_ThrowsWhenNoCapableWorker_NeverSpins()
+    {
+        // Defense-in-depth (CodeRabbit): a transcribe-only pool asked for a translate job must fail fast
+        // with InvalidOperationException, not loop forever acquiring/releasing the slot.
+        var pool = new WorkerPool(new[] { Worker("t", 1, canTranslate: false) });
+        await Assert.ThrowsAsync<System.InvalidOperationException>(
+            () => pool.AcquireAsync(new JobRequirements(Translate: true, RequiredModel: null), default));
+    }
+
+    [Fact]
+    public async Task DuplicateWorkerIds_DoNotCollide_BothSlotsUsableAndReleasable()
+    {
+        // Two workers misconfigured with the SAME Id — the lease key must keep per-slot accounting distinct.
+        var pool = new WorkerPool(new[] { Worker("dup", 1), Worker("dup", 1) });
+        Assert.Equal(2, pool.TotalCapacity);
+
+        var a = await pool.AcquireAsync(AnyJob, default);
+        var b = await pool.AcquireAsync(AnyJob, default);
+        Assert.Equal(2, pool.ActiveJobs);            // both slots acquired despite the Id clash
+        Assert.NotEqual(a.Key, b.Key);               // distinct routing keys
+
+        pool.Release(a.Key);
+        pool.Release(b.Key);
+        Assert.Equal(0, pool.ActiveJobs);            // both released cleanly (would be 1 if released by Id)
+    }
+}

--- a/WhisperSubs.Tests/WorkerPoolTests.cs
+++ b/WhisperSubs.Tests/WorkerPoolTests.cs
@@ -115,6 +115,34 @@ public class WorkerPoolTests
     }
 
     [Fact]
+    public async Task Snapshot_ReflectsIdentityAndLiveLoad()
+    {
+        var pool = new WorkerPool(new[] { Worker("local", 2, cost: 0), Worker("cloud", 1, cost: 5) });
+
+        var idle = pool.Snapshot();
+        Assert.Equal(2, idle.Count);
+        var local = idle.Single(s => s.Id == "local");
+        Assert.Equal(2, local.MaxConcurrency);
+        Assert.True(local.IsLocal);
+        Assert.Equal(0, local.InFlight);
+        var cloud = idle.Single(s => s.Id == "cloud");
+        Assert.Equal(5, cloud.CostWeight);
+        Assert.False(cloud.IsLocal);
+
+        // Acquire one slot → the snapshot's InFlight reflects it (local is cheapest, so it's taken first).
+        var lease = await pool.AcquireAsync(AnyJob, default);
+        pool.SetCurrent(lease.Key, "The Movie S01E12");
+        var busy = pool.Snapshot().Single(s => s.Id == "local");
+        Assert.Equal(1, busy.InFlight);
+        Assert.Contains("The Movie S01E12", busy.CurrentItems);   // "what's running where"
+
+        pool.Release(lease.Key, "The Movie S01E12");
+        var freed = pool.Snapshot().Single(s => s.Id == "local");
+        Assert.Equal(0, freed.InFlight);
+        Assert.Empty(freed.CurrentItems);                          // cleared on release
+    }
+
+    [Fact]
     public async Task DuplicateWorkerIds_DoNotCollide_BothSlotsUsableAndReleasable()
     {
         // Two workers misconfigured with the SAME Id — the lease key must keep per-slot accounting distinct.

--- a/WhisperSubs.Tests/WorkerSchedulingTests.cs
+++ b/WhisperSubs.Tests/WorkerSchedulingTests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using WhisperSubs.Controller.Workers;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+/// <summary>
+/// v4.0 worker pool: the pure selection policy. Verifies the hard capability filter and the cost-weighted
+/// "prefer local, burst to paid only when locals are saturated" behaviour that must hold for any topology.
+/// </summary>
+public class WorkerSchedulingTests
+{
+    private static WorkerCapabilities Caps(bool local = true, double cost = 0, int maxConc = 1,
+        bool canTranslate = true, int priority = 0, string[]? models = null)
+        => new()
+        {
+            IsLocal = local, CostWeight = cost, MaxConcurrency = maxConc, CanTranslate = canTranslate,
+            Priority = priority, Models = new HashSet<string>(models ?? Array.Empty<string>())
+        };
+
+    private static WorkerSlot Slot(string id, bool healthy = true, int inFlight = 0, WorkerCapabilities? caps = null)
+        => new(id, healthy, inFlight, caps ?? Caps());
+
+    private static readonly JobRequirements AnyJob = new(false, null);
+
+    // ── CanServe (hard constraints) ──
+    [Fact] public void CanServe_HealthyFreeWorker_True()
+        => Assert.True(WorkerScheduling.CanServe(Slot("a"), AnyJob));
+
+    [Fact] public void CanServe_Unhealthy_False()
+        => Assert.False(WorkerScheduling.CanServe(Slot("a", healthy: false), AnyJob));
+
+    [Fact] public void CanServe_AtCapacity_False()
+        => Assert.False(WorkerScheduling.CanServe(Slot("a", inFlight: 1, caps: Caps(maxConc: 1)), AnyJob));
+
+    [Fact] public void CanServe_TranslateJob_NeedsTranslateCapability()
+    {
+        var job = new JobRequirements(true, null);
+        Assert.False(WorkerScheduling.CanServe(Slot("a", caps: Caps(canTranslate: false)), job));
+        Assert.True(WorkerScheduling.CanServe(Slot("b", caps: Caps(canTranslate: true)), job));
+    }
+
+    [Fact] public void CanServe_ModelConstraint()
+    {
+        var job = new JobRequirements(false, "large-v3");
+        Assert.True(WorkerScheduling.CanServe(Slot("any"), job));                                        // empty models = any
+        Assert.True(WorkerScheduling.CanServe(Slot("has", caps: Caps(models: new[] { "large-v3" })), job));
+        Assert.False(WorkerScheduling.CanServe(Slot("no", caps: Caps(models: new[] { "small" })), job));
+    }
+
+    // ── Pick (prefer local, burst to paid) ──
+    [Fact] public void Pick_PrefersLocalOverPaid()
+    {
+        var local = Slot("local", caps: Caps(local: true, cost: 0));
+        var cloud = Slot("cloud", caps: Caps(local: false, cost: 5));
+        Assert.Equal("local", WorkerScheduling.Pick(new[] { cloud, local }, AnyJob)!.Value.Id);
+    }
+
+    [Fact] public void Pick_BurstsToPaid_OnlyWhenLocalsSaturated()
+    {
+        var localFull = Slot("local", inFlight: 1, caps: Caps(local: true, cost: 0, maxConc: 1));
+        var cloud = Slot("cloud", caps: Caps(local: false, cost: 5));
+        Assert.Equal("cloud", WorkerScheduling.Pick(new[] { localFull, cloud }, AnyJob)!.Value.Id);
+    }
+
+    [Fact] public void Pick_PrefersLeastBusyAmongEqualCost()
+    {
+        var busy = Slot("busy", inFlight: 1, caps: Caps(cost: 0, maxConc: 3));
+        var idle = Slot("idle", inFlight: 0, caps: Caps(cost: 0, maxConc: 3));
+        Assert.Equal("idle", WorkerScheduling.Pick(new[] { busy, idle }, AnyJob)!.Value.Id);
+    }
+
+    [Fact] public void Pick_PriorityTiebreak()
+    {
+        var lo = Slot("x", caps: Caps(cost: 0, priority: 10));
+        var hi = Slot("y", caps: Caps(cost: 0, priority: 1));
+        Assert.Equal("y", WorkerScheduling.Pick(new[] { lo, hi }, AnyJob)!.Value.Id);
+    }
+
+    [Fact] public void Pick_DeterministicTiebreakById()
+    {
+        // Identical everything → lowest ordinal Id wins, deterministically.
+        Assert.Equal("a", WorkerScheduling.Pick(new[] { Slot("b"), Slot("a") }, AnyJob)!.Value.Id);
+    }
+
+    [Fact] public void Pick_NullWhenNothingFeasible()
+    {
+        var full = Slot("a", inFlight: 1, caps: Caps(maxConc: 1));
+        var down = Slot("b", healthy: false);
+        Assert.Null(WorkerScheduling.Pick(new[] { full, down }, AnyJob));
+        Assert.Null(WorkerScheduling.Pick(Array.Empty<WorkerSlot>(), AnyJob));
+    }
+}

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>3.29.0.0</Version>
+    <Version>4.0.0.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>

--- a/worker/.dockerignore
+++ b/worker/.dockerignore
@@ -1,0 +1,7 @@
+# Keep the build context minimal -- only the Dockerfile + adapter + entrypoint
+# are needed by the build. Everything else is docs/examples.
+README.md
+docker-compose.example.yml
+*.md
+.git
+.gitignore

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# whisper-subs worker image: whisper.cpp `whisper-server` (Vulkan, static) fronted
+# by a tiny stdlib-only Python adapter that speaks the plugin's OpenAI-audio dialect.
+#
+# Build (Intel/AMD iGPU via Vulkan, the shipped default):
+#   docker build -t drumsergio/whisper-subs-worker:0.1.0 worker/
+#
+# Other backends are a one-line flag change (see worker/README.md):
+#   CPU-only : --build-arg WHISPER_CMAKE_FLAGS="-DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON"
+#   +ffmpeg  : --build-arg INSTALL_FFMPEG=true      (accept non-WAV audio from other clients)
+# CUDA/ROCm need a different base image + runtime libs -- documented in the README.
+
+# Pin base images by explicit tag (never :latest). For fully reproducible CI builds,
+# replace with a digest pin, e.g. debian:trixie-slim@sha256:<digest>.
+ARG BUILD_IMAGE=debian:trixie-slim
+ARG RUNTIME_IMAGE=debian:trixie-slim
+
+# --------------------------------------------------------------------------- #
+# Stage 1: build whisper-server (static, Vulkan) from a pinned whisper.cpp tag
+# --------------------------------------------------------------------------- #
+FROM ${BUILD_IMAGE} AS build
+
+# Keep in lockstep with the plugin's pinned whisper.cpp (CLAUDE.md / build-release.yml).
+ARG WHISPER_VERSION=v1.8.4
+# Mirrors the plugin's `vulkan` CI matrix flags exactly.
+ARG WHISPER_CMAKE_FLAGS="-DGGML_VULKAN=ON -DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON -DGGML_BMI2=ON"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git cmake g++ make pkg-config ca-certificates \
+        libvulkan-dev glslc \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+RUN git clone --depth 1 --branch "${WHISPER_VERSION}" \
+        https://github.com/ggml-org/whisper.cpp.git .
+
+# -DBUILD_SHARED_LIBS=OFF is MANDATORY (static link; see plugin CLAUDE.md).
+# static libgcc/libstdc++ avoids GLIBCXX drift between build and runtime layers.
+RUN cmake -B build \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=OFF \
+        -DCMAKE_EXE_LINKER_FLAGS="-static-libgcc -static-libstdc++" \
+        ${WHISPER_CMAKE_FLAGS} \
+    && cmake --build build --config Release --target whisper-server -j"$(nproc)" \
+    && test -x build/bin/whisper-server
+
+# --------------------------------------------------------------------------- #
+# Stage 2: slim runtime
+# --------------------------------------------------------------------------- #
+FROM ${RUNTIME_IMAGE} AS runtime
+
+ARG INSTALL_FFMPEG=false
+
+# Runtime deps:
+#   python3        -> the adapter (standard library only)
+#   tini           -> PID 1, reaps the whisper-server child, forwards signals
+#   curl           -> Docker healthcheck + the model downloader
+#   ca-certificates-> HTTPS to Hugging Face for model download
+#   libvulkan1     -> Vulkan loader (dlopens the ICD driver)
+#   mesa-vulkan-drivers -> Intel (ANV) + AMD (RADV) Vulkan drivers + ICD JSONs
+#   libgomp1       -> OpenMP runtime used by the whisper.cpp CPU paths
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 tini curl ca-certificates \
+        libvulkan1 libgomp1 mesa-vulkan-drivers \
+    && if [ "$INSTALL_FFMPEG" = "true" ]; then \
+           apt-get install -y --no-install-recommends ffmpeg; \
+       fi \
+    && rm -rf /var/lib/apt/lists/*
+
+# Non-root user; own the model cache so a named volume is writable on first run.
+# (Debian base has no uid-1000 user; on an Ubuntu-based CUDA build, pick a free uid.)
+RUN useradd --uid 1000 --create-home --shell /usr/sbin/nologin whisper \
+    && mkdir -p /models /opt/whisper-adapter \
+    && chown -R whisper:whisper /models
+
+COPY --from=build /src/build/bin/whisper-server        /usr/local/bin/whisper-server
+COPY --from=build /src/models/download-ggml-model.sh   /usr/local/bin/download-ggml-model.sh
+COPY adapter.py     /opt/whisper-adapter/adapter.py
+COPY entrypoint.sh  /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/whisper-server \
+             /usr/local/bin/download-ggml-model.sh \
+             /usr/local/bin/entrypoint.sh
+
+ENV WHISPER_MODEL=large-v3-turbo-q5_0 \
+    WHISPER_MODEL_DIR=/models \
+    WHISPER_BIN=/usr/local/bin/whisper-server \
+    WHISPER_LANGUAGE=auto \
+    LISTEN_HOST=0.0.0.0 \
+    LISTEN_PORT=8080 \
+    WHISPER_BACKEND_HOST=127.0.0.1 \
+    WHISPER_BACKEND_PORT=8081 \
+    CONVERT=false
+
+EXPOSE 8080
+VOLUME ["/models"]
+
+USER whisper
+WORKDIR /opt/whisper-adapter
+
+# tini as PID 1 so the whisper-server grandchild is reaped and SIGTERM is forwarded.
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/entrypoint.sh"]

--- a/worker/README.md
+++ b/worker/README.md
@@ -1,0 +1,290 @@
+# WhisperSubs Worker Image
+
+An example, ready-to-run **OpenAI-compatible transcription worker** for the
+WhisperSubs remote worker pool. It wraps whisper.cpp's `whisper-server`
+([ggml-org/whisper.cpp](https://github.com/ggml-org/whisper.cpp), `examples/server`)
+built with **Vulkan** — so it GPU-accelerates on **Intel** and **AMD** integrated
+or discrete GPUs — behind a tiny standard-library Python adapter that speaks the
+exact HTTP dialect the plugin's `RemoteWhisperProvider` expects.
+
+You run one (or several) of these on any machine with a spare GPU, then point the
+plugin at each over HTTP. The plugin extracts audio and farms transcription out to
+the workers; all audio still stays inside your own network.
+
+> This is one **example** backend. Any server that implements the OpenAI
+> `/v1/audio/transcriptions` and `/v1/audio/translations` endpoints works — see
+> [Alternative backends](#alternative-backends) for CPU/NVIDIA options.
+
+---
+
+## What the plugin sends (the contract this image serves)
+
+`Providers/RemoteWhisperProvider.cs` posts `multipart/form-data`. The worker must
+serve exactly this:
+
+| Purpose | Method + path | Key form fields | Returns |
+|---|---|---|---|
+| Transcribe | `POST /v1/audio/transcriptions` | `file` (16 kHz mono WAV), `model`, `response_format=srt`, `language` (optional 2-letter; omitted for auto) | SRT text |
+| Detect language | `POST /v1/audio/transcriptions` | `file`, `model`, `response_format=verbose_json` (no `language`) | JSON containing a top-level `language` |
+| Translate → English | `POST /v1/audio/translations` | `file`, `model`, `response_format=srt`, `language` (optional source) | English SRT |
+
+Auth is an optional `Authorization: Bearer <key>`. The `file` is always a 16 kHz
+mono `s16le` WAV (the plugin extracts it with FFmpeg before sending).
+
+---
+
+## Design: why a thin adapter (and not `whisper-server` directly)
+
+`whisper-server` is **not** fully OpenAI-compatible, verified against
+whisper.cpp **v1.8.4** (`examples/server/server.cpp`):
+
+1. **One inference path, not two.** It registers a single inference route —
+   `--request-path` + `--inference-path`, default `/inference` — plus `/load` and
+   `/health`. It cannot serve both `/v1/audio/transcriptions` **and**
+   `/v1/audio/translations`; `--inference-path` can only point the one route at one
+   of them.
+2. **Translate is a form field, not a path.** Translation is selected by a
+   `translate=true` multipart field (`server.cpp` parses `translate`, `language`,
+   `response_format` from the form). The plugin instead selects it by **path**
+   (`/v1/audio/translations`), sending no `translate` field.
+3. **It defaults `language` to `"en"`.** A request with no `language` field would
+   force English and break both auto-transcription and the `verbose_json`
+   language-detection call.
+
+A pure reverse proxy (nginx/Caddy) can rewrite the path but **cannot inject a new
+multipart field** into a streamed request body, so it could never map the
+translations path to `translate=true`. Hence a minimal body-aware adapter:
+
+- routes `POST /v1/audio/transcriptions` → upstream `/inference` **verbatim**;
+- routes `POST /v1/audio/translations` → upstream `/inference` with a
+  `translate=true` part **prepended** to the multipart body — no reparse, the body
+  is **streamed** straight through so a 2-hour film (~260 MB WAV) is never buffered
+  in RAM (matters when several workers run at once);
+- launches `whisper-server` with `--language auto` so detection and auto-mode work
+  (`response_format=verbose_json` returns whisper's language name, which the plugin
+  maps to a 2-letter code);
+- adds optional Bearer auth and a cheap readiness probe;
+- supervises the `whisper-server` child and exits (so the container restarts) if it
+  dies.
+
+The adapter is ~300 lines of Python standard library — **no pip dependencies** —
+in [`adapter.py`](adapter.py). `response_format=srt` and `verbose_json` are both
+native to `whisper-server`, so no response rewriting is needed.
+
+> **One model per worker.** `whisper-server` serves a single model, fixed at
+> startup by `WHISPER_MODEL`. The plugin's per-worker **Model** field is sent but
+> ignored by this backend — choose the model on the worker.
+
+---
+
+## Quick start — Intel / AMD iGPU (Vulkan)
+
+```bash
+# from the repo root
+docker compose -f worker/docker-compose.example.yml up -d
+docker logs -f whisper-subs-worker      # first boot downloads the model
+```
+
+Then in Jellyfin: **Dashboard → Plugins → WhisperSubs → Workers**, add a worker:
+
+| Field | Value |
+|---|---|
+| **Endpoint** | `http://<worker-host>:9010` — base URL, **no** `/v1` suffix |
+| **API key** | only if you set `API_KEY` on the worker |
+| **Model** | informational (the worker's `WHISPER_MODEL` is authoritative) |
+| **Max concurrency** | **1** — one GPU processes ~one stream at a time |
+
+whisper.cpp runs one transcription per GPU context, so keep **MaxConcurrency = 1**
+per single-GPU worker. To do more in parallel, run more workers (another GPU,
+another host) and add each to the pool.
+
+---
+
+## Configuration (environment variables)
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `WHISPER_MODEL` | `large-v3-turbo-q5_0` | GGML model name; downloaded on first run into `/models` |
+| `WHISPER_MODEL_DIR` | `/models` | Model cache directory (mount a volume here) |
+| `API_KEY` | *(empty)* | If set, `Authorization: Bearer <key>` is required on the POST routes |
+| `LISTEN_PORT` | `8080` | Adapter listen port (inside the container) |
+| `CONVERT` | `false` | `true` runs FFmpeg to accept non-WAV audio (needs `INSTALL_FFMPEG=true` image) |
+| `WHISPER_THREADS` | *(whisper default)* | CPU threads (`--threads`) |
+| `WHISPER_LANGUAGE` | `auto` | Upstream default language; per-request `language` still overrides |
+| `WHISPER_EXTRA_ARGS` | *(empty)* | Extra `whisper-server` flags, e.g. `--flash-attn` or `--vad --vad-model /models/ggml-silero-v5.1.2.bin` |
+| `WHISPER_BACKEND_PORT` | `8081` | Internal `whisper-server` port (localhost only) |
+| `WHISPER_READY_TIMEOUT` | `600` | Seconds to wait for the model to load before serving |
+
+---
+
+## GPU backends
+
+### Intel iGPU (Vulkan) — the default
+
+The shipped image already targets Vulkan. Pass `/dev/dri` and add the host
+`render` group (see the compose file). Leave `VK_ICD_FILENAMES` **unset** to let
+the Vulkan loader auto-discover the Mesa **ANV** driver; only pin it if multiple
+GPUs are present and you need a specific one. On Debian/Mesa the Intel ICD is
+usually `/usr/share/vulkan/icd.d/intel_icd.x86_64.json` (verify with
+`docker exec whisper-subs-worker ls /usr/share/vulkan/icd.d/`). The entrypoint
+self-heals a wrong pin by unsetting it and falling back to auto-discovery.
+
+### AMD GPU
+
+- **Vulkan (this image, no rebuild):** works via Mesa **RADV** — pass `/dev/dri`
+  exactly as for Intel. Pin `radeon_icd.x86_64.json` only if needed.
+- **ROCm/HIP (alternative):** rebuild against the ROCm toolkit — different base
+  image and runtime libs:
+  ```bash
+  # build inside rocm/dev-ubuntu-22.04, then a rocm/runtime base:
+  cmake -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF \
+    -DGGML_HIP=ON -DCMAKE_C_COMPILER=hipcc -DCMAKE_CXX_COMPILER=hipcc \
+    --target whisper-server
+  ```
+  Runtime needs `/dev/kfd` + `/dev/dri` and `rocm-hip-runtime`. (This mirrors the
+  plugin's own ROCm build recipe.)
+
+### NVIDIA GPU
+
+- **CUDA (recommended for NVIDIA):** rebuild with the CUDA toolkit base image:
+  ```bash
+  docker build -t whisper-subs-worker:cuda \
+    --build-arg BUILD_IMAGE=nvidia/cuda:12.6.3-devel-ubuntu24.04 \
+    --build-arg RUNTIME_IMAGE=nvidia/cuda:12.6.3-runtime-ubuntu24.04 \
+    --build-arg WHISPER_CMAKE_FLAGS="-DGGML_CUDA=ON -DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON" \
+    worker/
+  ```
+  Run with the NVIDIA Container Toolkit: `docker run --gpus all ...` (or compose
+  `deploy.resources.reservations.devices` / `runtime: nvidia`). The CUDA runtime
+  base already provides the NVIDIA userspace libs; `mesa-vulkan-drivers` is
+  unnecessary for this variant.
+- **Vulkan on NVIDIA:** also possible with the default image if the NVIDIA Vulkan
+  ICD is exposed to the container, but CUDA is the better-supported path.
+
+### CPU only (no GPU)
+
+```bash
+docker build -t whisper-subs-worker:cpu \
+  --build-arg WHISPER_CMAKE_FLAGS="-DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON" \
+  worker/
+```
+
+Drop the `devices:` / `group_add:` lines from the compose file. Expect real-time
+factors well above 1 on large models — prefer a smaller model (see below) or a GPU.
+
+---
+
+## Alternative backends
+
+You are not tied to this image. The plugin talks plain OpenAI audio, so any
+compliant server works. Pick by hardware:
+
+- **[Speaches](https://github.com/speaches-ai/speaches)** (formerly
+  *faster-whisper-server*) — a drop-in OpenAI-compatible server exposing
+  `POST /v1/audio/transcriptions` and `POST /v1/audio/translations`. Built on
+  **faster-whisper / CTranslate2**, whose accelerated backends are **CPU (INT8)**
+  and **NVIDIA CUDA (FP16)**. It is an excellent choice for **CPU-only** boxes and
+  **NVIDIA** GPUs. **CTranslate2 has no Vulkan/oneAPI path, so it does *not*
+  accelerate on Intel iGPUs** — which is exactly why this whisper.cpp + Vulkan image
+  exists for the Intel/AMD-iGPU case.
+- **Any other OpenAI `/v1/audio/*` server** (self-hosted or otherwise) that returns
+  SRT for `response_format=srt` and a `language` field for `verbose_json`.
+
+Whatever you choose, point the plugin's worker **Endpoint** at its base URL and set
+**MaxConcurrency** to match how many streams that backend can really run at once.
+
+---
+
+## Model selection
+
+Models download automatically on first run from
+[huggingface.co/ggerganov/whisper.cpp](https://huggingface.co/ggerganov/whisper.cpp)
+via whisper.cpp's `download-ggml-model.sh`. Set `WHISPER_MODEL` to any known name:
+
+| `WHISPER_MODEL` | Approx. size | Notes |
+|---|---|---|
+| `large-v3-turbo-q5_0` | ~547 MB | **Default.** Best speed/quality/size balance; ideal for an iGPU |
+| `large-v3-turbo` | ~1.6 GB | Full turbo; a bit more quality, more memory |
+| `large-v3` | ~3.1 GB | Highest quality, slowest; ~10 GB RAM under load |
+| `medium` / `small` / `base` | ~1.5 GB / ~466 MB / ~142 MB | Lighter/faster, lower accuracy — good for CPU workers |
+
+`large-v3-turbo-q5_0` is the recommended default: fast, small, and high quality.
+Raise `mem_limit` in the compose file if you move to a full large model.
+
+---
+
+## Verify it works
+
+Readiness (unauthenticated; returns `{"status":"ok"}` once the model is loaded):
+
+```bash
+curl -fsS http://<worker-host>:9010/health
+```
+
+Full smoke test — transcribe a 1-second silent WAV (add `-H "Authorization: Bearer <key>"`
+if `API_KEY` is set):
+
+```bash
+# 16 kHz mono s16le WAV, exactly what the plugin sends
+docker run --rm linuxserver/ffmpeg -f lavfi -i anullsrc=r=16000:cl=mono \
+  -t 1 -c:a pcm_s16le -f wav - > /tmp/silence.wav 2>/dev/null
+
+curl -fsS http://<worker-host>:9010/v1/audio/transcriptions \
+  -F file=@/tmp/silence.wav -F model=whisper-1 -F response_format=srt
+
+# language detection
+curl -fsS http://<worker-host>:9010/v1/audio/transcriptions \
+  -F file=@/tmp/silence.wav -F model=whisper-1 -F response_format=verbose_json
+
+# translation route (adapter injects translate=true)
+curl -fsS http://<worker-host>:9010/v1/audio/translations \
+  -F file=@/tmp/silence.wav -F model=whisper-1 -F response_format=srt
+```
+
+---
+
+## Building & publishing
+
+The published image is built and pushed by CI, mirroring the repo's conventions:
+
+- **Registry:** Docker Hub, image `drumsergio/whisper-subs-worker`.
+- **Tags:** semantic version tags only — e.g. `0.1.0` — **never `:latest`**.
+- **Base images:** pinned by explicit tag; use a `@sha256:` digest pin for fully
+  reproducible CI builds.
+- **whisper.cpp:** pinned to the same tag the plugin uses (`v1.8.4`); bump it in the
+  Dockerfile `WHISPER_VERSION` arg in lockstep with the plugin's pin.
+
+Local build:
+
+```bash
+docker build -t drumsergio/whisper-subs-worker:0.1.0 worker/
+```
+
+---
+
+## Security notes
+
+> **Run this on a trusted network only, unless you set `API_KEY` *and* put TLS in front.**
+> With no `API_KEY` (the default) the worker is an **unauthenticated** transcription/translation
+> endpoint — anyone who can reach the published port can drive your GPU/CPU. The adapter listens on
+> `0.0.0.0` (it must, so the plugin can reach it from another host) and logs a loud warning at startup
+> when it is serving without a key. Do **not** port-forward it or run it on a public VPS unprotected.
+
+- Set `API_KEY` to require a `Bearer` token on the transcription and translation routes (the readiness
+  probe stays open so Docker healthchecks work). The check is constant-time. The upstream
+  `whisper-server` binds to `127.0.0.1` only; the adapter is the sole public listener.
+- For traffic that leaves the host, terminate **TLS** at a reverse proxy in front of the worker and use
+  an `https://` endpoint in the plugin (it warns when a key is sent over plain HTTP).
+- The adapter frames requests strictly by a single non-negative `Content-Length`, rejects
+  `Transfer-Encoding` and oversized bodies (`WHISPER_MAX_BODY_BYTES`, default 8 GiB), and drops a
+  stalled socket after `WHISPER_SOCKET_TIMEOUT` (default 120 s) so one slow client can't wedge the GPU
+  slot. It is still wise to bound total connections at a reverse proxy for an exposed deployment.
+- The container runs as a non-root user; the example compose adds `no-new-privileges`, `cap_drop: ALL`,
+  and a read-only root filesystem. GPU access is granted only via `/dev/dri` plus the host `render` group.
+- **`CONVERT=true`** (with an `INSTALL_FFMPEG=true` image) makes `whisper-server` shell out to FFmpeg on
+  the uploaded media — a much larger parser attack surface. Leave it off unless you need non-WAV input,
+  and never enable it on an exposed worker.
+
+---
+
+*Part of [WhisperSubs](https://github.com/GeiserX/whisper-subs) — GPL-3.0.*

--- a/worker/adapter.py
+++ b/worker/adapter.py
@@ -1,0 +1,428 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# whisper-subs worker adapter
+# ===========================
+#
+# A tiny, dependency-free (Python standard library only) HTTP adapter that makes
+# an upstream `whisper-server` (ggml-org/whisper.cpp, examples/server) speak the
+# exact OpenAI-audio dialect that the whisper-subs plugin's RemoteWhisperProvider
+# expects.
+#
+# WHY THIS EXISTS
+# ---------------
+# whisper.cpp's `whisper-server` exposes a SINGLE inference path (default
+# `/inference`, remappable with `--inference-path`). It cannot serve both
+# `/v1/audio/transcriptions` AND `/v1/audio/translations` at once, and it selects
+# translation via a `translate` multipart FIELD rather than a distinct path.
+#
+# The plugin (Providers/RemoteWhisperProvider.cs), by contrast, is hard-wired to:
+#   * POST /v1/audio/transcriptions   -> transcribe (or detect language)
+#   * POST /v1/audio/translations     -> translate to English
+# with multipart fields: file, model, response_format (srt | verbose_json),
+# and an optional language. Translation is chosen purely by the PATH.
+#
+# A pure reverse proxy (nginx/Caddy) can rewrite the path but cannot inject a new
+# multipart field into a streamed body, so the translations route could never be
+# mapped to whisper.cpp's `translate=true`. This adapter does exactly and only
+# that mapping, while STREAMING the (potentially very large) audio body straight
+# through so N concurrent workers never buffer whole films in RAM.
+#
+# WHAT IT DOES
+# ------------
+#   * POST /v1/audio/transcriptions  -> proxied verbatim to upstream /inference.
+#   * POST /v1/audio/translations    -> proxied to /inference with a `translate=true`
+#                                       multipart part PREPENDED to the body (no
+#                                       reparsing, fully streamed).
+#   * GET|HEAD /health and GET|HEAD on the two audio paths -> cheap readiness probe
+#     (200 when the upstream model is loaded, 503 while loading). Never runs
+#     inference, never requires the API key -> safe for Docker healthchecks.
+#   * Optional Bearer auth on the POST routes when API_KEY is set.
+#   * Spawns and supervises the upstream `whisper-server` child process; if it
+#     dies, the adapter exits non-zero so the container restarts.
+#
+# Language handling: whisper-server defaults `language` to "en" (server.cpp), which
+# would break auto-detect and the plugin's verbose_json language-detection call.
+# We therefore launch it with `--language auto`; an explicit `language` field in a
+# request still overrides per-call. (See entrypoint / adapter spawn below.)
+
+import hmac
+import http.client
+import os
+import shlex
+import signal
+import socket
+import subprocess
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+# --------------------------------------------------------------------------- #
+# Configuration (all via environment; sensible defaults for the shipped image)
+# --------------------------------------------------------------------------- #
+def _env(name, default):
+    v = os.environ.get(name)
+    return v if v is not None and v != "" else default
+
+
+LISTEN_HOST = _env("LISTEN_HOST", "0.0.0.0")
+LISTEN_PORT = int(_env("LISTEN_PORT", "8080"))
+
+BACKEND_HOST = _env("WHISPER_BACKEND_HOST", "127.0.0.1")
+BACKEND_PORT = int(_env("WHISPER_BACKEND_PORT", "8081"))
+BACKEND_INFERENCE_PATH = _env("WHISPER_INFERENCE_PATH", "/inference")
+
+# Long, finite ceiling. The plugin enforces its own per-call deadline and drops
+# the socket; we just must not guillotine a legitimately long film transcription.
+BACKEND_TIMEOUT = float(_env("WHISPER_BACKEND_TIMEOUT", str(24 * 60 * 60)))
+
+API_KEY = _env("API_KEY", "")  # empty -> no auth required
+
+WHISPER_BIN = _env("WHISPER_BIN", "/usr/local/bin/whisper-server")
+# entrypoint.sh resolves + downloads the model and exports the absolute path.
+MODEL_FILE = _env("WHISPER_MODEL_FILE", "")
+WHISPER_LANGUAGE = _env("WHISPER_LANGUAGE", "auto")
+WHISPER_THREADS = _env("WHISPER_THREADS", "")   # "" -> whisper.cpp default
+WHISPER_CONVERT = _env("CONVERT", "false").lower() in ("1", "true", "yes", "y")
+WHISPER_EXTRA_ARGS = _env("WHISPER_EXTRA_ARGS", "")
+
+READY_TIMEOUT = int(_env("WHISPER_READY_TIMEOUT", "600"))  # seconds to first-ready
+
+# Drop a stalled-but-open client after this many seconds so one slow/silent
+# connection can't hold the single whisper-server inference slot forever (M2).
+SOCKET_TIMEOUT = float(_env("WHISPER_SOCKET_TIMEOUT", "120"))
+
+# Reject an absurd Content-Length outright (M2). A 2h film's 16 kHz mono WAV is
+# ~260 MB; the default 8 GiB ceiling is generous but bounds a memory/disk-abuse
+# upload. Set WHISPER_MAX_BODY_BYTES=0 to disable the cap.
+MAX_BODY_BYTES = int(_env("WHISPER_MAX_BODY_BYTES", str(8 * 1024 * 1024 * 1024)))
+
+CHUNK = 256 * 1024
+
+TRANSCRIBE_PATH = "/v1/audio/transcriptions"
+TRANSLATE_PATH = "/v1/audio/translations"
+
+
+def log(msg):
+    sys.stdout.write("[adapter] %s\n" % msg)
+    sys.stdout.flush()
+
+
+# --------------------------------------------------------------------------- #
+# Upstream whisper-server lifecycle
+# --------------------------------------------------------------------------- #
+_child = None  # type: subprocess.Popen | None
+
+
+def spawn_whisper_server():
+    global _child
+    if not MODEL_FILE or not os.path.isfile(MODEL_FILE):
+        log("FATAL: model file not found: %r (set WHISPER_MODEL / WHISPER_MODEL_FILE)" % MODEL_FILE)
+        sys.exit(1)
+
+    cmd = [
+        WHISPER_BIN,
+        "--host", BACKEND_HOST,
+        "--port", str(BACKEND_PORT),
+        "--model", MODEL_FILE,
+        "--inference-path", BACKEND_INFERENCE_PATH,
+        # Default to auto-detect so a request WITHOUT a language field detects the
+        # spoken language instead of forcing English (whisper-server defaults to
+        # "en"). The plugin's verbose_json language-detection call relies on this.
+        "--language", WHISPER_LANGUAGE,
+    ]
+    if WHISPER_THREADS:
+        cmd += ["--threads", WHISPER_THREADS]
+    if WHISPER_CONVERT:
+        # Requires ffmpeg in the image (build with --build-arg INSTALL_FFMPEG=true).
+        cmd += ["--convert"]
+    if WHISPER_EXTRA_ARGS:
+        cmd += shlex.split(WHISPER_EXTRA_ARGS)
+
+    log("starting upstream: %s" % " ".join(shlex.quote(c) for c in cmd))
+    _child = subprocess.Popen(cmd)
+
+    # If the upstream dies, take the whole container down so it restarts cleanly
+    # (docker-compose `restart: unless-stopped`) rather than serving 502s forever.
+    def _watch():
+        code = _child.wait()
+        log("upstream whisper-server exited (code=%s); shutting down" % code)
+        os._exit(1 if code else 0)
+
+    threading.Thread(target=_watch, name="whisper-watch", daemon=True).start()
+
+
+def _terminate_child():
+    if _child and _child.poll() is None:
+        try:
+            _child.terminate()
+            try:
+                _child.wait(timeout=10)
+            except Exception:
+                _child.kill()
+        except Exception:
+            pass
+
+
+def backend_ready():
+    try:
+        c = http.client.HTTPConnection(BACKEND_HOST, BACKEND_PORT, timeout=5)
+        c.request("GET", "/health")
+        r = c.getresponse()
+        r.read()
+        c.close()
+        return r.status == 200
+    except Exception:
+        return False
+
+
+def wait_until_ready(timeout):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if backend_ready():
+            return True
+        if _child and _child.poll() is not None:
+            return False  # child already crashed; watcher will exit us
+        time.sleep(1.0)
+    return False
+
+
+# --------------------------------------------------------------------------- #
+# HTTP handler
+# --------------------------------------------------------------------------- #
+class Handler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    server_version = "whisper-subs-worker"
+    # Drop a stalled socket (slow-loris / silent client) so it can't wedge the GPU slot (M2).
+    timeout = SOCKET_TIMEOUT
+
+    # Quieter, single-line access log.
+    def log_message(self, fmt, *args):
+        log("%s - %s" % (self.address_string(), fmt % args))
+
+    # -- helpers ----------------------------------------------------------- #
+    def _send_json(self, status, payload, close=False):
+        body = payload.encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        if close:
+            self.close_connection = True
+            self.send_header("Connection", "close")
+        self.end_headers()
+        try:
+            self.wfile.write(body)
+        except Exception:
+            pass
+
+    def _readiness(self):
+        if backend_ready():
+            self._send_json(200, '{"status":"ok"}')
+        else:
+            self._send_json(503, '{"status":"loading model"}', close=True)
+
+    def _authorized(self):
+        if not API_KEY:
+            return True
+        # Constant-time compare so the key can't be recovered byte-by-byte via response timing (L1).
+        return hmac.compare_digest(self.headers.get("Authorization", ""), "Bearer " + API_KEY)
+
+    # -- verbs ------------------------------------------------------------- #
+    def do_HEAD(self):
+        if self.path in ("/health", TRANSCRIBE_PATH, TRANSLATE_PATH, "/"):
+            # HEAD readiness: status only, no body.
+            ok = backend_ready()
+            self.send_response(200 if ok else 503)
+            self.send_header("Content-Length", "0")
+            if not ok:
+                self.close_connection = True
+                self.send_header("Connection", "close")
+            self.end_headers()
+        else:
+            self.send_response(404)
+            self.send_header("Content-Length", "0")
+            self.close_connection = True
+            self.end_headers()
+
+    def do_GET(self):
+        # GET on the audio paths is a lightweight readiness probe only; the real
+        # work is POST. This lets a healthcheck "hit the transcriptions endpoint"
+        # without spending a GPU inference and without needing the API key.
+        if self.path in ("/health", TRANSCRIBE_PATH, TRANSLATE_PATH, "/"):
+            self._readiness()
+        else:
+            self._send_json(404, '{"error":"not found"}', close=True)
+
+    def do_POST(self):
+        if self.path == TRANSCRIBE_PATH:
+            self._proxy_inference(inject_translate=False)
+        elif self.path == TRANSLATE_PATH:
+            self._proxy_inference(inject_translate=True)
+        else:
+            self._send_json(404, '{"error":"not found"}', close=True)
+
+    # -- core proxy -------------------------------------------------------- #
+    def _proxy_inference(self, inject_translate):
+        if not self._authorized():
+            self._send_json(401, '{"error":"unauthorized"}', close=True)
+            return
+
+        content_type = self.headers.get("Content-Type", "")
+
+        # This adapter frames the body strictly by Content-Length. Reject Transfer-Encoding outright
+        # (501) so a `Content-Length` + `Transfer-Encoding: chunked` pair can't desync a front proxy
+        # against this origin (TE.CL request smuggling, M3).
+        if self.headers.get("Transfer-Encoding"):
+            self._send_json(501, '{"error":"transfer-encoding not supported"}', close=True)
+            return
+
+        # Exactly one Content-Length, strictly a non-negative decimal. int() is too lenient (it accepts
+        # " 10 ", "+10", "-5", "1_000"); reject duplicates/garbage to avoid a CL.CL desync (M3).
+        cl_values = self.headers.get_all("Content-Length") or []
+        if len(cl_values) != 1 or not cl_values[0].strip().isdigit():
+            self._send_json(
+                400 if cl_values else 411,
+                '{"error":"a single non-negative Content-Length is required"}',
+                close=True,
+            )
+            return
+        body_len = int(cl_values[0].strip())
+
+        # Reject an absurd upload before streaming it anywhere (M2).
+        if MAX_BODY_BYTES and body_len > MAX_BODY_BYTES:
+            self._send_json(413, '{"error":"request body too large"}', close=True)
+            return
+
+        prefix = b""
+        total_len = body_len
+        if inject_translate:
+            boundary = _extract_boundary(content_type)
+            if not boundary:
+                self._send_json(
+                    400,
+                    '{"error":"translations route requires multipart/form-data"}',
+                    close=True,
+                )
+                return
+            # Prepend a well-formed multipart part. The original body already
+            # starts with `--boundary...`, so `prefix + body` stays valid and the
+            # injected field is simply the first one parsed. No reparse, no buffer.
+            prefix = (
+                "--%s\r\n"
+                'Content-Disposition: form-data; name="translate"\r\n'
+                "\r\n"
+                "true\r\n" % boundary
+            ).encode("latin-1")
+            total_len = body_len + len(prefix)
+
+        conn = None
+        try:
+            conn = http.client.HTTPConnection(
+                BACKEND_HOST, BACKEND_PORT, timeout=BACKEND_TIMEOUT
+            )
+            conn.putrequest(
+                "POST", BACKEND_INFERENCE_PATH, skip_host=True, skip_accept_encoding=True
+            )
+            conn.putheader("Host", "%s:%d" % (BACKEND_HOST, BACKEND_PORT))
+            conn.putheader("Content-Type", content_type)
+            conn.putheader("Content-Length", str(total_len))
+            conn.endheaders()
+
+            if prefix:
+                conn.send(prefix)
+
+            remaining = body_len
+            aborted = False
+            while remaining > 0:
+                chunk = self.rfile.read(min(CHUNK, remaining))
+                if not chunk:
+                    aborted = True  # client (plugin) closed the body early
+                    break
+                conn.send(chunk)
+                remaining -= len(chunk)
+
+            if aborted:
+                # We promised Content-Length bytes we can no longer deliver. The finally resets the
+                # upstream connection so whisper-server stops waiting and frees its context.
+                self._send_json(400, '{"error":"client closed request body"}', close=True)
+                return
+
+            resp = conn.getresponse()
+            payload = resp.read()  # SRT / JSON responses are small text bodies
+            resp_ctype = resp.getheader("Content-Type", "text/plain; charset=utf-8")
+        except (socket.timeout, ConnectionError, OSError, http.client.HTTPException) as exc:
+            log("upstream error: %r" % exc)
+            self._send_json(502, '{"error":"upstream whisper-server unavailable"}', close=True)
+            return
+        finally:
+            # Always release the upstream socket — including the exception path, which previously
+            # relied on GC to close it (L4). close() is safe to call more than once.
+            if conn is not None:
+                conn.close()
+
+        # Relay upstream status + body back to the plugin verbatim.
+        self.send_response(resp.status)
+        self.send_header("Content-Type", resp_ctype)
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        try:
+            self.wfile.write(payload)
+        except Exception:
+            pass
+
+
+def _extract_boundary(content_type):
+    # e.g. 'multipart/form-data; boundary=----XYZ' (boundary may be quoted).
+    if "multipart/form-data" not in content_type.lower():
+        return None
+    for part in content_type.split(";"):
+        part = part.strip()
+        if part.lower().startswith("boundary="):
+            b = part[len("boundary="):].strip()
+            if len(b) >= 2 and b[0] == '"' and b[-1] == '"':
+                b = b[1:-1]
+            return b
+    return None
+
+
+# --------------------------------------------------------------------------- #
+# main
+# --------------------------------------------------------------------------- #
+def main():
+    def _term(signum, _frame):
+        log("received signal %s; stopping" % signum)
+        _terminate_child()
+        os._exit(0)
+
+    signal.signal(signal.SIGTERM, _term)
+    signal.signal(signal.SIGINT, _term)
+
+    spawn_whisper_server()
+
+    log("waiting for upstream model to load (timeout=%ds)..." % READY_TIMEOUT)
+    if not wait_until_ready(READY_TIMEOUT):
+        log("upstream not ready within %ds; continuing to serve (readiness=503 until loaded)" % READY_TIMEOUT)
+    else:
+        log("upstream ready; model loaded")
+
+    if not API_KEY and LISTEN_HOST not in ("127.0.0.1", "localhost", "::1"):
+        log("WARNING: serving on %s with NO API_KEY — this transcription endpoint is UNAUTHENTICATED. "
+            "Run it only on a trusted network; set API_KEY (and put TLS in front) before exposing it "
+            "to any untrusted network or the internet (M1)." % LISTEN_HOST)
+
+    httpd = ThreadingHTTPServer((LISTEN_HOST, LISTEN_PORT), Handler)
+    httpd.daemon_threads = True
+    log("listening on %s:%d -> upstream %s:%d%s (auth=%s, convert=%s)" % (
+        LISTEN_HOST, LISTEN_PORT, BACKEND_HOST, BACKEND_PORT, BACKEND_INFERENCE_PATH,
+        "on" if API_KEY else "off", "on" if WHISPER_CONVERT else "off",
+    ))
+    try:
+        httpd.serve_forever()
+    finally:
+        _terminate_child()
+
+
+if __name__ == "__main__":
+    main()

--- a/worker/docker-compose.example.yml
+++ b/worker/docker-compose.example.yml
@@ -1,0 +1,84 @@
+# whisper-subs worker -- Intel / AMD iGPU (Vulkan) example.
+#
+# 1. Start it:            docker compose -f docker-compose.example.yml up -d
+#    (first boot downloads the model into the `whisper-models` volume; be patient.)
+# 2. Point the plugin at it: Dashboard > Plugins > WhisperSubs > Workers ->
+#    add a worker with Endpoint http://<this-host>:9010  (NO /v1 suffix),
+#    the API key below if set, and MaxConcurrency = 1 (one iGPU ~= one stream).
+#
+# NB: never use the :latest tag -- pin a semver image tag.
+
+services:
+  whisper-subs-worker:
+    image: drumsergio/whisper-subs-worker:0.1.0
+    # To build locally instead of pulling, comment out `image:` above and uncomment:
+    # build:
+    #   context: .
+    #   dockerfile: Dockerfile
+    container_name: whisper-subs-worker
+    restart: unless-stopped
+
+    ports:
+      # host:container -- the plugin connects to http://<host>:9010
+      - "9010:8080"
+
+    environment:
+      # Served whisper model. whisper-server serves exactly ONE model; the plugin's
+      # per-worker "Model" field is sent but ignored by this backend -- set it HERE.
+      WHISPER_MODEL: large-v3-turbo-q5_0
+      # Optional Bearer token. If set, configure the SAME key on the plugin worker.
+      # API_KEY: "change-me-to-a-long-random-string"
+      # Accept non-WAV audio from other OpenAI clients (needs an image built with
+      # --build-arg INSTALL_FFMPEG=true). The plugin always sends 16kHz WAV, so off.
+      # CONVERT: "false"
+      # WHISPER_THREADS: "4"           # CPU threads for whisper.cpp (default: its own)
+      # WHISPER_EXTRA_ARGS: "--flash-attn"   # extra whisper-server flags
+      # Pin a specific Vulkan ICD only if auto-discovery picks the wrong GPU. The
+      # exact filename varies (Debian/Mesa often uses the *.x86_64.json form); leave
+      # UNSET to auto-discover. Verify with: docker exec ... ls /usr/share/vulkan/icd.d/
+      # VK_ICD_FILENAMES: /usr/share/vulkan/icd.d/intel_icd.x86_64.json   # Intel
+      # VK_ICD_FILENAMES: /usr/share/vulkan/icd.d/radeon_icd.x86_64.json  # AMD
+
+    devices:
+      # Intel/AMD iGPU passthrough.
+      - /dev/dri:/dev/dri
+
+    group_add:
+      # The non-root container user needs the host's `render` (and sometimes
+      # `video`) group to open /dev/dri/renderD128. Find the numeric GID with
+      #   getent group render     (e.g. 993, 104, ...)
+      # and replace "render" below with that number if the name does not resolve.
+      - "render"
+
+    volumes:
+      # Model cache -- survives restarts so the model is downloaded only once.
+      - whisper-models:/models
+
+    # Container hardening. The image already runs non-root (uid 1000); these drop the
+    # rest of the ambient privilege so an exposed/compromised worker is contained.
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    # Read-only root filesystem: only the model cache (/models volume) and a small tmpfs
+    # need to be writable. Comment this pair out if a model download ever needs to write
+    # elsewhere on first run.
+    read_only: true
+    tmpfs:
+      - /tmp
+
+    # Cap RAM. large-v3-turbo-q5_0 is light; raise to ~10g for full large-v3.
+    mem_limit: 6g
+
+    healthcheck:
+      # /health reports 200 only once the model is loaded (same backend that
+      # serves /v1/audio/transcriptions). Unauthenticated by design.
+      test: ["CMD", "curl", "-fsS", "-o", "/dev/null", "http://127.0.0.1:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      # Generous: the first start downloads the model before it can report healthy.
+      start_period: 600s
+
+volumes:
+  whisper-models:

--- a/worker/entrypoint.sh
+++ b/worker/entrypoint.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Container entrypoint for the whisper-subs worker image.
+#   1. Resolve + (first run) download the requested GGML model into the cache volume.
+#   2. Self-heal a stale VK_ICD_FILENAMES so Vulkan can always fall back to auto-discovery.
+#   3. Hand off (exec) to the Python adapter, which spawns and supervises whisper-server.
+set -eu
+
+MODEL_DIR="${WHISPER_MODEL_DIR:-/models}"
+MODEL_NAME="${WHISPER_MODEL:-large-v3-turbo-q5_0}"
+MODEL_FILE="${MODEL_DIR}/ggml-${MODEL_NAME}.bin"
+
+mkdir -p "$MODEL_DIR"
+
+if [ ! -f "$MODEL_FILE" ]; then
+    echo "[entrypoint] model '${MODEL_NAME}' not present; downloading into ${MODEL_DIR} ..."
+    # download-ggml-model.sh validates the name against whisper.cpp's known list and
+    # fetches ggml-<model>.bin from huggingface.co/ggerganov/whisper.cpp.
+    download-ggml-model.sh "$MODEL_NAME" "$MODEL_DIR"
+fi
+
+if [ ! -f "$MODEL_FILE" ]; then
+    echo "[entrypoint] FATAL: model file still missing after download: ${MODEL_FILE}" >&2
+    echo "[entrypoint] check WHISPER_MODEL is a valid whisper.cpp model name." >&2
+    exit 1
+fi
+
+# Vulkan: if a specific ICD was pinned but does not exist in this image/host, drop
+# it so the loader auto-discovers whatever driver IS present (Intel ANV, AMD RADV, ...).
+if [ -n "${VK_ICD_FILENAMES:-}" ] && [ ! -e "${VK_ICD_FILENAMES}" ]; then
+    echo "[entrypoint] WARN: VK_ICD_FILENAMES='${VK_ICD_FILENAMES}' not found; unsetting for Vulkan auto-discovery." >&2
+    unset VK_ICD_FILENAMES
+fi
+
+export WHISPER_MODEL_FILE="$MODEL_FILE"
+echo "[entrypoint] serving model: ${MODEL_FILE}"
+
+exec python3 /opt/whisper-adapter/adapter.py


### PR DESCRIPTION
# v4.0.0.0 — Distributed / pooled multi-worker transcription

The major release: transcription is no longer one-file-at-a-time on a single box. A shared **worker pool** runs many transcriptions in parallel across any number of OpenAI-compatible Whisper endpoints (local iGPU/CPU, NVIDIA/AMD, a NAS, a cloud API — the user's choice), while a **single-server install stays byte-for-byte unchanged with zero config**.

## What's in it
- **N-slot pool dispatcher (PR-3, #117)** — replaces the global `TranscriptionLock(1,1)` with a `WorkerPool` gated at ΣMaxConcurrency, routing each job to the cheapest free worker (cost-weighted, local-first). Default one local worker = one job at a time (identical to before); N workers run concurrently. Preserves #112 (tier ordering, `(item,language)` dedup, persistence) and #110 (lazy sweep + skip-cache). Adversarially reviewed; fixed a double-dispatch race + a latent dispatch-loop wedge.
- **Worker Docker image (PR-4, #118)** — `worker/`: whisper.cpp + Vulkan behind a tiny stdlib OpenAI-compatible adapter (whisper-server isn't OpenAI-compatible on both paths). Security-reviewed + hardened (auth, request-smuggling, DoS, container). Speaches documented for CPU/NVIDIA.
- **Config UI + queue visibility (PR-5, #119)** — an optional/advanced "Worker Pool" section (add/remove workers, Test-connection); the queue panel now shows the **inbound** waiting list and the **outbound** per-endpoint "what's running where" view. Simple by default (collapsed + empty).
- **v3.29 resilience folded in** — per-call duration-scaled deadlines (kills the multi-day stuck-task class), atomic `.srt` writes, streamed WAV upload, fail-fast.

## How to use the parallelism
Deploy the `worker/` image on each spare GPU box, add each endpoint in **WhisperSubs → Worker Pool**, then **Generate All** on a library/season — the dispatcher fans it across every worker.

## Tests
893 unit tests, 0 warnings. New pure logic (pool routing/accounting, worker-plan back-compat, job requirements, config validation, synthetic-WAV) fully covered. Config HTML needs a browser check on install.

## Follow-up (post-4.0)
- Make the *automatic* scheduled sweep parallel too (bounded producer) — today the automatic task is one-at-a-time; **Generate All** already parallelizes.
- Optional: CI to publish `drumsergio/whisper-subs-worker` to Docker Hub; bump whisper.cpp to a newer pinned tag.
