### PR TITLE
fix: Workers/TestConnection distinguishes reachable-but-slow from unreachable (4.1.1.0)

### DIFF
--- a/Api/SubtitleController.cs
+++ b/Api/SubtitleController.cs
@@ -405,6 +405,46 @@ namespace WhisperSubs.Api
             var model = string.IsNullOrWhiteSpace(worker.Model) ? "Systran/faster-whisper-large-v3" : worker.Model.Trim();
             var wav = Controller.Workers.SyntheticAudio.SilentWav16kMono(100);
 
+            // Reachability pre-probe (v4.1.1): before the (potentially slow) transcribe, do a cheap GET of the
+            // worker BASE url so we can tell a genuinely-unreachable endpoint (connection refused / DNS / TLS /
+            // host-unreachable) apart from a reachable-but-slow one. A modest GPU running a large model can take
+            // far longer than the transcribe deadline to decode even the silent probe clip (whisper decodes
+            // silence as a worst-case, full-length hallucination), and that must NOT be reported as "Unreachable" —
+            // a false negative that scares admins off a perfectly good worker. Same SSRF hardening as the transcribe
+            // call: no auto-redirect, and the link-local IP/DNS checks above already ran for this exact host.
+            var baseUrl = worker.ApiUrl.Trim();
+            if (System.Uri.TryCreate(baseUrl, System.UriKind.Absolute, out var baseUri))
+            {
+                baseUrl = baseUri.Scheme + "://" + baseUri.Authority + "/";
+            }
+            using (var reachHandler = new System.Net.Http.SocketsHttpHandler
+            {
+                AllowAutoRedirect = false,
+                ConnectTimeout = TimeSpan.FromSeconds(8)
+            })
+            using (var reachHttp = new System.Net.Http.HttpClient(reachHandler) { Timeout = TimeSpan.FromSeconds(8) })
+            {
+                try
+                {
+                    using var getReq = new System.Net.Http.HttpRequestMessage(System.Net.Http.HttpMethod.Get, baseUrl);
+                    using var getResp = await reachHttp.SendAsync(getReq);
+                    // Any HTTP status answered (even 401/404) proves the host is reachable — fall through to transcribe.
+                }
+                catch (System.Net.Http.HttpRequestException ex)
+                {
+                    // Connection refused / DNS failure / TLS failure / connect-timeout / host-unreachable — genuinely
+                    // unreachable. Stop here; the transcribe would only fail the same way, slower.
+                    var (ok, warning, msg) = Controller.Workers.WorkerProbe.ClassifyProbeOutcome(reachable: false, httpStatus: null, timedOut: false);
+                    return Ok(new { ok, warning, message = msg + ": " + ex.Message });
+                }
+                catch (OperationCanceledException)
+                {
+                    // The overall GET timeout elapsed AFTER connecting: the host completed the TCP/TLS handshake but
+                    // is slow to answer a bare GET (some transcribe servers only handle POST). That is REACHABLE —
+                    // fall through and let the transcribe probe be the real test. A GET timeout is NOT "unreachable".
+                }
+            }
+
             using var content = new System.Net.Http.MultipartFormDataContent();
             var fileContent = new System.Net.Http.ByteArrayContent(wav);
             fileContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("audio/wav");
@@ -419,43 +459,47 @@ namespace WhisperSubs.Api
             }
 
             // Dedicated no-redirect client (v4.0.1): a real transcribe endpoint never 302s, so disabling
-            // auto-redirect blocks a redirect-based SSRF pivot to an arbitrary URL.
+            // auto-redirect blocks a redirect-based SSRF pivot to an arbitrary URL. Overall timeout is 30s (v4.1.1,
+            // up from 20s): reachability is already confirmed, so a timeout here means "reachable and it accepted the
+            // audio but the decode is slow" — surfaced as a warning (worker still usable), never a hard failure.
             using var handler = new System.Net.Http.SocketsHttpHandler
             {
                 AllowAutoRedirect = false,
                 ConnectTimeout = TimeSpan.FromSeconds(10)
             };
