### PR TITLE
feat: auto-retry killed/cancelled jobs + persist in-flight leases (whisper-subs-1t0)

### DIFF
--- a/Configuration/PluginConfiguration.cs
+++ b/Configuration/PluginConfiguration.cs
@@ -287,6 +287,15 @@ namespace WhisperSubs.Configuration
         /// <summary>Absolute cap for the per-call deadline in hours — a genuinely long film's worst case still fits under it. Default 12.</summary>
         public int JobMaxTimeoutHours { get; set; } = 12;
 
+        /// <summary>
+        /// How many times a killed (task stopped / Jellyfin restart) or failed transcription job is
+        /// automatically re-queued before the plugin gives up on it. The job is re-queued at its original
+        /// priority tier, and the counter survives a restart (persisted to queue.json). 0 disables
+        /// auto-retry entirely — a killed/failed job is dropped exactly as before this feature, so the
+        /// behaviour is fully opt-out-able. Default 3. (whisper-subs-1t0.)
+        /// </summary>
+        public int JobMaxRetries { get; set; } = 3;
+
         // ── Worker pool (v4.0; power-user feature, empty by default) ─────────
         // Simple by default: a normal single-server install leaves Workers empty and EnableLocalWorker on,
         // so the plugin behaves exactly as today (the host's own whisper, one job at a time). Power users

--- a/Controller/SubtitleQueueService.cs
+++ b/Controller/SubtitleQueueService.cs
@@ -317,6 +317,26 @@ namespace WhisperSubs.Controller
         internal static bool ShouldRetry(int retryCount, int maxRetries) => retryCount < maxRetries;
 
         /// <summary>
+        /// Whether a persisted lease should be restored to the lanes on startup (whisper-subs-1t0). A Pending
+        /// lease never started, so it is ALWAYS restored (its budget is untouched). An IN-FLIGHT lease was
+        /// running when the process died — that counts as one consumed attempt, so it is restored only while
+        /// it still has retry budget (<see cref="ShouldRetry"/>); an in-flight lease already at/over the cap is
+        /// dropped rather than looped forever (the hard-kill boot-loop guard for an item that OOM-kills every
+        /// run — restore-unbounded would re-run it at an unchanged count and wedge the whole queue on restart).
+        /// </summary>
+        internal static bool ShouldRestore(bool wasInFlight, int retryCount, int maxRetries) =>
+            !wasInFlight || ShouldRetry(retryCount, maxRetries);
+
+        /// <summary>
+        /// The RetryCount a restored lease re-enters the lanes at (whisper-subs-1t0). A Pending lease never
+        /// started, so it keeps its count unchanged; an in-flight lease consumed one attempt (its process was
+        /// killed mid-run), so it comes back at RetryCount+1 — which, together with <see cref="ShouldRestore"/>,
+        /// bounds restarts so a permanently-killed item is eventually given up on instead of boot-looping.
+        /// </summary>
+        internal static int RestoredRetryCount(bool wasInFlight, int retryCount) =>
+            wasInFlight ? retryCount + 1 : retryCount;
+
+        /// <summary>
         /// Cancel/failure transition for an in-flight item. Under <see cref="_dispatchGate"/> — the SAME
         /// lock <see cref="Enqueue"/> and the dequeue+reserve take — it always leaves the in-flight set,
         /// and, when the item still has retry budget (<see cref="ShouldRetry"/>), atomically re-adds it to
@@ -438,10 +458,17 @@ namespace WhisperSubs.Controller
         }
 
         /// <summary>
-        /// Restores queue from disk on startup. Call after Jellyfin library is available.
+        /// Restores queue from disk on startup (whisper-subs-1t0). Call after the Jellyfin library is
+        /// available. Pending leases (never started) are restored unincremented; an interrupted IN-FLIGHT
+        /// lease counts as one consumed attempt, so it is restored at RetryCount+1 while it still has budget
+        /// and DROPPED (given up on) once it has hit the retry cap. Without that bound an item whose process
+        /// is SIGKILL'd mid-transcription every time (OOM on a long film) would restore at an unchanged
+        /// RetryCount, be drained before the sweep, OOM again, restore again — an infinite boot-loop that
+        /// wedges ALL subtitle generation on every restart. <paramref name="maxRetries"/> is the same cap the
+        /// dispatcher uses (config.JobMaxRetries).
         /// </summary>
-        [ExcludeFromCodeCoverage(Justification = "Requires Plugin.Instance + ILibraryManager")]
-        public int RestoreQueue(ILibraryManager libraryManager, ILogger logger)
+        [ExcludeFromCodeCoverage(Justification = "Requires Plugin.Instance + ILibraryManager; the restore decision is the unit-tested RestoreFromEntries")]
+        public int RestoreQueue(ILibraryManager libraryManager, ILogger logger, int maxRetries)
         {
             var path = QueueFilePath;
             if (string.IsNullOrEmpty(path) || !File.Exists(path)) return 0;
@@ -451,45 +478,25 @@ namespace WhisperSubs.Controller
                 var json = File.ReadAllText(path);
 
                 // Parse either shape: v2 = { Version, Pending[], InFlight[] }; legacy v1 = a bare
-                // QueueEntry[]. The interrupted in-flight leases are restored as Pending too — they were
-                // running (not completed) when the snapshot was taken, so they must be redone; an
-                // already-satisfied one is a cheap no-op thanks to GenerateSubtitleAsync's existing-file
-                // skip (#82). Pending is restored first so, if the same identity appears in both lists
-                // (it should not, but be safe), the lane dedup collapses them and we never double-restore.
+                // QueueEntry[] (all pending). An interrupted in-flight lease is redone — but BOUNDED (see
+                // RestoreFromEntries): it consumed one attempt, so it comes back at RetryCount+1 and is
+                // dropped once out of budget, killing the hard-kill boot-loop.
                 var (pending, inFlight) = ParseQueueFile(json);
-                var total = pending.Count + inFlight.Count;
-                if (total == 0) return 0;
+                if (pending.Count + inFlight.Count == 0) return 0;
 
-                int restored = 0;
-                foreach (var entry in pending.Concat(inFlight))
+                var (restored, givenUp) = RestoreFromEntries(
+                    pending, inFlight, maxRetries, guid => libraryManager.GetItemById(guid));
+
+                foreach (var (name, retryCount) in givenUp)
                 {
-                    if (!System.Guid.TryParse(entry.ItemId, out var guid)) continue;
-                    var item = libraryManager.GetItemById(guid);
-                    if (item == null) continue;
-
-                    var tier = PriorityScheduling.NormalizeRestoredTier(entry.Tier);
-                    var key = IdentityKey(item.Id, entry.Language);
-
-                    // A queue.json with the same (item, language) more than once must not re-run every
-                    // copy — de-dup the restored set too, keeping the strongest tier / OR'd force / larger
-                    // retry count. The retry budget carries over so a chronically-failing item is not given
-                    // a fresh set of attempts on every restart.
-                    var outcome = _lanes.Enqueue(key, (int)tier, new SubtitleWorkItem
-                    {
-                        Item = item,
-                        Language = entry.Language,
-                        Completion = null,
-                        Force = entry.Force,
-                        Tier = tier,
-                        RetryCount = entry.RetryCount
-                    }, MergeWork);
-
-                    if (outcome == LaneEnqueueOutcome.Added) restored++;
+                    logger.LogWarning(
+                        "[Queue] Giving up on {Name} after {Attempts} attempt(s) — it was killed mid-transcription and is out of retries; not restoring",
+                        name, retryCount + 1);
                 }
 
                 logger.LogInformation(
-                    "[Queue] Restored {Count} items from disk ({Pending} pending + {InFlight} interrupted in-flight re-queued, of {Total} saved)",
-                    restored, pending.Count, inFlight.Count, total);
+                    "[Queue] Restored {Count} of {Total} saved items ({Pending} pending + {InFlight} interrupted in-flight; {Dropped} in-flight given up at the {Max}-retry cap)",
+                    restored, pending.Count + inFlight.Count, pending.Count, inFlight.Count, givenUp.Count, maxRetries);
                 return restored;
             }
             catch (System.Exception ex)
