### PR TITLE
feat: parallelize the automatic subtitle sweep across the worker pool (PR-3b)

### DIFF
--- a/ScheduledTasks/InFlightTasks.cs
+++ b/ScheduledTasks/InFlightTasks.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace WhisperSubs.ScheduledTasks
+{
+    /// <summary>
+    /// Pure helper for the scheduled sweep's bounded-producer dispatch (v4.1): trims the tracked
+    /// in-flight task list so it stays bounded by pool capacity instead of growing with the library.
+    /// Only tasks that ran to completion are dropped — a cancelled or faulted task MUST stay tracked
+    /// so the sweep's final <see cref="Task.WhenAll(IEnumerable{Task})"/> still observes its
+    /// exception (pruning on <see cref="Task.IsCompleted"/> would silently orphan it).
+    /// </summary>
+    internal static class InFlightTasks
+    {
+        /// <summary>
+        /// Removes successfully completed tasks from <paramref name="inFlight"/>; returns how many
+        /// were removed.
+        /// </summary>
+        internal static int PruneCompleted(List<Task> inFlight)
+        {
+            return inFlight.RemoveAll(t => t.IsCompletedSuccessfully);
+        }
+    }
+}

--- a/ScheduledTasks/SubtitleGenerationTask.cs
+++ b/ScheduledTasks/SubtitleGenerationTask.cs
@@ -119,6 +119,7 @@ namespace WhisperSubs.ScheduledTasks
             var enabledLibraryIds = config.EnabledLibraries
                 .Where(id => !string.IsNullOrEmpty(id))
                 .Select(id => Guid.Parse(id))
+                .Distinct()   // tolerate a duplicated ID in hand-edited config — items must dispatch once
                 .ToList();
 
             if (enabledLibraryIds.Count == 0)
@@ -146,6 +147,7 @@ namespace WhisperSubs.ScheduledTasks
             }
 
             var allItems = new List<(BaseItem Item, string LibraryName)>();