-            using var http = new System.Net.Http.HttpClient(handler) { Timeout = TimeSpan.FromSeconds(20) };
+            using var http = new System.Net.Http.HttpClient(handler) { Timeout = TimeSpan.FromSeconds(30) };
 
             var sw = System.Diagnostics.Stopwatch.StartNew();
             try
             {
                 using var resp = await http.SendAsync(probe);
                 sw.Stop();
-                if (resp.IsSuccessStatusCode)
-                {
-                    return Ok(new
-                    {
-                        ok = true,
-                        status = (int)resp.StatusCode,
-                        latencyMs = sw.ElapsedMilliseconds,
-                        message = $"OK — transcribed a test clip in {sw.ElapsedMilliseconds} ms."
-                    });
-                }
-
                 // Do NOT echo the upstream response body (SSRF response-disclosure) — status + latency only.
-                return Ok(new
-                {
-                    ok = false,
-                    status = (int)resp.StatusCode,
-                    latencyMs = sw.ElapsedMilliseconds,
-                    message = $"Endpoint responded HTTP {(int)resp.StatusCode} — not a working transcribe endpoint."
-                });
+                var status = (int)resp.StatusCode;
+                var (ok, warning, msg) = Controller.Workers.WorkerProbe.ClassifyProbeOutcome(reachable: true, httpStatus: status, timedOut: false);
+                // The 2xx result is a stem; append the measured round-trip so the admin sees how fast it was.
+                var message = (ok && !warning) ? (msg + " (" + sw.ElapsedMilliseconds + " ms).") : msg;
+                return Ok(new { ok, warning, status, latencyMs = sw.ElapsedMilliseconds, message });
+            }
+            catch (OperationCanceledException)
+            {
+                // Overall 30s timeout, and reachability already passed: reachable + accepted the audio, decode slow.
+                sw.Stop();
+                var (ok, warning, msg) = Controller.Workers.WorkerProbe.ClassifyProbeOutcome(reachable: true, httpStatus: null, timedOut: true);
+                return Ok(new { ok, warning, latencyMs = sw.ElapsedMilliseconds, message = msg });
+            }
+            catch (System.Net.Http.HttpRequestException ex)
+            {
+                // The connection dropped mid-transcribe (it was reachable a moment ago) — report as unreachable.
+                sw.Stop();
+                var (ok, warning, msg) = Controller.Workers.WorkerProbe.ClassifyProbeOutcome(reachable: false, httpStatus: null, timedOut: false);
+                return Ok(new { ok, warning, latencyMs = sw.ElapsedMilliseconds, message = msg + ": " + ex.Message });
             }
             catch (Exception ex)
             {
+                // Never throw — the endpoint contract is an always-shaped {ok, warning, ...} result.
                 sw.Stop();
-                return Ok(new { ok = false, latencyMs = sw.ElapsedMilliseconds, message = $"Unreachable: {ex.Message}" });
+                return Ok(new { ok = false, warning = false, latencyMs = sw.ElapsedMilliseconds, message = $"Unreachable: {ex.Message}" });
             }
         }
 

--- a/Controller/Workers/WorkerProbe.cs
+++ b/Controller/Workers/WorkerProbe.cs
@@ -1,0 +1,76 @@
+namespace WhisperSubs.Controller.Workers
+{
+    /// <summary>
+    /// Pure classification for the worker "Test connection" probe (v4.1.1). The probe now runs in two stages —
+    /// a cheap reachability GET of the base URL, then a transcribe POST of a tiny silent clip — and this helper
+    /// maps that outcome to the {ok, warning, message} the config page renders (green / yellow / red). It is split
+    /// out of the coverage-excluded controller so every branch is unit-tested.
+    ///
+    /// The distinction it encodes is the whole point of the fix: a transcribe that TIMES OUT after the host was
+    /// already proven reachable is NOT a failure. A modest GPU running a large model (e.g. large-v3 on an Intel
+    /// iGPU) can take far longer than the probe's transcribe deadline to decode even the silent test clip —
+    /// whisper decodes silence as a worst-case, full-length hallucination — so a timeout there is a WARNING, not a
+    /// failure: the worker is reachable, authenticated and accepted the audio, and real jobs get a longer,
+    /// duration-scaled deadline. Only a genuine transport failure (refused / DNS / TLS / host-unreachable) of the
+    /// reachability GET — or a connection that drops mid-transcribe — is reported as "Unreachable".
+    /// </summary>
+    internal static class WorkerProbe
+    {
+        /// <summary>
+        /// The transcribe-timeout warning copy, kept as a const so the wording has a single source of truth.
+        /// The "30s" here must stay in step with the transcribe probe's overall timeout in the controller.
+        /// </summary>
+        internal const string TranscribeTimeoutMessage =
+            "Reachable and it accepted the audio, but the test transcription didn't finish within 30s. " +
+            "That's normal for a large model on a modest GPU (this probe uses a silent clip — a worst case for " +
+            "decode length). The worker will still be used; real jobs get a longer, duration-scaled deadline.";
+
+        /// <summary>
+        /// Maps a probe outcome to the config-page result.
+        /// <para>
+        /// <paramref name="reachable"/> is false only for a genuine transport failure of the reachability GET (or a
+        /// connection that dropped mid-transcribe); the caller appends the transport reason to the returned message
+        /// (e.g. "Unreachable: Connection refused"). When reachable, <paramref name="timedOut"/> true means the
+        /// transcribe exceeded its deadline, otherwise <paramref name="httpStatus"/> is the status the transcribe
+        /// answered with; for a 2xx the caller appends the measured latency to the returned stem.
+        /// </para>
+        /// The classifier is total over its inputs (never throws) and applies its rules in precedence order:
+        /// unreachable dominates, then a timeout, then the HTTP status.
+        /// </summary>
+        internal static (bool ok, bool warning, string message) ClassifyProbeOutcome(bool reachable, int? httpStatus, bool timedOut)
+        {
+            if (!reachable)
+            {
+                // Genuine transport failure. Caller appends ": <transport reason>".
+                return (false, false, "Unreachable");
+            }
+
+            if (timedOut)
+            {
+                // Reachable and it accepted the audio — the decode is just slow. A warning (worker stays usable),
+                // never a red failure. This is the false-negative the fix exists to prevent.
+                return (true, true, TranscribeTimeoutMessage);
+            }
+
+            if (httpStatus is int status)
+            {
+                if (status >= 200 && status < 300)
+                {
+                    // Caller appends the measured round-trip: "Reachable, auth OK, transcription verified (1234 ms)."
+                    return (true, false, "Reachable, auth OK, transcription verified");
+                }
+
+                if (status == 401 || status == 403)
+                {
+                    return (false, false, "Reachable, but authentication failed — check the API key.");
+                }
+
+                return (false, false, "Reachable, but the transcription endpoint returned HTTP " + status + ".");
+            }
+
+            // Reachable, didn't time out, yet carried no HTTP status: not produced by the controller's orchestration,
+            // but the classifier stays total over its input domain rather than throwing.
+            return (false, false, "Reachable, but the transcription endpoint returned no HTTP status.");
+        }
+    }
+}

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -1740,7 +1740,8 @@
                 },
 
                 // Probes one row's endpoint via POST Workers/TestConnection; shows the server's