@@ -497,6 +504,68 @@ namespace WhisperSubs.Controller
                 logger.LogWarning(ex, "[Queue] Failed to restore queue from {Path}", path);
                 return 0;
             }
+        }
+
+        /// <summary>
+        /// The restore core (whisper-subs-1t0), separated from <see cref="RestoreQueue"/> so it is
+        /// unit-testable without Plugin.Instance / a live ILibraryManager: it depends only on the parsed
+        /// entries, the retry cap, and an item resolver. Restores into the lanes and returns the count of
+        /// newly-added items PLUS the in-flight leases it GAVE UP on (name + prior RetryCount) for the caller
+        /// to log. Rules:
+        /// <list type="bullet">
+        /// <item>Pending entries never started → always restored at their unchanged RetryCount.</item>
+        /// <item>In-flight entries were running when the snapshot was taken → count as one consumed attempt:
+        /// restored at RetryCount+1 while <see cref="ShouldRetry"/>, else dropped (the boot-loop guard).</item>
+        /// </list>
+        /// Pending is processed first so a (should-not-happen) same-identity Pending∩InFlight overlap collapses
+        /// onto the pending copy via the lane dedup (<see cref="MergeWork"/>) rather than double-restoring.
+        /// Tier-less legacy entries normalise to High; only a genuinely-<see cref="LaneEnqueueOutcome.Added"/>
+        /// entry is counted.
+        /// </summary>
+        internal (int Restored, List<(string Name, int RetryCount)> GivenUp) RestoreFromEntries(
+            List<QueueEntry> pending,
+            List<QueueEntry> inFlight,
+            int maxRetries,
+            System.Func<System.Guid, BaseItem?> resolveItem)
+        {
+            int restored = 0;
+            var givenUp = new List<(string Name, int RetryCount)>();
+
+            foreach (var (entry, wasInFlight) in
+                     pending.Select(e => (e, false)).Concat(inFlight.Select(e => (e, true))))
+            {
+                if (!System.Guid.TryParse(entry.ItemId, out var guid)) continue;
+                var item = resolveItem(guid);
+                if (item == null) continue;
+
+                // An in-flight lease already at/over the cap is given up on — NOT re-enqueued — so a job that
+                // is SIGKILL'd mid-transcription every restart (OOM) can't boot-loop the whole queue. Pending
+                // leases never started, so ShouldRestore always keeps them (unincremented).
+                if (!ShouldRestore(wasInFlight, entry.RetryCount, maxRetries))
+                {
+                    givenUp.Add((item.Name, entry.RetryCount));
+                    continue;
+                }
+
+                var tier = PriorityScheduling.NormalizeRestoredTier(entry.Tier);
+                var key = IdentityKey(item.Id, entry.Language);
+
+                // De-dup the restored set (same (item,language) more than once collapses to one lane entry),
+                // keeping the strongest tier / OR'd force / larger retry count via MergeWork.
+                var outcome = _lanes.Enqueue(key, (int)tier, new SubtitleWorkItem
+                {
+                    Item = item,
+                    Language = entry.Language,
+                    Completion = null,
+                    Force = entry.Force,
+                    Tier = tier,
+                    RetryCount = RestoredRetryCount(wasInFlight, entry.RetryCount)
+                }, MergeWork);
+
+                if (outcome == LaneEnqueueOutcome.Added) restored++;
+            }
+
+            return (restored, givenUp);
         }
 
         /// <summary>
@@ -745,18 +814,26 @@ namespace WhisperSubs.Controller
                         }
                         catch (System.Exception ex)
                         {
-                            if (countProcessed) Interlocked.Increment(ref _processedCount);
-                            Interlocked.Increment(ref _failedCount);
                             _lastError = $"{wi.Item.Name}: {ex.Message}";
                             wi.Completion?.TrySetException(ex);
                             logger.LogError(ex, "[Dispatch] Failed: {ItemName}", wi.Item.Name);
                             // Transient failure (whisper crash, unreachable worker, …) — bounded auto-retry.
+                            // Count ONLY the terminal outcome: an attempt that is about to be re-queued is not
+                            // yet a processed/failed item, so a 4×-retried item must not inflate Processed/Failed
+                            // by 4. The give-up branch — where the retry budget is finally spent — is the one
+                            // that counts it once as processed+failed (mirrors the fail-fast unservable path).
                             if (RetryOrRelease(wi, maxRetries))
+                            {
                                 logger.LogWarning("[Dispatch] {ItemName} failed — re-queued to retry (retry {Retry} of {Max})",
                                     wi.Item.Name, wi.RetryCount + 1, maxRetries);
+                            }
                             else
+                            {
+                                if (countProcessed) Interlocked.Increment(ref _processedCount);
+                                Interlocked.Increment(ref _failedCount);
                                 logger.LogWarning("[Dispatch] Giving up on {ItemName} after {Attempts} attempt(s) — it keeps failing",
                                     wi.Item.Name, wi.RetryCount + 1);
+                            }
                         }
                         finally
                         {

--- a/Controller/SubtitleQueueService.cs
+++ b/Controller/SubtitleQueueService.cs
@@ -34,6 +34,14 @@ namespace WhisperSubs.Controller
         /// default is only a safe fallback.
         /// </summary>
         public PriorityTier Tier { get; init; } = PriorityTier.Medium;
+
+        /// <summary>
+        /// How many times this job has already been auto-re-queued after being killed (cancelled) or
+        /// failing. 0 for a fresh request. Bounded by <see cref="Configuration.PluginConfiguration.JobMaxRetries"/>
+        /// so a permanently-failing item is eventually given up on instead of looping forever. Persisted
+        /// to queue.json and restored, so the retry budget survives a restart. (whisper-subs-1t0.)
+        /// </summary>
+        public int RetryCount { get; init; }
     }
 
     public class QueueEntry
@@ -51,6 +59,32 @@ namespace WhisperSubs.Controller
         /// restore — NOT Critical(0), which a non-nullable int default would wrongly imply.
         /// </summary>
         public int? Tier { get; set; }