+            var seenItemIds = new HashSet<Guid>();   // dispatch each item once, even when two libraries reach it
             foreach (var libraryId in enabledLibraryIds)
             {
                 var library = _libraryManager.GetItemById(libraryId);
@@ -162,6 +164,12 @@ namespace WhisperSubs.ScheduledTasks
                 {
                     // Skip virtual/placeholder items with no media file
                     if (string.IsNullOrEmpty(queryItem.Path)) continue;
+
+                    // The same item can be reachable through two enabled (nested/overlapping) libraries.
+                    // Sequentially the duplicate was a cheap "existing .srt" skip; with N slots it would
+                    // now transcribe CONCURRENTLY (both copies see no .srt yet) — same output either way
+                    // (atomic sidecar writes), but hours of duplicated compute. Enumerate each item once.
+                    if (!seenItemIds.Add(queryItem.Id)) continue;
 
                     if (queryItem is Video video)
                     {
@@ -398,13 +406,6 @@ namespace WhisperSubs.ScheduledTasks
 
                 try
                 {
-                    _logger.LogInformation("[{Current}/{Total}] Processing {ItemName}",
-                        completed + 1, allItems.Count, item.Name);
-                    // Reset at item start so the bar reads 0 during audio extraction (before whisper
-                    // runs). WhisperProvider also resets at each whisper run; both are idempotent.
-                    queue.ResetFileProgress();
-                    queue.ReportTaskProgress(item.Name, completed, allItems.Count, failed, itemType, libName);
-
                     // No worker can serve this job's requirements (e.g. translation enabled but every
                     // configured worker is transcribe-only) — surface it via the same failure path below.
                     if (!pool.HasCapableWorker(requirements))
@@ -418,6 +419,29 @@ namespace WhisperSubs.ScheduledTasks
                     // the old inline await; with N workers the sweep shares the pool with the background
                     // dispatcher up to ΣMaxConcurrency.
                     var lease = await pool.AcquireAsync(requirements, cancellationToken);
+
+                    // A user/admin request that arrived while we were parked on AcquireAsync must not be
+                    // demoted behind the next swept item: this producer's waiter is FIFO-queued AHEAD of
+                    // the background dispatcher's, so the sweep would win every freed slot. Hand the slot
+                    // back, drain the priority lanes, then re-acquire. NEVER drain while still holding the
+                    // lease — at capacity 1, DrainPriorityAsync would wait forever on the very slot this
+                    // producer holds.
+                    while (queue.PriorityCount > 0)
+                    {
+                        pool.Release(lease.Key);
+                        _logger.LogInformation("Yielding worker slot to {Count} priority request(s) before the next swept item", queue.PriorityCount);
+                        await queue.DrainPriorityAsync(manager, pool, requirements, _logger, cancellationToken);
+                        lease = await pool.AcquireAsync(requirements, cancellationToken);
+                    }
+
+                    // Report AFTER the slot is won, so the panel names the item that is actually starting —
+                    // not the next one parked behind a long transcription (at capacity 1 the pre-acquire
+                    // report mislabeled the whole run). Reset so the bar reads 0 during audio extraction
+                    // (before whisper runs); WhisperProvider also resets at each whisper run — idempotent.
+                    _logger.LogInformation("[{Current}/{Total}] Processing {ItemName}",
+                        completed + 1, allItems.Count, item.Name);
+                    queue.ResetFileProgress();
+                    queue.ReportTaskProgress(item.Name, completed, allItems.Count, failed, itemType, libName);
                     pool.SetCurrent(lease.Key, item.Name);   // "what's running where" — surfaced in the status panel
 
                     // v4.1: run the item on its leased worker WITHOUT awaiting it inline, so the producer
@@ -434,9 +458,7 @@ namespace WhisperSubs.ScheduledTasks
                 {
                     Interlocked.Increment(ref failed);
                     _logger.LogError(ex, "Failed to generate subtitle for {ItemName}", item.Name);
-                    var done = Interlocked.Increment(ref completed);
-                    queue.ReportTaskProgress(null, done, allItems.Count, failed);
-                    progress.Report((double)done / allItems.Count * 100);
+                    CountSweptItem();
                 }
             }
 
@@ -463,6 +485,13 @@ namespace WhisperSubs.ScheduledTasks
                 catch (OperationCanceledException)
                 {
                     // Expected on cancellation — the in-flight items were cancelled with us.
+                }
+                catch (Exception ex)
+                {
+                    // A task can only end Faulted here if its own finally threw (not a known path). The
+                    // tail WhenAll above is the real propagation point — a settle-time fault must never
+                    // skip the skip-cache save below nor replace the producer's own exception.
+                    _logger.LogWarning(ex, "In-flight sweep item threw while settling; continuing so the skip-cache still saves");
                 }
 
                 // Persist even on cancellation / pause-timeout so the run keeps the progress it made.
@@ -493,23 +522,36 @@ namespace WhisperSubs.ScheduledTasks
                     {
                         await manager.GenerateSubtitleAsync(item, lease.Worker.Provider, language, cancellationToken);
                     }
+                    CountSweptItem();
                 }
-                catch (OperationCanceledException)
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
+                    // Real cancellation: rethrow WITHOUT counting, matching the old inline loop (a
+                    // cancelled item was never "Processed"). The filter keeps a third-party OCE (e.g. a
+                    // remote worker's HTTP timeout surfacing as TaskCanceledException) on the failure path
+                    // below, instead of marking the finished run Cancelled from the tail WhenAll.
                     throw;
                 }
                 catch (Exception ex)
                 {
                     Interlocked.Increment(ref failed);
                     _logger.LogError(ex, "Failed to generate subtitle for {ItemName}", item.Name);
+                    CountSweptItem();
                 }
                 finally
                 {
                     pool.Release(lease.Key, item.Name);
-                    var done = Interlocked.Increment(ref completed);
-                    queue.ReportTaskProgress(null, done, allItems.Count, failed);
-                    progress.Report((double)done / allItems.Count * 100);
                 }
+            }
+
+            // Shared "one more item is done" accounting for the producer's failure path and the per-item
+            // tasks (success + failure). Interlocked because N of these complete concurrently; cancelled
+            // items are deliberately NOT counted (identical to the old inline loop's semantics).
+            void CountSweptItem()
+            {
+                var done = Interlocked.Increment(ref completed);
+                queue.ReportTaskProgress(null, done, allItems.Count, failed);
+                progress.Report((double)done / allItems.Count * 100);
             }
         }
 

--- a/ScheduledTasks/SubtitleGenerationTask.cs
+++ b/ScheduledTasks/SubtitleGenerationTask.cs
@@ -204,6 +204,18 @@ namespace WhisperSubs.ScheduledTasks
                 _logger.LogInformation("Skip cache active: {Count} remembered item(s)", skipCache.Count);
             }
 
