### PR TITLE
chore: remove dead v4.0 members + pin the dispatcher dedup invariant

### DIFF
--- a/Controller/PriorityLanes.cs
+++ b/Controller/PriorityLanes.cs
@@ -109,34 +109,6 @@ namespace WhisperSubs.Controller
             }
         }
 
-        /// <summary>
-        /// Removes and returns the highest-priority entry whose value satisfies <paramref name="canDequeue"/>,
-        /// scanning lanes in priority order then FIFO within a lane. Strict tier order is preserved: a
-        /// lower-priority entry is returned only when no acceptable higher-priority one exists. Used by the
-        /// worker-pool dispatcher to skip a head job that no currently-free worker can serve (v4.0).
-        /// </summary>
-        public bool TryDequeue(Func<T, bool> canDequeue, out T value)
-        {
-            lock (_gate)
-            {
-                foreach (var lane in _lanes.Values)
-                {
-                    for (var node = lane.First; node != null; node = node.Next)
-                    {
-                        if (canDequeue(node.Value.Value))
-                        {
-                            value = node.Value.Value;
-                            RemoveNode(node);
-                            return true;
-                        }
-                    }
-                }
-
-                value = default!;
-                return false;
-            }
-        }
-
         /// <summary>Removes a specific key if queued. Returns true if it was present.</summary>
         public bool Remove(string key)
         {

--- a/Controller/Workers/WorkerModel.cs
+++ b/Controller/Workers/WorkerModel.cs
@@ -40,7 +40,7 @@ namespace WhisperSubs.Controller.Workers
     /// the scheduler's internal value.
     /// </summary>
     public readonly record struct WorkerStatus(
-        string Id, string Name, bool Healthy, int InFlight, int MaxConcurrency, bool IsLocal, double CostWeight,
+        string Id, string Name, int InFlight, int MaxConcurrency, bool IsLocal, double CostWeight,
         IReadOnlyList<string> CurrentItems);
 
     /// <summary>What a specific job needs from a worker (drives the hard capability filter).</summary>

--- a/Controller/Workers/WorkerPool.cs
+++ b/Controller/Workers/WorkerPool.cs
@@ -92,7 +92,7 @@ namespace WhisperSubs.Controller.Workers
                     var w = _byKey[key];
                     var caps = w.Capabilities;
                     list.Add(new WorkerStatus(
-                        w.Id, w.Name, Healthy: true, _inFlight[key],
+                        w.Id, w.Name, _inFlight[key],
                         caps.MaxConcurrency < 1 ? 1 : caps.MaxConcurrency, caps.IsLocal, caps.CostWeight,
                         new List<string>(_current[key])));
                 }