+
+        /// <summary>
+        /// Persisted retry counter (whisper-subs-1t0). A queue.json written before this feature has no
+        /// field, so it deserializes to 0 — the same "fresh job" state a new entry carries, which is
+        /// exactly right for a legacy restore.
+        /// </summary>
+        public int RetryCount { get; set; }
+    }
+
+    /// <summary>
+    /// The v2 (whisper-subs-1t0) on-disk shape of queue.json: a top-level object carrying BOTH the
+    /// pending lanes and the currently in-flight leases, so an item that was dequeued-and-running is no
+    /// longer lost on a restart. A pre-v2 queue.json is a bare <see cref="QueueEntry"/> array (no wrapper)
+    /// and is still read via the legacy fallback in <see cref="SubtitleQueueService.ParseQueueFile"/>.
+    /// </summary>
+    public class QueueFile
+    {
+        /// <summary>Schema version. 2 = this pending+in-flight object shape; a bare array is legacy v1.</summary>
+        public int Version { get; set; }
+
+        /// <summary>Items still waiting in the priority lanes, in dequeue order.</summary>
+        public List<QueueEntry> Pending { get; set; } = new List<QueueEntry>();
+
+        /// <summary>Leases that were dequeued and running when the snapshot was taken. On restore these
+        /// are re-enqueued as Pending (they were interrupted, not completed — redo them).</summary>
+        public List<QueueEntry> InFlight { get; set; } = new List<QueueEntry>();
     }
 
     public class SubtitleQueueService
@@ -65,8 +99,14 @@ namespace WhisperSubs.Controller
         private readonly PriorityLanes<SubtitleWorkItem> _lanes = new();
 
         // Keys currently being PROCESSED (dequeued, transcription running). Kept separate from the
-        // queued set so a re-request while an item is mid-transcription does not double-queue it.
-        private readonly ConcurrentDictionary<string, byte> _inFlight = new();
+        // queued set so a re-request while an item is mid-transcription does not double-queue it. The
+        // value is the full work item (whisper-subs-1t0) so an in-flight lease's identity/tier/language/
+        // force/retry-count is recoverable — PersistQueue writes it to queue.json, and RestoreQueue
+        // re-enqueues it as Pending after an interrupting restart, so a running item is never dropped.
+        // Nullable value: the low-level TryReserve(key) identity-only overload (tests / bare reservation)
+        // stores null, which PersistQueue skips; every real dispatch reserves WITH the item, so a value
+        // is never null in production.
+        private readonly ConcurrentDictionary<string, SubtitleWorkItem?> _inFlight = new();
 
         // Serialises the queue↔in-flight transition so the invariant "an identity is queued XOR in-flight"
         // holds atomically: the dispatcher's dequeue+reserve and Enqueue's in-flight-check+lane-add run
@@ -251,14 +291,82 @@ namespace WhisperSubs.Controller
                 Language = existing.Language,
                 Completion = existing.Completion ?? incoming.Completion,
                 Force = existing.Force || incoming.Force,
-                Tier = PriorityScheduling.Stronger(existing.Tier, incoming.Tier)
+                Tier = PriorityScheduling.Stronger(existing.Tier, incoming.Tier),
+                // Keep the LARGER retry count so a concurrent fresh request (RetryCount 0) can never reset
+                // the retry budget of an item that is already being retried — the bound only ever tightens.
+                RetryCount = System.Math.Max(existing.RetryCount, incoming.RetryCount)
             };
 
-        // Reserve a key as in-flight (being processed); returns false if already reserved.
-        internal bool TryReserve(string key) => _inFlight.TryAdd(key, 0);
+        // Reserve a key as in-flight (being processed), retaining the work item so the lease is persistable
+        // and re-queueable on an interrupted restart; returns false if already reserved.
+        internal bool TryReserve(string key, SubtitleWorkItem? item) => _inFlight.TryAdd(key, item);
+
+        // Identity-only reservation (no retained work item) — used by the low-level dedup tests and any
+        // caller that only needs to claim the identity. Stores null, which PersistQueue skips.
+        internal bool TryReserve(string key) => TryReserve(key, null);
 
         // Release after processing (or on failure/cancel) so the same work can be requested again later.
         internal void Release(string key) => _inFlight.TryRemove(key, out _);
+
+        /// <summary>
+        /// Pure retry decision (whisper-subs-1t0): an item that has already been retried
+        /// <paramref name="retryCount"/> times may be retried again only while it is strictly under the
+        /// configured cap. <paramref name="maxRetries"/> &lt;= 0 disables retry entirely (0 = the pre-feature
+        /// "drop a killed/failed job" behaviour), so auto-retry is opt-out-able.
+        /// </summary>
+        internal static bool ShouldRetry(int retryCount, int maxRetries) => retryCount < maxRetries;
+
+        /// <summary>
+        /// Cancel/failure transition for an in-flight item. Under <see cref="_dispatchGate"/> — the SAME
+        /// lock <see cref="Enqueue"/> and the dequeue+reserve take — it always leaves the in-flight set,
+        /// and, when the item still has retry budget (<see cref="ShouldRetry"/>), atomically re-adds it to
+        /// the lanes at its original tier with RetryCount+1. This is the exact reverse of
+        /// <see cref="TryDequeuePriority"/>'s dequeue+reserve: doing the release and the lane-add under one
+        /// gate means the identity is never simultaneously in-flight AND queued, and a concurrent
+        /// re-request merges (via <see cref="MergeWork"/>) rather than duplicating. Returns true if the
+        /// item was re-queued, false if the retry budget was spent and it was dropped. Persists either way
+        /// so the transition is durable.
+        /// </summary>
+        internal bool RetryOrRelease(SubtitleWorkItem wi, int maxRetries)
+        {
+            var key = IdentityKey(wi.Item.Id, wi.Language);
+            lock (_dispatchGate)
+            {
+                var requeue = ShouldRetry(wi.RetryCount, maxRetries);
+                Release(key);
+                if (requeue)
+                {
+                    _lanes.Enqueue(key, (int)wi.Tier, new SubtitleWorkItem
+                    {
+                        Item = wi.Item,
+                        Language = wi.Language,
+                        Completion = null,   // any awaited completion was already signalled by the caller
+                        Force = wi.Force,
+                        Tier = wi.Tier,
+                        RetryCount = wi.RetryCount + 1
+                    }, MergeWork);
+                }
+                PersistQueue();
+                return requeue;
+            }
+        }
+
+        /// <summary>
+        /// Terminally drop an in-flight identity that reached a final state (completed successfully, or
+        /// given up on after exhausting retries, or unservable by any worker) and persist so queue.json no
+        /// longer lists it as in-flight — otherwise a crash would restore a finished item as pending. Under
+        /// the gate for a lanes+in-flight snapshot consistent with enqueue/dequeue. The RETRY path never
+        /// uses this — it moves the item back to the lanes (see <see cref="RetryOrRelease"/>).
+        /// </summary>
+        [ExcludeFromCodeCoverage(Justification = "Release + PersistQueue (requires Plugin.Instance) — persistence orchestration")]
+        private void ReleaseInFlightAndPersist(string key)
+        {
+            lock (_dispatchGate)
+            {
+                Release(key);
+                PersistQueue();
+            }
+        }
 
         [ExcludeFromCodeCoverage(Justification = "Requires Plugin.Instance")]
         private static string QueueFilePath