-                // message inline (green when ok, red otherwise) via textContent.
+                // message inline via textContent — green when verified, yellow when reachable-but-slow
+                // (ok && warning), red when unreachable/auth/HTTP error.
                 testWorker: function (row, btn) {
                     var result = row.querySelector('.wkTestResult');
                     var url = (row.querySelector('.wkUrl').value || '').trim();
@@ -1763,7 +1764,12 @@
                         if (result) {
                             // Server-provided message rendered via textContent (never innerHTML).
                             result.textContent = (r && r.message) ? r.message : ((r && r.ok) ? 'OK' : 'Failed');
-                            result.style.color = (r && r.ok) ? '#52B54B' : '#CC3333';
+                            // Three states from the {ok, warning} shape: ok && !warning = verified (green);
+                            // ok && warning = reachable but the test transcription was slow (yellow, still usable);
+                            // !ok = unreachable / auth failure / HTTP error (red).
+                            result.style.color = (r && r.ok)
+                                ? ((r && r.warning) ? '#CC7B19' : '#52B54B')
+                                : '#CC3333';
                         }
                     }).catch(function (err) {
                         if (result) {

--- a/WhisperSubs.Tests/WorkerProbeTests.cs
+++ b/WhisperSubs.Tests/WorkerProbeTests.cs
@@ -1,0 +1,101 @@
+using WhisperSubs.Controller.Workers;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+/// <summary>
+/// v4.1.1: the worker "Test connection" probe distinguishes a genuinely-unreachable endpoint from a
+/// reachable-but-slow one. These cover every branch of the pure classifier that drives the {ok, warning, message}
+/// the config page renders as red / yellow / green — the fix for the false-negative where a slow GPU (large-v3 on
+/// an Intel iGPU) blew the transcribe timeout on the silent probe clip and a reachable worker was reported as
+/// unreachable.
+/// </summary>
+public class WorkerProbeTests
+{
+    [Fact]
+    public void NotReachable_IsHardFailure()
+    {
+        var (ok, warning, message) = WorkerProbe.ClassifyProbeOutcome(reachable: false, httpStatus: null, timedOut: false);
+        Assert.False(ok);
+        Assert.False(warning);
+        Assert.Equal("Unreachable", message);   // controller appends ": <transport reason>"
+    }
+
+    [Theory]
+    [InlineData(200)]
+    [InlineData(201)]
+    [InlineData(299)]
+    public void Reachable_2xx_IsVerifiedSuccess(int status)
+    {
+        var (ok, warning, message) = WorkerProbe.ClassifyProbeOutcome(reachable: true, httpStatus: status, timedOut: false);
+        Assert.True(ok);
+        Assert.False(warning);
+        Assert.Equal("Reachable, auth OK, transcription verified", message);   // controller appends " (<latency> ms)."
+    }
+
+    [Theory]
+    [InlineData(401)]
+    [InlineData(403)]
+    public void Reachable_AuthFailure_IsHardFailure(int status)
+    {
+        var (ok, warning, message) = WorkerProbe.ClassifyProbeOutcome(reachable: true, httpStatus: status, timedOut: false);
+        Assert.False(ok);
+        Assert.False(warning);
+        Assert.Equal("Reachable, but authentication failed — check the API key.", message);
+    }
+
+    [Theory]
+    [InlineData(400)]
+    [InlineData(404)]
+    [InlineData(429)]
+    [InlineData(500)]
+    [InlineData(503)]
+    public void Reachable_OtherStatus_ReportsTheStatus(int status)
+    {
+        var (ok, warning, message) = WorkerProbe.ClassifyProbeOutcome(reachable: true, httpStatus: status, timedOut: false);
+        Assert.False(ok);
+        Assert.False(warning);
+        Assert.Equal("Reachable, but the transcription endpoint returned HTTP " + status + ".", message);
+    }
+
+    [Fact]
+    public void Reachable_ButTranscribeTimedOut_IsWarningNotFailure()
+    {
+        // The crux of the fix: reachable + slow transcribe must be OK-with-warning (yellow), never a red failure.
+        var (ok, warning, message) = WorkerProbe.ClassifyProbeOutcome(reachable: true, httpStatus: null, timedOut: true);
+        Assert.True(ok);
+        Assert.True(warning);
+        Assert.Equal(WorkerProbe.TranscribeTimeoutMessage, message);
+        Assert.Contains("didn't finish within 30s", message);
+        Assert.Contains("duration-scaled deadline", message);
+    }
+
+    [Fact]
+    public void Timeout_TakesPrecedence_OverStatus_WhenReachable()
+    {
+        // Defensive precedence: a long-running decode that also carried a status is still a usable worker (warning).
+        var (ok, warning, _) = WorkerProbe.ClassifyProbeOutcome(reachable: true, httpStatus: 200, timedOut: true);
+        Assert.True(ok);
+        Assert.True(warning);
+    }
+
+    [Fact]
+    public void NotReachable_TakesPrecedence_OverEverything()
+    {
+        // Unreachable dominates even if a stale status/timeout is also passed.
+        var (ok, warning, message) = WorkerProbe.ClassifyProbeOutcome(reachable: false, httpStatus: 200, timedOut: true);
+        Assert.False(ok);
+        Assert.False(warning);
+        Assert.Equal("Unreachable", message);
+    }
+
+    [Fact]
+    public void Reachable_NoStatusNoTimeout_IsTotalAndSafe()
+    {
+        // Not produced by the orchestration, but the classifier is total over its inputs rather than throwing.
+        var (ok, warning, message) = WorkerProbe.ClassifyProbeOutcome(reachable: true, httpStatus: null, timedOut: false);
+        Assert.False(ok);
+        Assert.False(warning);
+        Assert.Contains("no HTTP status", message);
+    }
+}

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>4.1.0.0</Version>
+    <Version>4.1.1.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
The `Workers/TestConnection` probe POSTs a silent WAV and timed out at 20s, then reported **"Unreachable"**. On a slow GPU worker (large-v3 on an Intel iGPU) whisper hallucinates a full-length decode on the silence and exceeds 20s — so a perfectly good worker looked broken (false negative). Found live while wiring the geiserback iGPU into the pool.

**Fix — two-stage probe:**
1. Cheap **reachability GET** of the base URL (SSRF-hardened, no-redirect, 8s). A transport failure (refused/DNS/TLS/host-unreachable) → red **Unreachable**. Any response, or even a GET timeout (some servers only handle POST) → reachable, continue.
2. **Transcribe POST** (30s), classified by the new pure `WorkerProbe.ClassifyProbeOutcome(reachable, httpStatus, timedOut)` (precedence: unreachable → timeout → status):
   - 2xx → green "transcription verified (Nms)"
   - 401/403 → red "authentication failed"
   - other status → red, echoes the status
   - **timeout after reachable → yellow WARNING** (`ok:true, warning:true`): reachable + accepted the audio, just slow — the worker stays usable, and real jobs get the longer duration-scaled deadline.

Config page now renders three states (green / **amber** / red). Result shape gains `warning`. SSRF checks unchanged.

**Tests:** new `WorkerProbeTests` (15) cover every branch + precedence guards. **912 pass (897 + 15), 0 warnings.** Pure helper is coverage-gated; the HTTP orchestration stays `[ExcludeFromCodeCoverage]`.

Version → 4.1.1.0. Pairs with the worker-image 0.1.2 accuracy PR.