+            // v4.1: the sweep is a bounded-concurrency producer over the shared worker pool. The loop
+            // below dispatches each item that needs generation as a tracked task instead of awaiting it
+            // inline; AcquireAsync blocks while every slot is busy, so at most pool.TotalCapacity swept
+            // items are ever in flight. With the default one local worker (TotalCapacity 1) the producer
+            // cannot dispatch item k+1 until item k releases its slot — transcriptions stay strictly
+            // one-at-a-time in enumeration order, exactly like the old inline await.
+            var inFlight = new List<Task>();
+            if (pool.TotalCapacity > 1)
+            {
+                _logger.LogInformation("Worker pool allows up to {Capacity} concurrent transcription(s) — sweeping in parallel", pool.TotalCapacity);
+            }
+
             try
             {
             for (int i = 0; i < allItems.Count; i++)
@@ -233,11 +245,11 @@ namespace WhisperSubs.ScheduledTasks
                     var token = cacheVideo.DateLastSaved.Ticks;
                     if (SubtitleSkipCache.CanSkip(skipCache.TryGet(item.Id), token, nowTicks, config.SkipCacheExpiryDays))
                     {
+                        var done = Interlocked.Increment(ref completed);
                         _logger.LogInformation("[{Current}/{Total}] Skipping {ItemName}: already satisfied (cached)",
-                            completed + 1, allItems.Count, item.Name);
-                        completed++;
-                        queue.ReportTaskProgress(null, completed, allItems.Count, failed);
-                        progress.Report((double)completed / allItems.Count * 100);
+                            done, allItems.Count, item.Name);
+                        queue.ReportTaskProgress(null, done, allItems.Count, failed);
+                        progress.Report((double)done / allItems.Count * 100);
                         continue;
                     }
                 }
@@ -258,9 +270,9 @@ namespace WhisperSubs.ScheduledTasks
                                 var exactLrc = System.IO.Path.Combine(audioDir, audioBase + ".lrc");
                                 if (System.IO.File.Exists(exactLrc) || System.IO.Directory.GetFiles(audioDir, audioBase + ".*.lrc").Length > 0)
                                 {
-                                    completed++;
-                                    queue.ReportTaskProgress(null, completed, allItems.Count, failed);
-                                    progress.Report((double)completed / allItems.Count * 100);
+                                    var done = Interlocked.Increment(ref completed);
+                                    queue.ReportTaskProgress(null, done, allItems.Count, failed);
+                                    progress.Report((double)done / allItems.Count * 100);
                                     continue;
                                 }
                             }
@@ -372,13 +384,13 @@ namespace WhisperSubs.ScheduledTasks
 
                         if (alreadyComplete)
                         {
+                            var done = Interlocked.Increment(ref completed);
                             // Log WHY so users (esp. large libraries) can see skips aren't a no-op.
                             _logger.LogInformation(
                                 "[{Current}/{Total}] Skipping {ItemName}: already satisfied (full={Full}, forced={Forced}, translated={Translated})",
-                                completed + 1, allItems.Count, item.Name, hasFullSrt, hasForcedSrt, hasTranslatedSrt);
-                            completed++;
-                            queue.ReportTaskProgress(null, completed, allItems.Count, failed);
-                            progress.Report((double)completed / allItems.Count * 100);
+                                done, allItems.Count, item.Name, hasFullSrt, hasForcedSrt, hasTranslatedSrt);
+                            queue.ReportTaskProgress(null, done, allItems.Count, failed);
+                            progress.Report((double)done / allItems.Count * 100);
                             continue;
                         }
                     }
@@ -401,26 +413,18 @@ namespace WhisperSubs.ScheduledTasks
                     }
 
                     // Acquire a slot on the shared worker pool (the global concurrency gate that replaced the
-                    // old TranscriptionLock) and run this swept item on the chosen worker. With the default
-                    // one local worker this serialises exactly like the old lock; with N workers the sweep
-                    // shares the pool with the background dispatcher up to ΣMaxConcurrency.
+                    // old TranscriptionLock). This is the sweep's backpressure: it blocks while every slot is
+                    // busy, so with the default one local worker the dispatch below serialises exactly like
+                    // the old inline await; with N workers the sweep shares the pool with the background
+                    // dispatcher up to ΣMaxConcurrency.
                     var lease = await pool.AcquireAsync(requirements, cancellationToken);
                     pool.SetCurrent(lease.Key, item.Name);   // "what's running where" — surfaced in the status panel