@@ -311,11 +419,12 @@ namespace WhisperSubs.Controller
             {
                 if (_lanes.TryDequeue(out var dequeued) && dequeued != null)
                 {
-                    // Reserve it in-flight. Honour the result: TryReserve returns false only if the identity
-                    // is already in-flight, which under _dispatchGate cannot happen for a freshly-dequeued
-                    // item — but if it ever did, drop this copy rather than double-dispatch. queue.json is
-                    // persisted either way (the item left the lanes).
-                    var reserved = TryReserve(IdentityKey(dequeued.Item.Id, dequeued.Language));
+                    // Reserve it in-flight, retaining the work item so the lease is persistable/recoverable.
+                    // Honour the result: TryReserve returns false only if the identity is already in-flight,
+                    // which under _dispatchGate cannot happen for a freshly-dequeued item — but if it ever
+                    // did, drop this copy rather than double-dispatch. queue.json is persisted either way
+                    // (the item left the lanes).
+                    var reserved = TryReserve(IdentityKey(dequeued.Item.Id, dequeued.Language), dequeued);
                     PersistQueue();
                     if (reserved)
                     {
@@ -340,11 +449,19 @@ namespace WhisperSubs.Controller
             try
             {
                 var json = File.ReadAllText(path);
-                var entries = JsonSerializer.Deserialize<List<QueueEntry>>(json);
-                if (entries == null || entries.Count == 0) return 0;
+
+                // Parse either shape: v2 = { Version, Pending[], InFlight[] }; legacy v1 = a bare
+                // QueueEntry[]. The interrupted in-flight leases are restored as Pending too — they were
+                // running (not completed) when the snapshot was taken, so they must be redone; an
+                // already-satisfied one is a cheap no-op thanks to GenerateSubtitleAsync's existing-file
+                // skip (#82). Pending is restored first so, if the same identity appears in both lists
+                // (it should not, but be safe), the lane dedup collapses them and we never double-restore.
+                var (pending, inFlight) = ParseQueueFile(json);
+                var total = pending.Count + inFlight.Count;
+                if (total == 0) return 0;
 
                 int restored = 0;
-                foreach (var entry in entries)
+                foreach (var entry in pending.Concat(inFlight))
                 {
                     if (!System.Guid.TryParse(entry.ItemId, out var guid)) continue;
                     var item = libraryManager.GetItemById(guid);
@@ -354,20 +471,25 @@ namespace WhisperSubs.Controller
                     var key = IdentityKey(item.Id, entry.Language);
 
                     // A queue.json with the same (item, language) more than once must not re-run every
-                    // copy — de-dup the restored set too, keeping the strongest tier / OR'd force.
+                    // copy — de-dup the restored set too, keeping the strongest tier / OR'd force / larger
+                    // retry count. The retry budget carries over so a chronically-failing item is not given
+                    // a fresh set of attempts on every restart.
                     var outcome = _lanes.Enqueue(key, (int)tier, new SubtitleWorkItem
                     {
                         Item = item,
                         Language = entry.Language,
                         Completion = null,
                         Force = entry.Force,
-                        Tier = tier
+                        Tier = tier,
+                        RetryCount = entry.RetryCount
                     }, MergeWork);
 
                     if (outcome == LaneEnqueueOutcome.Added) restored++;
                 }
 
-                logger.LogInformation("[Queue] Restored {Count} items from disk (of {Total} saved)", restored, entries.Count);
+                logger.LogInformation(
+                    "[Queue] Restored {Count} items from disk ({Pending} pending + {InFlight} interrupted in-flight re-queued, of {Total} saved)",
+                    restored, pending.Count, inFlight.Count, total);
                 return restored;
             }
             catch (System.Exception ex)
@@ -375,6 +497,32 @@ namespace WhisperSubs.Controller
                 logger.LogWarning(ex, "[Queue] Failed to restore queue from {Path}", path);
                 return 0;
             }
+        }
+
+        /// <summary>
+        /// Parse queue.json in either shape (whisper-subs-1t0). v2 is a top-level object
+        /// <c>{ Version, Pending[], InFlight[] }</c>; legacy v1 is a bare <see cref="QueueEntry"/> array
+        /// (no wrapper) whose entries are all pending. Disambiguated by the first non-whitespace character
+        /// (<c>[</c> = array = v1). Pure (string in, two lists out) so the version dispatch and the legacy
+        /// fallback are unit-testable without Plugin.Instance / a library. An empty document yields two
+        /// empty lists; a malformed one throws <see cref="JsonException"/> (caught + logged by the caller,
+        /// preserving the pre-existing "warn on a corrupt queue.json" behaviour).
+        /// </summary>
+        internal static (List<QueueEntry> Pending, List<QueueEntry> InFlight) ParseQueueFile(string json)
+        {
+            if (string.IsNullOrWhiteSpace(json))
+                return (new List<QueueEntry>(), new List<QueueEntry>());
+
+            if (json.TrimStart().StartsWith('['))
+            {
+                var legacy = JsonSerializer.Deserialize<List<QueueEntry>>(json) ?? new List<QueueEntry>();
+                return (legacy, new List<QueueEntry>());
+            }
+
+            var file = JsonSerializer.Deserialize<QueueFile>(json);
+            return file == null
+                ? (new List<QueueEntry>(), new List<QueueEntry>())
+                : (file.Pending ?? new List<QueueEntry>(), file.InFlight ?? new List<QueueEntry>());
         }
 
         [ExcludeFromCodeCoverage(Justification = "Requires Plugin.Instance for file path")]
@@ -385,15 +533,30 @@ namespace WhisperSubs.Controller
 
             try
             {
-                var entries = _lanes.Snapshot().Select(e => new QueueEntry
+                // Persist BOTH the pending lanes AND the in-flight leases (whisper-subs-1t0) so a job that
+                // was dequeued-and-running survives a restart instead of being silently dropped. Pending
+                // tier comes from the lane (authoritative for position); in-flight tier from the work item.
+                var pending = _lanes.Snapshot().Select(e => new QueueEntry
                 {
                     ItemId = e.Value.Item.Id.ToString("N"),
                     Language = e.Value.Language,
                     Force = e.Value.Force,
-                    Tier = e.Tier
+                    Tier = e.Tier,
+                    RetryCount = e.Value.RetryCount
                 }).ToList();
 
-                var json = JsonSerializer.Serialize(entries);
+                var inFlight = _inFlight.Values
+                    .Where(w => w != null)
+                    .Select(w => new QueueEntry
+                    {
+                        ItemId = w!.Item.Id.ToString("N"),
+                        Language = w.Language,
+                        Force = w.Force,
+                        Tier = (int)w.Tier,
+                        RetryCount = w.RetryCount
+                    }).ToList();
+
+                var json = JsonSerializer.Serialize(new QueueFile { Version = 2, Pending = pending, InFlight = inFlight });
                 lock (_fileLock)
                 {
                     // Atomic write (v4.0.1): serialize to a unique temp file then File.Move(overwrite) so a
@@ -452,7 +615,7 @@ namespace WhisperSubs.Controller
                         var pool = GetPool(config, loggerFactory, forTask: false);
                         var requirements = WorkerJob.Requirements(config.SubtitleMode, config.EnableTranslation);
                         started = true;
-                        await DispatchDrainAsync(manager, pool, requirements, countProcessed: true, logger, cancellationToken);
+                        await DispatchDrainAsync(manager, pool, requirements, countProcessed: true, config.JobMaxRetries, logger, cancellationToken);
                     }
                     catch (System.Exception ex)
                     {
@@ -495,6 +658,7 @@ namespace WhisperSubs.Controller
             WorkerPool pool,
             JobRequirements requirements,
             bool countProcessed,
+            int maxRetries,
             ILogger logger,
             CancellationToken cancellationToken)
         {
@@ -513,7 +677,10 @@ namespace WhisperSubs.Controller
                     _lastError = $"{unservable.Item.Name}: no configured worker can serve this job";
                     unservable.Completion?.TrySetException(
                         new System.InvalidOperationException("No configured worker can serve this job"));
-                    Release(IdentityKey(unservable.Item.Id, unservable.Language));
+                    // Deterministic fail-fast (broken config), NOT a transient kill — do not retry, just
+                    // drop it. Release AND persist so the interrupted-in-flight snapshot on disk no longer
+                    // lists it (otherwise it would restore as pending and re-fail every startup).
+                    ReleaseInFlightAndPersist(IdentityKey(unservable.Item.Id, unservable.Language));
                     logger.LogError("[Dispatch] No capable worker for {ItemName} — skipping", unservable.Item.Name);
                 }
                 _currentItemName = null;
@@ -551,16 +718,30 @@ namespace WhisperSubs.Controller
                     // the slot. Cancellation is observed INSIDE, via the token passed to the transcription.
                     running.Add(Task.Run(async () =>
                     {
+                        var key = IdentityKey(wi.Item.Id, wi.Language);
                         try
                         {
                             await manager.GenerateSubtitleAsync(
                                 wi.Item, l.Worker.Provider, wi.Language, cancellationToken, wi.Force);
                             if (countProcessed) Interlocked.Increment(ref _processedCount);
                             wi.Completion?.TrySetResult(true);
+                            // Completed — release the in-flight lease and persist so a crash can't restore
+                            // a finished item as pending. (whisper-subs-1t0.)
+                            ReleaseInFlightAndPersist(key);
                         }
                         catch (System.OperationCanceledException)
                         {
+                            // Cancelled = task stopped or Jellyfin restart mid-transcription. This is the
+                            // very case that used to silently drop an item (the #1 bug). Re-queue it for a
+                            // bounded retry instead of losing it; RetryOrRelease moves it lanes⇄in-flight
+                            // atomically under the gate (never both, never neither).
                             wi.Completion?.TrySetCanceled();
+                            if (RetryOrRelease(wi, maxRetries))
+                                logger.LogWarning("[Dispatch] {ItemName} was cancelled (task stopped / restart) — re-queued to retry (retry {Retry} of {Max})",
+                                    wi.Item.Name, wi.RetryCount + 1, maxRetries);
+                            else
+                                logger.LogWarning("[Dispatch] Giving up on {ItemName} after {Attempts} attempt(s) — cancelled and out of retries",
+                                    wi.Item.Name, wi.RetryCount + 1);
                         }
                         catch (System.Exception ex)
                         {
@@ -569,10 +750,20 @@ namespace WhisperSubs.Controller
                             _lastError = $"{wi.Item.Name}: {ex.Message}";
                             wi.Completion?.TrySetException(ex);
                             logger.LogError(ex, "[Dispatch] Failed: {ItemName}", wi.Item.Name);
+                            // Transient failure (whisper crash, unreachable worker, …) — bounded auto-retry.
+                            if (RetryOrRelease(wi, maxRetries))
+                                logger.LogWarning("[Dispatch] {ItemName} failed — re-queued to retry (retry {Retry} of {Max})",
+                                    wi.Item.Name, wi.RetryCount + 1, maxRetries);
+                            else
+                                logger.LogWarning("[Dispatch] Giving up on {ItemName} after {Attempts} attempt(s) — it keeps failing",
+                                    wi.Item.Name, wi.RetryCount + 1);
                         }
                         finally
                         {
-                            Release(IdentityKey(wi.Item.Id, wi.Language));
+                            // Only the worker SLOT is freed here (always). The in-flight (item,language)
+                            // reservation is released along the success/retry/drop paths above — NOT here —
+                            // so a re-queued item that was already re-dequeued+reserved by another slot is
+                            // not wrongly un-reserved (which would let it dispatch twice).
                             pool.Release(l.Key, wi.Item.Name);
                         }
                     }));
@@ -604,12 +795,13 @@ namespace WhisperSubs.Controller
             SubtitleManager manager,
             WorkerPool pool,
             JobRequirements requirements,
+            int maxRetries,
             ILogger logger,
             CancellationToken cancellationToken)
         {
             // countProcessed:false — the old priority drain did not add to _processedCount (only the
             // background loop did), so the /Queue `processed` stat stays byte-identical to pre-v4.
-            await DispatchDrainAsync(manager, pool, requirements, countProcessed: false, logger, cancellationToken);
+            await DispatchDrainAsync(manager, pool, requirements, countProcessed: false, maxRetries, logger, cancellationToken);
             _currentItemName = null;
         }
     }

--- a/ScheduledTasks/SubtitleGenerationTask.cs
+++ b/ScheduledTasks/SubtitleGenerationTask.cs
@@ -112,7 +112,7 @@ namespace WhisperSubs.ScheduledTasks
             if (restored > 0)
             {
                 _logger.LogInformation("Draining {Count} restored priority items before auto-generation", restored);
-                await queue.DrainPriorityAsync(manager, pool, requirements, _logger, cancellationToken);
+                await queue.DrainPriorityAsync(manager, pool, requirements, config.JobMaxRetries, _logger, cancellationToken);
             }
 
             // Collect items — the query is fast (DB lookup), no bulk in-memory storage needed
@@ -240,7 +240,7 @@ namespace WhisperSubs.ScheduledTasks
                 if (queue.PriorityCount > 0)
                 {
                     _logger.LogInformation("Pausing auto-generation to process {Count} priority request(s)", queue.PriorityCount);
-                    await queue.DrainPriorityAsync(manager, pool, requirements, _logger, cancellationToken);
+                    await queue.DrainPriorityAsync(manager, pool, requirements, config.JobMaxRetries, _logger, cancellationToken);
                 }
 
                 var (item, libName) = allItems[i];
@@ -430,7 +430,7 @@ namespace WhisperSubs.ScheduledTasks
                     {
                         pool.Release(lease.Key);
                         _logger.LogInformation("Yielding worker slot to {Count} priority request(s) before the next swept item", queue.PriorityCount);
-                        await queue.DrainPriorityAsync(manager, pool, requirements, _logger, cancellationToken);
+                        await queue.DrainPriorityAsync(manager, pool, requirements, config.JobMaxRetries, _logger, cancellationToken);
                         lease = await pool.AcquireAsync(requirements, cancellationToken);
                     }
 

--- a/ScheduledTasks/SubtitleGenerationTask.cs
+++ b/ScheduledTasks/SubtitleGenerationTask.cs
@@ -107,8 +107,10 @@ namespace WhisperSubs.ScheduledTasks
             var pool = queue.GetPool(config, _loggerFactory, forTask: true);
             var requirements = WorkerJob.Requirements(config.SubtitleMode, config.EnableTranslation);
 
-            // Restore persisted queue from disk (survives restarts)
-            var restored = queue.RestoreQueue(_libraryManager, _logger);
+            // Restore persisted queue from disk (survives restarts). Pass the retry cap so an in-flight lease
+            // that was killed mid-transcription is restored as one consumed attempt (RetryCount+1) and given
+            // up on once out of budget — otherwise an item that OOM-kills every run boot-loops the queue.
+            var restored = queue.RestoreQueue(_libraryManager, _logger, config.JobMaxRetries);
             if (restored > 0)
             {
                 _logger.LogInformation("Draining {Count} restored priority items before auto-generation", restored);

--- a/WhisperSubs.Tests/QueueRetryAndRestoreTests.cs
+++ b/WhisperSubs.Tests/QueueRetryAndRestoreTests.cs
@@ -209,4 +209,155 @@ public class QueueRetryAndRestoreTests
         Assert.Equal(1, queue.PriorityCount);
         Assert.True(queue.TryReserve(key));   // proves it left the in-flight set
     }
+
+    // ── Bounded in-flight restore (whisper-subs-1t0 Fix 1 — the hard-kill boot-loop guard) ──
+
+    private static Func<Guid, BaseItem?> Resolver(params BaseItem[] items)
+    {
+        var byId = items.ToDictionary(i => i.Id);
+        return id => byId.GetValueOrDefault(id);
+    }
+
+    private static QueueEntry NewEntry(BaseItem item, int retryCount, string language = "en",
+        PriorityTier tier = PriorityTier.High, bool force = false)
+        => new QueueEntry
+        {
+            ItemId = item.Id.ToString("N"),
+            Language = language,
+            Force = force,
+            Tier = (int)tier,
+            RetryCount = retryCount
+        };
+
+    [Theory]
+    // Pending (wasInFlight=false) is ALWAYS restored, whatever its count — it never started.
+    [InlineData(false, 0, 3, true)]
+    [InlineData(false, 3, 3, true)]
+    [InlineData(false, 99, 3, true)]
+    // In-flight (wasInFlight=true) restores only while strictly under the cap (one attempt already consumed).
+    [InlineData(true, 0, 3, true)]
+    [InlineData(true, 2, 3, true)]    // maxRetries-1 → still restored (at +1)
+    [InlineData(true, 3, 3, false)]   // at the cap → dropped
+    [InlineData(true, 4, 3, false)]   // over the cap → dropped
+    [InlineData(true, 0, 0, false)]   // retry disabled → a killed in-flight lease is dropped
+    public void ShouldRestore_TruthTable(bool wasInFlight, int retryCount, int maxRetries, bool expected)
+        => Assert.Equal(expected, SubtitleQueueService.ShouldRestore(wasInFlight, retryCount, maxRetries));
+
+    [Theory]
+    [InlineData(false, 0, 0)]   // Pending: unchanged (never started)
+    [InlineData(false, 2, 2)]   // Pending: unchanged
+    [InlineData(true, 0, 1)]    // In-flight: +1 (one attempt consumed)
+    [InlineData(true, 2, 3)]    // In-flight: +1
+    public void RestoredRetryCount_PendingUnchanged_InFlightPlusOne(bool wasInFlight, int retryCount, int expected)
+        => Assert.Equal(expected, SubtitleQueueService.RestoredRetryCount(wasInFlight, retryCount));
+
+    [Fact]
+    public void RestoreFromEntries_InFlightConsumesOneAttempt_PendingUnchanged_OverCapDropped()
+    {
+        // The highest-value test — the exact case Fix 1 exists for: an in-flight lease at the cap must NOT be
+        // restored (else it OOM-kills, restores, OOM-kills … a boot-loop that wedges ALL generation), one under
+        // the cap comes back at +1 (its kill counted as an attempt), and a Pending item keeps its count.
+        const int maxRetries = 3;
+        var queue = new SubtitleQueueService();
+
+        var pending = NewItem("Pending");                 // Pending at rc=2 → restored at 2 (unchanged)
+        var inflightBudget = NewItem("InFlightBudget");   // In-flight at rc=2 (=max-1) → restored at 3
+        var inflightAtCap = NewItem("InFlightAtCap");     // In-flight at rc=3 (=max)  → DROPPED, not restored
+
+        var (restored, givenUp) = queue.RestoreFromEntries(
+            pending: new List<QueueEntry> { NewEntry(pending, retryCount: 2) },
+            inFlight: new List<QueueEntry>
+            {
+                NewEntry(inflightBudget, retryCount: maxRetries - 1),
+                NewEntry(inflightAtCap, retryCount: maxRetries)
+            },
+            maxRetries: maxRetries,
+            resolveItem: Resolver(pending, inflightBudget, inflightAtCap));
+
+        Assert.Equal(2, restored);                          // pending + inflightBudget; inflightAtCap dropped
+        Assert.Single(givenUp);
+        Assert.Equal("InFlightAtCap", givenUp[0].Name);
+        Assert.Equal(maxRetries, givenUp[0].RetryCount);    // reported at its prior (spent) count
+        Assert.Equal(2, queue.PriorityCount);
+
+        // Drain and confirm the restored RetryCounts.
+        var counts = new Dictionary<string, int>();
+        while (queue.TryDequeuePriority(out var wi) && wi != null)
+            counts[wi.Item.Name] = wi.RetryCount;
+
+        Assert.Equal(2, counts["Pending"]);                 // Pending: unchanged (never started)
+        Assert.Equal(maxRetries, counts["InFlightBudget"]); // In-flight: RetryCount+1 (one attempt consumed)
+        Assert.False(counts.ContainsKey("InFlightAtCap"));  // dropped — never re-enters the lanes
+    }
+
+    [Fact]
+    public void RestoreFromEntries_SameIdentityInPendingAndInFlight_CollapsesToOneLaneEntry()
+    {
+        // Pending∩InFlight overlap (should-not-happen, but be safe): the same identity in BOTH lists restores
+        // as ONE lane entry (merge, not double). Pending is processed first; the in-flight copy (rc+1) merges
+        // onto it via the lane dedup, and MergeWork keeps the larger retry count.
+        var queue = new SubtitleQueueService();
+        var item = NewItem("Overlap");
+
+        var (restored, givenUp) = queue.RestoreFromEntries(
+            pending: new List<QueueEntry> { NewEntry(item, retryCount: 0) },
+            inFlight: new List<QueueEntry> { NewEntry(item, retryCount: 0) },
+            maxRetries: 3,
+            resolveItem: Resolver(item));
+
+        Assert.Equal(1, restored);                 // ONE lane entry, not two
+        Assert.Empty(givenUp);
+        Assert.Equal(1, queue.PriorityCount);
+
+        Assert.True(queue.TryDequeuePriority(out var wi));
+        Assert.Same(item, wi!.Item);
+        Assert.Equal(1, wi.RetryCount);            // in-flight copy's rc+1 (=1) wins the merge over pending's 0
+    }
+
+    [Fact]
+    public void RestoreFromEntries_SkipsUnparseableGuidAndMissingItem_RestoresTheRest()
+    {
+        var queue = new SubtitleQueueService();
+        var present = NewItem("Present");
+        var missing = NewItem("Missing");   // deliberately NOT known to the resolver
+
+        var (restored, givenUp) = queue.RestoreFromEntries(
+            pending: new List<QueueEntry>
+            {
+                new QueueEntry { ItemId = "not-a-guid", Language = "en", Tier = (int)PriorityTier.High },
+                NewEntry(missing, retryCount: 0),   // resolver returns null → skipped
+                NewEntry(present, retryCount: 0)    // restored
+            },
+            inFlight: new List<QueueEntry>(),
+            maxRetries: 3,
+            resolveItem: Resolver(present));        // only 'present' resolves
+
+        Assert.Equal(1, restored);
+        Assert.Empty(givenUp);
+        Assert.Equal(1, queue.PriorityCount);
+    }
+
+    [Fact]
+    public void RestoreFromEntries_TierlessInFlightLease_NormalizesToHigh_AndRestoresAtPlusOne()
+    {
+        // A legacy tier-less in-flight entry (Tier null) still normalizes to High (NOT Critical) AND obeys the
+        // in-flight +1 rule — the #112 migration rule and the 1t0 budget rule compose correctly.
+        var queue = new SubtitleQueueService();
+        var item = NewItem("Legacy");
+
+        var (restored, givenUp) = queue.RestoreFromEntries(
+            pending: new List<QueueEntry>(),
+            inFlight: new List<QueueEntry>
+            {
+                new QueueEntry { ItemId = item.Id.ToString("N"), Language = "en", Tier = null, RetryCount = 0 }
+            },
+            maxRetries: 3,
+            resolveItem: Resolver(item));
+
+        Assert.Equal(1, restored);
+        Assert.Empty(givenUp);
+        Assert.True(queue.TryDequeuePriority(out var wi));
+        Assert.Equal(PriorityTier.High, wi!.Tier);   // tier-less → High
+        Assert.Equal(1, wi.RetryCount);              // in-flight → +1
+    }
 }