--- a/Providers/SubtitleProviderFactory.cs
+++ b/Providers/SubtitleProviderFactory.cs
@@ -7,34 +7,12 @@ namespace WhisperSubs.Providers
 {
     internal static class SubtitleProviderFactory
     {
-        [ExcludeFromCodeCoverage(Justification = "Orchestration: news up providers and depends on Plugin.Instance, File.Exists and TryAcquire — not unit-testable, same rationale as the excluded download/process methods.")]
-        public static ISubtitleProvider Create(PluginConfiguration config, ILoggerFactory loggerFactory)
-        {
-            if (!string.IsNullOrWhiteSpace(config.RemoteWhisperApiUrl))
-            {
-                var model = string.IsNullOrWhiteSpace(config.RemoteWhisperModel)
-                    ? "Systran/faster-whisper-large-v3"
-                    : config.RemoteWhisperModel.Trim();
-                var apiKey = (config.RemoteWhisperApiKey ?? string.Empty).Trim();
-                return new RemoteWhisperProvider(
-                    loggerFactory.CreateLogger<RemoteWhisperProvider>(),
-                    config.RemoteWhisperApiUrl,
-                    model,
-                    apiKey,
-                    config.JobTimeoutRealtimeFactor,
-                    config.JobMinTimeoutSeconds,
-                    config.JobMaxTimeoutHours);
-            }
-
-            return CreateLocal(config, loggerFactory);
-        }
-
         /// <summary>
         /// Builds the host's local in-process whisper-cli provider (VAD + detection-model resolution).
-        /// Extracted from <see cref="Create"/> so the v4.0 worker pool can construct the local worker
-        /// directly, without the remote-vs-local switch.
+        /// The v4.0 worker pool (WorkerRegistry) constructs the local worker with this directly; remote
+        /// workers get their own RemoteWhisperProvider per configured endpoint in WorkerRegistry.
         /// </summary>
-        [ExcludeFromCodeCoverage(Justification = "Orchestration: news up WhisperProvider + WhisperSetupService, File.Exists, TryAcquire — same rationale as Create.")]
+        [ExcludeFromCodeCoverage(Justification = "Orchestration: news up WhisperProvider + WhisperSetupService and depends on Plugin.Instance, File.Exists and TryAcquire — not unit-testable, same rationale as the excluded download/process methods.")]
         public static ISubtitleProvider CreateLocal(PluginConfiguration config, ILoggerFactory loggerFactory)
         {
             var setup = new WhisperSetupService(
@@ -101,7 +79,7 @@ namespace WhisperSubs.Providers
 
         /// <summary>
         /// Maps the plugin's VAD tuning config fields onto a <see cref="VadTuning"/>. Extracted from
-        /// <see cref="Create"/> (excluded from coverage as untestable orchestration) so the field-by-field
+        /// <see cref="CreateLocal"/> (excluded from coverage as untestable orchestration) so the field-by-field
         /// mapping stays pure and unit-testable — a guard against a silent field transposition. (Issue #105.)
         /// </summary>
         internal static VadTuning BuildVadTuning(PluginConfiguration config)

--- a/WhisperSubs.Tests/PriorityLanesTests.cs
+++ b/WhisperSubs.Tests/PriorityLanesTests.cs
@@ -150,43 +150,4 @@ public class PriorityLanesTests
         Assert.Equal(0, lanes.Count);
         Assert.False(lanes.CountsByTier().ContainsKey(Medium)); // lane pruned
     }
-
-    // ── predicate dequeue (v4.0 dispatcher: skip a head job no free worker can serve) ──
-
-    [Fact]
-    public void TryDequeuePredicate_ReturnsHighestPriorityAcceptable()
-    {
-        var lanes = new PriorityLanes<string>();
-        lanes.Enqueue("c", Critical, "crit");
-        lanes.Enqueue("h", High, "high");
-        // Accept everything → same as the plain head (strongest tier).
-        Assert.True(lanes.TryDequeue(_ => true, out var v));
-        Assert.Equal("crit", v);
-    }
-
-    [Fact]
-    public void TryDequeuePredicate_SkipsRejectedHead_PreservesTierOrder()
-    {
-        var lanes = new PriorityLanes<string>();
-        lanes.Enqueue("c", Critical, "crit");   // rejected by the predicate
-        lanes.Enqueue("h1", High, "high1");
-        lanes.Enqueue("h2", High, "high2");
-        // Skip "crit" → the next acceptable is the FIFO head of the next-strongest lane.
-        Assert.True(lanes.TryDequeue(v => v != "crit", out var v1));
-        Assert.Equal("high1", v1);
-        // "crit" is still queued (only skipped, not removed).
-        Assert.True(lanes.ContainsKey("c"));
-        Assert.Equal(2, lanes.Count);
-    }
-
-    [Fact]
-    public void TryDequeuePredicate_FalseWhenNoneAcceptable()
-    {
-        var lanes = new PriorityLanes<string>();
-        lanes.Enqueue("a", Medium, "a");
-        lanes.Enqueue("b", Low, "b");
-        Assert.False(lanes.TryDequeue(_ => false, out var v));
-        Assert.Null(v);
-        Assert.Equal(2, lanes.Count); // nothing removed
-    }
 }

--- a/WhisperSubs.Tests/SubtitleQueueDedupTests.cs
+++ b/WhisperSubs.Tests/SubtitleQueueDedupTests.cs
@@ -1,0 +1,110 @@
+using MediaBrowser.Controller.Entities;
+using WhisperSubs.Controller;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+/// <summary>
+/// Pins the v4.0 dispatcher's core safety invariant: one (item, language) identity is never
+/// dispatchable twice concurrently. <c>Enqueue</c> and <c>TryDequeuePriority</c> coordinate under one
+/// dispatch gate — a dequeue atomically moves the identity from the lanes into the in-flight set, a
+/// re-enqueue while QUEUED merges onto the existing entry (Force OR'd, tier promoted), and a
+/// re-enqueue while IN-FLIGHT is rejected until the dispatcher releases the reservation. Uses fresh
+/// service instances (the singleton is convention, not enforced) so each test starts with empty
+/// lanes/in-flight state; with no <c>Plugin.Instance</c> the queue.json persistence is a no-op, so
+/// these stay disk-free — the same pattern as <c>RequestStoreTests</c>.
+/// </summary>
+public class SubtitleQueueDedupTests
+{
+    private static Video NewItem(string name = "Film") => new Video { Id = Guid.NewGuid(), Name = name };
+
+    [Fact]
+    public void Dequeue_MovesIdentityInFlight_SoReEnqueueCannotDispatchTwice()
+    {
+        var queue = new SubtitleQueueService();
+        var item = NewItem();
+
+        Assert.True(queue.Enqueue(item, "en", PriorityTier.High));
+        Assert.True(queue.TryDequeuePriority(out var dispatched));
+        Assert.Same(item, dispatched!.Item);
+
+        // The dequeue reserved the identity in-flight (queued XOR in-flight holds)...
+        Assert.False(queue.TryReserve(SubtitleQueueService.IdentityKey(item.Id, "en")));
+        Assert.Equal(0, queue.PriorityCount);
+
+        // ...so a re-request mid-transcription must not create a second dispatchable entry,
+        // no matter how strong the tier or the force flag.
+        Assert.False(queue.Enqueue(item, "en", PriorityTier.Critical, force: true));
+        Assert.Equal(0, queue.PriorityCount);
+        Assert.False(queue.TryDequeuePriority(out var second));
+        Assert.Null(second);
+    }
+
+    [Fact]
+    public void Enqueue_WhileInFlight_LanguageCaseDiffers_StillRejected()
+    {
+        // IdentityKey lowercases the language, so "EN" and "en" are the same unit of work across
+        // BOTH the queued and in-flight sets — a case-variant re-request must not double-dispatch.
+        var queue = new SubtitleQueueService();
+        var item = NewItem();
+
+        Assert.True(queue.Enqueue(item, "en", PriorityTier.High));
+        Assert.True(queue.TryDequeuePriority(out _));
+
+        Assert.False(queue.Enqueue(item, "EN", PriorityTier.Critical));
+        Assert.False(queue.TryDequeuePriority(out _));
+    }
+
+    [Fact]
+    public void Release_MakesTheSameIdentityDispatchableAgain()
+    {
+        var queue = new SubtitleQueueService();
+        var item = NewItem();
+
+        Assert.True(queue.Enqueue(item, "en", PriorityTier.High));
+        Assert.True(queue.TryDequeuePriority(out _));
+
+        // The dispatcher's per-job finally releases the reservation once transcription ends.
+        queue.Release(SubtitleQueueService.IdentityKey(item.Id, "en"));
+
+        // The identity is now requestable and dispatchable again (e.g. a forced regenerate).
+        Assert.True(queue.Enqueue(item, "en", PriorityTier.High));
+        Assert.True(queue.TryDequeuePriority(out var again));
+        Assert.Same(item, again!.Item);
+    }
+
+    [Fact]
+    public void ReEnqueue_WhileQueued_MergesForceAndTier_InsteadOfDuplicating()
+    {
+        var queue = new SubtitleQueueService();
+        var item = NewItem();
+
+        // A user request at Medium followed by an admin forced request at Critical collapses to ONE
+        // entry carrying the OR'd force and the promoted tier — never two competing jobs (#112).
+        Assert.True(queue.Enqueue(item, "en", PriorityTier.Medium, force: false));
+        Assert.False(queue.Enqueue(item, "en", PriorityTier.Critical, force: true)); // merged, not added
+        Assert.Equal(1, queue.PriorityCount);
+
+        Assert.True(queue.TryDequeuePriority(out var merged));
+        Assert.True(merged!.Force);
+        Assert.Equal(PriorityTier.Critical, merged.Tier);
+        Assert.Same(item, merged.Item);
+
+        Assert.False(queue.TryDequeuePriority(out _)); // there was only ever one entry
+    }
+
+    [Fact]
+    public void ReEnqueue_WithWeakerTier_NeverWeakensTheQueuedEntry()
+    {
+        var queue = new SubtitleQueueService();
+        var item = NewItem();
+
+        Assert.True(queue.Enqueue(item, "en", PriorityTier.Critical, force: true));
+        Assert.False(queue.Enqueue(item, "en", PriorityTier.Background, force: false));
+        Assert.Equal(1, queue.PriorityCount);
+
+        Assert.True(queue.TryDequeuePriority(out var kept));
+        Assert.True(kept!.Force);                        // force is OR'd, never cleared
+        Assert.Equal(PriorityTier.Critical, kept.Tier);  // tier only ever promotes
+    }
+}


### PR DESCRIPTION
Follow-up from the post-release architectural audit (dead-code + test-gap findings).

**Deleted (each grep-verified across C#, configPage.html, whisperSubs.js):**
- `WorkerStatus.Healthy` — only ever constructed as `true`, never read; not on the /Queue wire (the endpoint projects an explicit anonymous object).
- `PriorityLanes.TryDequeue(predicate)` overload + its 3 tests — zero production callers; its doc comment claimed a dispatcher caller that doesn't exist.
- `SubtitleProviderFactory.Create` — v4.0 builds providers via `WorkerRegistry` (`CreateLocal` + per-endpoint `RemoteWhisperProvider`); dangling `<see cref>`s fixed.

**Audit flags refuted, kept as live (with evidence):**
- `WorkerSlot.Healthy` — read by `WorkerScheduling.CanServe` on every dispatch (dormant health seam, production always passes true).
- `WorkerCapabilities.Priority`/`.Models` + `JobRequirements.RequiredModel` — read by `CanServe`/`Score` (hard capability filter + tiebreak); dormant inputs, not dead code.

**New: `SubtitleQueueDedupTests` (5)** — pins the dispatcher's core safety invariant: an `(item, language)` identity can never be dispatchable twice. Covers dequeue-reserves-identity (re-enqueue while in-flight rejected), case-insensitive identity across the in-flight boundary, release-restores-dispatchability, queued-merge (Force OR'd + tier promoted, never demoted).

895 passing (893 − 3 removed predicate tests + 5 new), 0 warnings. File set disjoint from #122 and #123 — merges cleanly in any order.