-                    try
-                    {
-                        if (config.PauseOnPlayback)
-                        {
-                            await TranscribeWithPlaybackMonitorAsync(manager, item, lease.Worker.Provider, language, cancellationToken);
-                        }
-                        else
-                        {
-                            await manager.GenerateSubtitleAsync(item, lease.Worker.Provider, language, cancellationToken);
-                        }
-                    }
-                    finally
-                    {
-                        pool.Release(lease.Key, item.Name);
-                    }
+
+                    // v4.1: run the item on its leased worker WITHOUT awaiting it inline, so the producer
+                    // can line up the next item on another free worker. The task owns the lease release and
+                    // its own failure/progress accounting (Interlocked — it races the producer's skip paths).
+                    inFlight.Add(RunSweptItemAsync(item, lease));
+                    InFlightTasks.PruneCompleted(inFlight);
                 }
                 catch (OperationCanceledException)
                 {
@@ -428,14 +432,18 @@ namespace WhisperSubs.ScheduledTasks
                 }
                 catch (Exception ex)
                 {
-                    failed++;
+                    Interlocked.Increment(ref failed);
                     _logger.LogError(ex, "Failed to generate subtitle for {ItemName}", item.Name);
+                    var done = Interlocked.Increment(ref completed);
+                    queue.ReportTaskProgress(null, done, allItems.Count, failed);
+                    progress.Report((double)done / allItems.Count * 100);
                 }
-
-                completed++;
-                queue.ReportTaskProgress(null, completed, allItems.Count, failed);
-                progress.Report((double)completed / allItems.Count * 100);
             }
+
+            // Everything is dispatched — wait for the in-flight tail so the completion report below sees
+            // the final counts. WhenAll only settles after EVERY task completes, so a cancelled tail still
+            // reaches the finally with nothing orphaned (and its cancellation propagates from here).
+            await Task.WhenAll(inFlight);
 
             queue.ReportTaskProgress(null, completed, allItems.Count, failed);
             queue.ReportTaskComplete();
@@ -444,6 +452,19 @@ namespace WhisperSubs.ScheduledTasks
             }
             finally
             {
+                // A cancelled (or failed) producer can leave dispatched items still running — settle them
+                // FIRST, so the skip-cache save below happens after the last in-flight item is done (each
+                // one saves its partial SRT on cancel via its own token) and none is ever orphaned. The
+                // catch keeps the producer's own exception propagating; a no-op when the WhenAll above ran.
+                try
+                {
+                    await Task.WhenAll(inFlight);
+                }
+                catch (OperationCanceledException)
+                {
+                    // Expected on cancellation — the in-flight items were cancelled with us.
+                }
+
                 // Persist even on cancellation / pause-timeout so the run keeps the progress it made.
                 // Prune to the enumerated candidate set (not the reached set) so items not yet visited
                 // this run keep their prior entry — the reason per-item state beats a global watermark.
@@ -452,6 +473,42 @@ namespace WhisperSubs.ScheduledTasks
                 {
                     skipCache.PruneTo(candidateIds);
                     skipCache.Save(cachePath, cacheSignature, _logger);
+                }
+            }
+
+            // The per-item transcription task the producer dispatches after leasing a worker slot. Mirrors
+            // the old inline body: same PauseOnPlayback branch (each in-flight item monitors playback
+            // independently via its own linked CTS), cancellation propagates (marking the task cancelled
+            // for the WhenAlls above), any other failure is logged + counted, and the slot is ALWAYS
+            // released. Counters/reports use Interlocked because N of these complete concurrently.
+            async Task RunSweptItemAsync(BaseItem item, WorkerLease lease)
+            {
+                try
+                {
+                    if (config.PauseOnPlayback)
+                    {
+                        await TranscribeWithPlaybackMonitorAsync(manager, item, lease.Worker.Provider, language, cancellationToken);
+                    }
+                    else
+                    {
+                        await manager.GenerateSubtitleAsync(item, lease.Worker.Provider, language, cancellationToken);
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    Interlocked.Increment(ref failed);
+                    _logger.LogError(ex, "Failed to generate subtitle for {ItemName}", item.Name);
+                }
+                finally
+                {
+                    pool.Release(lease.Key, item.Name);
+                    var done = Interlocked.Increment(ref completed);
+                    queue.ReportTaskProgress(null, done, allItems.Count, failed);
+                    progress.Report((double)done / allItems.Count * 100);
                 }
             }
         }