--- a/WhisperSubs.Tests/QueueRetryAndRestoreTests.cs
+++ b/WhisperSubs.Tests/QueueRetryAndRestoreTests.cs
@@ -1,0 +1,212 @@
+using System.Text.Json;
+using MediaBrowser.Controller.Entities;
+using WhisperSubs.Controller;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+/// <summary>
+/// whisper-subs-1t0 — queue robustness: bounded auto-retry of killed/failed jobs and lossless restart via
+/// persisted in-flight leases. Pins the pure retry decision (<see cref="SubtitleQueueService.ShouldRetry"/>),
+/// the queue.json v1/v2 parse (<see cref="SubtitleQueueService.ParseQueueFile"/>), and the cancel/failure
+/// re-enqueue transition (<see cref="SubtitleQueueService.RetryOrRelease"/>). Uses fresh service instances
+/// (as <c>SubtitleQueueDedupTests</c> does) so each test starts clean; with no <c>Plugin.Instance</c> the
+/// queue.json persistence is a disk-free no-op.
+/// </summary>
+public class QueueRetryAndRestoreTests
+{
+    private static Video NewItem(string name = "Film") => new Video { Id = Guid.NewGuid(), Name = name };
+
+    // ── ShouldRetry truth table (retryCount 0..max, maxRetries incl. 0 and negative = disabled) ──
+
+    [Theory]
+    [InlineData(0, 0, false)]   // maxRetries 0 = auto-retry disabled = pre-feature "drop a killed job"
+    [InlineData(1, 0, false)]
+    [InlineData(0, -1, false)]  // any maxRetries <= 0 disables
+    [InlineData(0, 1, true)]
+    [InlineData(1, 1, false)]   // budget of 1 spent after the first retry
+    [InlineData(0, 3, true)]
+    [InlineData(1, 3, true)]
+    [InlineData(2, 3, true)]
+    [InlineData(3, 3, false)]   // 3 retries used → give up (4th attempt not taken)
+    [InlineData(4, 3, false)]
+    public void ShouldRetry_TruthTable(int retryCount, int maxRetries, bool expected)
+        => Assert.Equal(expected, SubtitleQueueService.ShouldRetry(retryCount, maxRetries));
+
+    // ── ParseQueueFile: v2 object shape, legacy v1 bare array, empty ──
+
+    [Fact]
+    public void ParseQueueFile_V2_SplitsPendingAndInFlight_PreservingTierForceRetry()
+    {
+        // A queue with BOTH pending and in-flight items survives a serialize/deserialize round-trip.
+        var file = new QueueFile
+        {
+            Version = 2,
+            Pending = new List<QueueEntry>
+            {
+                new QueueEntry { ItemId = "a", Language = "en", Force = false, Tier = (int)PriorityTier.High, RetryCount = 0 }
+            },
+            InFlight = new List<QueueEntry>
+            {
+                new QueueEntry { ItemId = "b", Language = "es", Force = true, Tier = (int)PriorityTier.Critical, RetryCount = 2 }
+            }
+        };
+        var json = JsonSerializer.Serialize(file);
+
+        var (pending, inFlight) = SubtitleQueueService.ParseQueueFile(json);
+
+        Assert.Single(pending);
+        Assert.Single(inFlight);
+        Assert.Equal("a", pending[0].ItemId);
+        Assert.Equal((int)PriorityTier.High, pending[0].Tier);
+
+        // The in-flight lease comes back with its tier/force/retry intact so RestoreQueue can re-enqueue
+        // it as Pending at the RIGHT tier (and keep its retry budget).
+        Assert.Equal("b", inFlight[0].ItemId);
+        Assert.Equal("es", inFlight[0].Language);
+        Assert.True(inFlight[0].Force);
+        Assert.Equal((int)PriorityTier.Critical, inFlight[0].Tier);
+        Assert.Equal(2, inFlight[0].RetryCount);
+    }
+
+    [Fact]
+    public void ParseQueueFile_V2_HandWrittenPascalCase_IsRead()
+    {
+        // Pins the actual on-disk field names the persister writes (default PascalCase serialization).
+        var json = "{\"Version\":2," +
+                   "\"Pending\":[{\"ItemId\":\"p\",\"Language\":\"en\",\"Force\":false,\"Tier\":1,\"RetryCount\":0}]," +
+                   "\"InFlight\":[{\"ItemId\":\"f\",\"Language\":\"de\",\"Force\":true,\"Tier\":0,\"RetryCount\":1}]}";
+
+        var (pending, inFlight) = SubtitleQueueService.ParseQueueFile(json);
+
+        Assert.Single(pending);
+        Assert.Single(inFlight);
+        Assert.Equal("f", inFlight[0].ItemId);
+        Assert.True(inFlight[0].Force);
+        Assert.Equal(1, inFlight[0].RetryCount);
+    }
+
+    [Fact]
+    public void ParseQueueFile_LegacyV1BareArray_AllPending_NoInFlight_TierlessNormalizesToHigh()
+    {
+        // A pre-feature queue.json is a bare array with no wrapper and no Tier / RetryCount fields.
+        var json = "[{\"ItemId\":\"abc\",\"Language\":\"en\",\"Force\":true}]";
+
+        var (pending, inFlight) = SubtitleQueueService.ParseQueueFile(json);
+
+        Assert.Single(pending);
+        Assert.Empty(inFlight);              // legacy has no in-flight concept
+        Assert.Equal("abc", pending[0].ItemId);
+        Assert.True(pending[0].Force);
+        Assert.Null(pending[0].Tier);        // tier-less
+        Assert.Equal(0, pending[0].RetryCount); // missing field → 0 (a fresh job)
+
+        // …and the tier-less entry still normalizes to High (NOT Critical), preserving the #112 rule.
+        Assert.Equal(PriorityTier.High, PriorityScheduling.NormalizeRestoredTier(pending[0].Tier));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\n\t")]
+    public void ParseQueueFile_EmptyOrWhitespace_YieldsTwoEmptyLists(string json)
+    {
+        var (pending, inFlight) = SubtitleQueueService.ParseQueueFile(json);
+        Assert.Empty(pending);
+        Assert.Empty(inFlight);
+    }
+
+    // ── RetryOrRelease: bounded re-enqueue on cancel/failure ──
+
+    [Fact]
+    public void RetryOrRelease_UnderMax_ReQueuesAtSameTier_WithIncrementedRetryCount()
+    {
+        var queue = new SubtitleQueueService();
+        var item = NewItem();
+
+        Assert.True(queue.Enqueue(item, "en", PriorityTier.High));   // fresh request: RetryCount 0
+        Assert.True(queue.TryDequeuePriority(out var dispatched));   // now in-flight
+        Assert.Equal(0, dispatched!.RetryCount);
+
+        // Cancelled/failed with retry budget remaining → moved back to the lanes, dispatchable again.
+        Assert.True(queue.RetryOrRelease(dispatched, maxRetries: 3));
+        Assert.Equal(1, queue.PriorityCount);
+
+        Assert.True(queue.TryDequeuePriority(out var again));
+        Assert.Same(item, again!.Item);
+        Assert.Equal(PriorityTier.High, again.Tier);   // original tier preserved
+        Assert.Equal(1, again.RetryCount);             // incremented
+    }
+
+    [Fact]
+    public void RetryOrRelease_AtMax_DropsInsteadOfReQueue_AndReleasesIdentity()
+    {
+        var queue = new SubtitleQueueService();
+        var item = NewItem();
+        var key = SubtitleQueueService.IdentityKey(item.Id, "en");
+
+        // An item that has already used its whole retry budget (RetryCount == maxRetries).
+        var wi = new SubtitleWorkItem { Item = item, Language = "en", Tier = PriorityTier.High, RetryCount = 3 };
+        Assert.True(queue.TryReserve(key, wi));   // in-flight
+
+        Assert.False(queue.RetryOrRelease(wi, maxRetries: 3));   // give up
+        Assert.Equal(0, queue.PriorityCount);                    // NOT re-queued
+
+        // Identity was released → a brand-new request for it can be reserved again (no leak).
+        Assert.True(queue.TryReserve(key, wi));
+    }
+
+    [Fact]
+    public void RetryOrRelease_MaxRetriesZero_NeverReQueues_IsOptOut()
+    {
+        var queue = new SubtitleQueueService();
+        var item = NewItem();
+
+        Assert.True(queue.Enqueue(item, "en", PriorityTier.Medium));
+        Assert.True(queue.TryDequeuePriority(out var dispatched));
+
+        // 0 = auto-retry disabled = the pre-feature "a killed/failed job is dropped" behaviour.
+        Assert.False(queue.RetryOrRelease(dispatched!, maxRetries: 0));
+        Assert.Equal(0, queue.PriorityCount);
+    }
+
+    [Fact]
+    public void RetryOrRelease_ThenConcurrentReRequest_Merges_AndKeepsLargerRetryCount()
+    {
+        var queue = new SubtitleQueueService();
+        var item = NewItem();
+
+        Assert.True(queue.Enqueue(item, "en", PriorityTier.Medium));    // RetryCount 0
+        Assert.True(queue.TryDequeuePriority(out var dispatched));      // in-flight
+        Assert.True(queue.RetryOrRelease(dispatched!, maxRetries: 3));  // re-queued at RetryCount 1
+
+        // A fresh admin request for the SAME identity while it's queued must merge (not duplicate) and must
+        // NOT reset the retry budget — Force OR'd, tier promoted, retry count kept at the larger value.
+        Assert.False(queue.Enqueue(item, "en", PriorityTier.Critical, force: true));  // merged, not added
+        Assert.Equal(1, queue.PriorityCount);
+
+        Assert.True(queue.TryDequeuePriority(out var merged));
+        Assert.True(merged!.Force);
+        Assert.Equal(PriorityTier.Critical, merged.Tier);
+        Assert.Equal(1, merged.RetryCount);   // NOT reset to 0 by the fresh request
+    }
+
+    [Fact]
+    public void RetryOrRelease_ReQueuedItem_IsInFlightXorQueued_AtEachStep()
+    {
+        // The reverse transition must never leave the identity both in-flight AND queued.
+        var queue = new SubtitleQueueService();
+        var item = NewItem();
+        var key = SubtitleQueueService.IdentityKey(item.Id, "en");
+
+        Assert.True(queue.Enqueue(item, "en", PriorityTier.High));
+        Assert.True(queue.TryDequeuePriority(out var dispatched));
+        // In-flight now → a re-request is rejected (reservation held).
+        Assert.False(queue.TryReserve(key));
+
+        Assert.True(queue.RetryOrRelease(dispatched!, maxRetries: 3));
+        // Back in the lanes now → NOT in-flight, so the identity is reservable again (would be re-dequeued).
+        Assert.Equal(1, queue.PriorityCount);
+        Assert.True(queue.TryReserve(key));   // proves it left the in-flight set
+    }
+}


### PR DESCRIPTION
Bead **whisper-subs-1t0**: the queue silently dropped work when a job was cancelled/failed or Jellyfin restarted mid-transcription — a dequeued item is removed from queue.json and held only in the in-memory `_inFlight`, which `PersistQueue` never saved (this lost La fiebre del oro S6E01). Now the queue is robust.

**Two changes:**
1. **Persist in-flight leases (lossless restart):** `_inFlight` holds the full `SubtitleWorkItem`; `queue.json` is now **v2** `{Version,Pending,InFlight}` (still reads legacy v1 bare-array → all Pending, tier-less→High). `RestoreQueue` re-enqueues in-flight items as Pending at their original tier (RetryCount preserved — a restart doesn't burn the budget); the lane index collapses any pending∩in-flight overlap (no double-restore).
2. **Bounded auto-retry:** on cancel/failure a job is re-enqueued at its tier with RetryCount+1 while `ShouldRetry(retryCount, maxRetries)` (pure) holds; at the cap it's dropped with a clear log. Config `JobMaxRetries` (default 3; 0 = today's drop behaviour).

**Concurrency care:** the in-flight *release* moved out of the per-job `finally` onto the success/retry/drop paths (keeping it in `finally` would un-reserve an item a concurrent slot already re-dequeued → double-dispatch); the worker-slot release stays in `finally`. `RetryOrRelease` does Release+re-enqueue in one `_dispatchGate` critical section (exact reverse of the atomic dequeue+reserve) so an identity is never in-flight AND queued at once, and a concurrent re-request merges (keeps the larger RetryCount).

**933 tests pass (912 + 21 new QueueRetryAndRestoreTests), 0 warnings.** SubtitleQueueDedupTests (sole-dispatch invariant) still green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable retry limits for failed or interrupted transcription jobs.
  * Improved queue recovery so pending work can resume after a restart without duplicating completed items.

* **Bug Fixes**
  * Prevented jobs from being retried indefinitely.
  * Improved handling of interrupted and in-progress work to avoid losing or restoring tasks incorrectly.
  * Added support for older saved queue formats while restoring jobs safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->