--- a/WhisperSubs.Tests/InFlightTasksTests.cs
+++ b/WhisperSubs.Tests/InFlightTasksTests.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using WhisperSubs.ScheduledTasks;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+/// <summary>
+/// v4.1 parallel sweep: pins the in-flight pruning predicate. Only tasks that ran to completion may
+/// be dropped from the tracked list — cancelled and faulted tasks must survive pruning so the sweep's
+/// final Task.WhenAll still observes their exceptions (pruning on IsCompleted instead would silently
+/// orphan a cancelled item's OperationCanceledException).
+/// </summary>
+public class InFlightTasksTests
+{
+    [Fact]
+    public void PruneCompleted_DropsOnlySuccessfullyCompletedTasks()
+    {
+        var succeeded = Task.CompletedTask;
+        var cancelled = Task.FromCanceled(new CancellationToken(canceled: true));
+        var faulted = Task.FromException(new InvalidOperationException("boom"));
+        var running = new TaskCompletionSource().Task;
+
+        var inFlight = new List<Task> { succeeded, cancelled, faulted, running };
+        var removed = InFlightTasks.PruneCompleted(inFlight);
+
+        Assert.Equal(1, removed);
+        Assert.Equal(new List<Task> { cancelled, faulted, running }, inFlight);
+
+        _ = faulted.Exception; // observe so the faulted fixture task never trips the finalizer
+    }
+
+    [Fact]
+    public void PruneCompleted_EmptyList_IsANoOp()
+    {
+        var inFlight = new List<Task>();
+
+        Assert.Equal(0, InFlightTasks.PruneCompleted(inFlight));
+        Assert.Empty(inFlight);
+    }
+}


### PR DESCRIPTION
# feat: parallelize the automatic subtitle sweep across the worker pool (PR-3b)

Closes the v4.0 known follow-up: the AUTOMATIC scheduled sweep transcribed swept items one at a time (one pool lease, awaited inline), so the backlog only ever used ONE worker even with N configured. Manual Generate / Generate All already parallelized; this brings the nightly library sweep to the same model, so a multi-worker pool (e.g. two iGPU servers) churns the whole backlog concurrently.

## Design — bounded-concurrency producer over the existing pool

The per-item preamble (playback wait, skip-cache, `alreadyComplete`, `HasCapableWorker`) stays producer-side and sequential. For an item that needs generation, the producer `AcquireAsync`s a slot (the `SemaphoreSlim(ΣMaxConcurrency)` gate = natural backpressure — never more in flight than pool capacity, no new config knob), then dispatches the item as a tracked task (`RunSweptItemAsync`) that owns its lease release and its own Interlocked accounting. A tail `Task.WhenAll` settles everything before the completion report, and the outer `finally` settles in-flight items **before** the skip-cache `PruneTo`/`Save` — so cancellation still saves partial SRTs and never orphans a task.

**Byte-identical at capacity 1 (the unconfigured default):** with one local worker the semaphore has one permit, held from dispatch until the item's `finally` releases it — the producer blocks on `AcquireAsync` before starting item k+1, so items run strictly one-at-a-time in enumeration order, exactly like the old inline await.

## Adversarial-review fixes folded in (review of f7a00fd)

- **Priority yield (should-fix):** the producer's parked `AcquireAsync` waiter is FIFO-queued ahead of the background dispatcher's, which would demote a user request behind the *next* swept item (hours). After acquiring, if `PriorityCount > 0` the producer hands the slot back, drains the priority lanes, and re-acquires — restoring #112's "user requests outrank the sweep". (Deliberately release-then-drain: draining while holding the lease self-deadlocks at capacity 1.)
- **Status panel (should-fix):** the "Processing [k/N] + name + progress reset" report moved to after the acquire, so the panel names the item actually starting — not the next one parked behind a long transcription.
- Cancelled items are no longer counted into `Processed` (matches the old loop's accounting).
- A third-party `OperationCanceledException` (e.g. a remote worker HTTP timeout surfacing as `TaskCanceledException`) now lands on the failure path (`when (cancellationToken.IsCancellationRequested)` filter) instead of marking a fully-finished run "Cancelled".
- The outer finally's settle also catches non-OCE faults, so a settle-time fault can't skip the skip-cache save or mask the producer's own exception.
- Duplicate enumeration de-dup (`Distinct()` on library IDs + per-run `HashSet` of item IDs): overlapping libraries previously made the duplicate a cheap "existing .srt" skip; concurrently both copies would transcribe (waste, not corruption — sidecar writes are atomic).

The review confirmed the rest sound: no deadlock (slot holders never wait on the producer; the playback wait is 4h-capped exactly as before), no lease leak (the task's `finally` is the sole releaser), no unbounded `inFlight` growth (failed items complete successfully and are pruned; retention is bounded by capacity), counters exact (each item counted exactly once, no overshoot).

## Tests

New pure helper `InFlightTasks.PruneCompleted` (keeps non-success tasks so the `WhenAll`s observe their exceptions) is unit-tested. The orchestration lives in the coverage-excluded task class, consistent with the existing pattern. Full suite: 895 passing, 0 warnings.

No version bump — the release + bump (this is 4.1 material: a feature) stays gated.
