### PR TITLE
feat: AudioLanguageSelection toggle + document multi-audio transcription (whisper-subs-v00)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,6 +258,7 @@ Version is read from `<Version>` in `WhisperSubs.csproj`. Bump there before push
 - FFprobe extracts `language` tags from audio streams. Normalization: 30+ ISO 639-2 -> 639-1 mappings in `SubtitleManager.NormalizeLanguageCode()`.
 - Dedup: multiple streams with same language produce only one SRT.
 - Fallback: files with no language tags get whisper auto-detection — one SRT with language `auto`.
+- Multi-audio selection (`AudioLanguageSelection`, default `All`): with `DefaultLanguage=auto` the plugin transcribes EVERY detected audio language (one `.<lang>.generated.srt` each). `PrimaryOnly` restricts the per-track full/forced passes to the primary track only, via the pure `SubtitleManager.SelectAudioLanguages(detected, selection)` applied to the `foreach (var lang in passLanguages)` in `GenerateSubtitleAsync`. It only narrows the auto multi-language case (a specific code or the no-tags `auto` fallback is single-element and untouched); the translation pass deliberately still sees the full `languages` list. Serialized by name (`JsonStringEnumConverter`).
 
 ## Config Page (Web UI)
 

--- a/Configuration/AudioLanguageSelection.cs
+++ b/Configuration/AudioLanguageSelection.cs
@@ -1,0 +1,30 @@
+using System.Text.Json.Serialization;
+
+namespace WhisperSubs.Configuration
+{
+    /// <summary>
+    /// Chooses which audio-track languages get transcribed when <see cref="PluginConfiguration.DefaultLanguage"/>
+    /// is "auto" and a file has MORE THAN ONE audio language. With "auto" the plugin detects every audio
+    /// track's language and, by default, transcribes each one (producing a <c>.&lt;lang&gt;.generated.srt</c>
+    /// per audio language). This toggle lets an admin restrict that to only the primary/default audio track.
+    /// Serialized by NAME over the config REST API (<see cref="JsonStringEnumConverter"/>); the config page
+    /// uses the string value.
+    /// </summary>
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum AudioLanguageSelection
+    {
+        /// <summary>
+        /// Transcribe EVERY detected audio-track language (default, existing behavior): one
+        /// <c>.&lt;lang&gt;.generated.srt</c> per audio language present.
+        /// </summary>
+        All = 0,
+
+        /// <summary>
+        /// Transcribe ONLY the primary (first-listed) audio track's language; secondary audio languages
+        /// are skipped. Only affects the "auto" multi-language case — a specific
+        /// <see cref="PluginConfiguration.DefaultLanguage"/> already resolves to a single language, and the
+        /// no-tags whisper-auto-detect fallback is already a single pass.
+        /// </summary>
+        PrimaryOnly = 1,
+    }
+}

--- a/Configuration/PluginConfiguration.cs
+++ b/Configuration/PluginConfiguration.cs
@@ -27,6 +27,17 @@ namespace WhisperSubs.Configuration
         public string DefaultLanguage { get; set; } = "auto";
 
         /// <summary>
+        /// When <see cref="DefaultLanguage"/> is "auto" and a file has multiple audio languages, controls
+        /// whether every audio-track language is transcribed (<see cref="AudioLanguageSelection.All"/>,
+        /// default — one <c>.&lt;lang&gt;.generated.srt</c> per language) or only the primary/default audio
+        /// track (<see cref="AudioLanguageSelection.PrimaryOnly"/>). Default All preserves existing behavior,
+        /// so an upgrade never changes what an install already produces. Has no effect when a specific
+        /// language is set (already one language) or when no audio language tags are found (a single whisper
+        /// auto-detect pass). Does not affect the English translation pass.
+        /// </summary>
+        public AudioLanguageSelection AudioLanguageSelection { get; set; } = AudioLanguageSelection.All;
+
+        /// <summary>
         /// Controls whether to generate full subtitles, forced-only subtitles, or both.
         /// </summary>
         [JsonConverter(typeof(SubtitleModeConverter))]

--- a/Controller/SubtitleManager.cs
+++ b/Controller/SubtitleManager.cs
@@ -234,6 +234,14 @@ namespace WhisperSubs.Controller
                 enableTranslation: config?.EnableTranslation == true,
                 force: force);
 
+            // Which audio-track languages the per-track passes below transcribe. PrimaryOnly restricts
+            // the "auto" multi-audio case to just the primary/default track; All (default) keeps every
+            // detected language. This is a no-op for a specific DefaultLanguage or the no-tags 'auto'
+            // fallback (both single-element). NOTE: the translation pass deliberately still sees the FULL
+            // `languages` list — it needs a non-English source even when the primary audio track is English.
+            var passLanguages = SelectAudioLanguages(
+                languages, config?.AudioLanguageSelection ?? AudioLanguageSelection.All);
+
             int attempted = 0;
             int failed = 0;
             Exception? firstError = null;
@@ -257,7 +265,7 @@ namespace WhisperSubs.Controller
 
             if (subtitleMode != SubtitleMode.TranslationOnly)
             {
-                foreach (var lang in languages)
+                foreach (var lang in passLanguages)
                 {
                     // Full (original-language transcription) pass.
                     if (plan.OriginalPassApplies)
@@ -336,6 +344,31 @@ namespace WhisperSubs.Controller
                 ForcedPassApplies: forcedPassApplies,
                 OriginalPassApplies: fullPassApplies && wantOriginal,
                 TranslationApplies: translationApplies);
+        }
+
+        /// <summary>
+        /// Pure selection of which detected audio-track languages the per-track (original-language +
+        /// forced) passes iterate over, given the <see cref="AudioLanguageSelection"/> toggle.
+        /// <list type="bullet">
+        /// <item><see cref="AudioLanguageSelection.All"/> (default) returns <paramref name="detected"/>
+        /// unchanged — one subtitle per audio language, the existing behavior.</item>
+        /// <item><see cref="AudioLanguageSelection.PrimaryOnly"/> keeps only the first/primary track's
+        /// language.</item>
+        /// </list>
+        /// A 0- or 1-element list is returned unchanged either way, so this only ever narrows the "auto"
+        /// multi-language case: a specific default language and the no-tags whisper-auto-detect fallback are
+        /// both single-element and therefore unaffected. Extracted so the choice is unit-testable without
+        /// <c>Plugin.Instance</c>.
+        /// </summary>
+        internal static IReadOnlyList<string> SelectAudioLanguages(
+            IReadOnlyList<string> detected, AudioLanguageSelection selection)
+        {
+            if (selection == AudioLanguageSelection.PrimaryOnly && detected.Count > 0)
+            {
+                return new[] { detected[0] };
+            }
+
+            return detected;
         }
 
         /// <summary>

--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ After installation, navigate to **Dashboard** > **Plugins** > **WhisperSubs** to
 | Setting | Description |
 |---|---|
 | **Default Language** | `Auto-detect` reads the language from each file's audio stream metadata and generates matching subtitles. Choose a specific language to force it for all transcriptions. |
+| **Audio Languages (auto-detect)** (`AudioLanguageSelection`) | Only applies with **Auto-detect** on a file that has more than one audio language. `All audio languages` (default) transcribes **every** audio track's language -- one `.<lang>.generated.srt` per language. `Primary audio track only` transcribes just the first/primary track and skips the others. A specific default language, or a file with no audio language tags, is unaffected. |
 | **Subtitle Mode** | Full, Forced Only, Full + Forced, or Translation Only. See [Subtitle Modes](#subtitle-modes) below. |
 | **Enable Auto-Generation** | When enabled, the scheduled task will scan selected libraries and generate subtitles for items that lack them. |
 | **Enabled Libraries** | Select which libraries should be monitored for automatic subtitle generation. |
@@ -417,6 +418,8 @@ After installation, navigate to **Dashboard** > **Plugins** > **WhisperSubs** to
 The plugin supports three language modes:
 
 1. **Auto-detect (recommended)** -- The plugin uses FFprobe to read the audio stream's language tag (e.g., `spa` → `es`, `eng` → `en`). Subtitles are generated in the language that matches the audio. If a file has multiple audio tracks in different languages, subtitles are generated for each one.
+
+   **Multiple audio languages.** By default (`AudioLanguageSelection = All`) every audio track's language is transcribed, producing one `.<lang>.generated.srt` per language (e.g. a Spanish + English file yields both `Movie.es.generated.srt` and `Movie.en.generated.srt`, each transcribed from its own audio track). Set **Audio Languages (auto-detect)** to `Primary audio track only` (`AudioLanguageSelection = PrimaryOnly`) to transcribe only the first/primary audio track and skip the secondary ones. This only affects auto-detect on multi-language files; a specific default language, or a file with no audio language tags, already resolves to a single track. The English translation pass is independent of this setting.
 
 2. **Whisper auto-detection** -- When no language metadata is available, the request falls through to whisper's built-in language detection (`-l auto`), which analyzes the first 30 seconds of audio.
 

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -132,6 +132,21 @@
                     </div>
 
                     <div class="selectContainer">
+                        <label class="selectLabel" for="selectAudioLanguageSelection">Audio languages (auto-detect)</label>
+                        <select is="emby-select" id="selectAudioLanguageSelection" name="AudioLanguageSelection">
+                            <option value="All">All audio languages</option>
+                            <option value="PrimaryOnly">Primary audio track only</option>
+                        </select>
+                        <div class="fieldDescription">
+                            Only applies when the language above is <strong>Auto-detect</strong> and a file has more than one audio language.
+                            <strong>All audio languages</strong> (default) transcribes every audio track's language &mdash; one
+                            <code>.&lt;lang&gt;.generated.srt</code> per language.
+                            <strong>Primary audio track only</strong> transcribes just the first/primary audio track and skips the others.
+                            A specific language above, or a file with no audio language tags, is unaffected (already a single track).
+                        </div>
+                    </div>
+
+                    <div class="selectContainer">
                         <label class="selectLabel" for="selectSubtitleMode">Subtitle Mode</label>
                         <select is="emby-select" id="selectSubtitleMode" name="SubtitleMode">
                             <option value="0">Full</option>
@@ -1331,6 +1346,7 @@
                             page.querySelector('#txtRemoteWhisperModel').value = config.RemoteWhisperModel || 'Systran/faster-whisper-large-v3';
                             page.querySelector('#txtRemoteWhisperApiKey').value = config.RemoteWhisperApiKey || '';
                             page.querySelector('#selectDefaultLanguage').value = config.DefaultLanguage || 'auto';
+                            page.querySelector('#selectAudioLanguageSelection').value = config.AudioLanguageSelection || 'All';
                             page.querySelector('#selectSubtitleMode').value = (config.SubtitleMode != null ? config.SubtitleMode : 0).toString();
                             page.querySelector('#chkEnableAutoGeneration').checked = config.EnableAutoGeneration || false;
                             page.querySelector('#chkEnableLyricsGeneration').checked = config.EnableLyricsGeneration || false;
@@ -1385,6 +1401,7 @@
                         config.RemoteWhisperModel = (page.querySelector('#txtRemoteWhisperModel').value || '').trim() || 'Systran/faster-whisper-large-v3';
                         config.RemoteWhisperApiKey = (page.querySelector('#txtRemoteWhisperApiKey').value || '').trim();
                         config.DefaultLanguage = page.querySelector('#selectDefaultLanguage').value || 'auto';
+                        config.AudioLanguageSelection = page.querySelector('#selectAudioLanguageSelection').value || 'All';
                         config.SubtitleMode = parseInt(page.querySelector('#selectSubtitleMode').value, 10) || 0;
                         config.EnableAutoGeneration = page.querySelector('#chkEnableAutoGeneration').checked;
                         config.EnableLyricsGeneration = page.querySelector('#chkEnableLyricsGeneration').checked;

--- a/WhisperSubs.Tests/AudioLanguageSelectionTests.cs
+++ b/WhisperSubs.Tests/AudioLanguageSelectionTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using WhisperSubs.Configuration;
+using WhisperSubs.Controller;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+/// <summary>
+/// Locks the truth table for <see cref="SubtitleManager.SelectAudioLanguages"/> — which detected
+/// audio-track languages the per-track (original-language + forced) passes iterate over, given the
+/// <see cref="AudioLanguageSelection"/> toggle. The key contract: <c>All</c> is a pass-through and a
+/// 0/1-element list is untouched either way, so <c>PrimaryOnly</c> only ever narrows the "auto"
+/// multi-language case (a specific default language and the no-tags fallback are single-element).
+/// </summary>
+public class AudioLanguageSelectionTests
+{
+    // ---- All: pass-through, including empty and single-element ----------------------------------
+
+    [Fact]
+    public void All_ReturnsEveryDetectedLanguage()
+    {
+        var detected = new[] { "es", "en", "fr" };
+        var result = SubtitleManager.SelectAudioLanguages(detected, AudioLanguageSelection.All);
+        Assert.Equal(new[] { "es", "en", "fr" }, result);
+    }
+
+    [Fact]
+    public void All_Empty_ReturnsEmpty()
+    {
+        var result = SubtitleManager.SelectAudioLanguages(Array.Empty<string>(), AudioLanguageSelection.All);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void All_SingleElement_ReturnsThatElement()
+    {
+        var result = SubtitleManager.SelectAudioLanguages(new[] { "es" }, AudioLanguageSelection.All);
+        Assert.Equal(new[] { "es" }, result);
+    }
+
+    // ---- PrimaryOnly: keep only the first/primary track's language ------------------------------
+
+    [Fact]
+    public void PrimaryOnly_MultipleLanguages_KeepsOnlyTheFirst()
+    {
+        var detected = new[] { "es", "en", "fr" };
+        var result = SubtitleManager.SelectAudioLanguages(detected, AudioLanguageSelection.PrimaryOnly);
+        Assert.Equal(new[] { "es" }, result);
+    }
+
+    [Fact]
+    public void PrimaryOnly_SingleElement_ReturnsThatElement()
+    {
+        // A specific DefaultLanguage or a de-duped single audio language resolves to one element —
+        // PrimaryOnly leaves it exactly as-is (the toggle's job is only the multi-language case).
+        var result = SubtitleManager.SelectAudioLanguages(new[] { "es" }, AudioLanguageSelection.PrimaryOnly);
+        Assert.Equal(new[] { "es" }, result);
+    }
+
+    [Fact]
+    public void PrimaryOnly_Empty_ReturnsEmpty()
+    {
+        // The no-tags whisper-auto-detect path yields ["auto"], never empty, but guard the empty list
+        // so PrimaryOnly can never index element [0] of an empty sequence.
+        var result = SubtitleManager.SelectAudioLanguages(Array.Empty<string>(), AudioLanguageSelection.PrimaryOnly);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void PrimaryOnly_AutoFallback_YieldsSingleAuto()
+    {
+        // ResolveLanguagesAsync returns ["auto"] when no audio language tags exist; PrimaryOnly must not
+        // disturb that single whisper-auto-detect pass.
+        var result = SubtitleManager.SelectAudioLanguages(new[] { "auto" }, AudioLanguageSelection.PrimaryOnly);
+        Assert.Equal(new[] { "auto" }, result);
+    }
+
+    [Fact]
+    public void PrimaryOnly_PreservesPrimaryEvenWhenSecondaryIsEnglish()
+    {
+        // The primary track wins regardless of what the secondaries are; the (separate) translation
+        // pass is what fills an English gap, and it is deliberately not narrowed by this toggle.
+        var detected = new[] { "de", "en" };
+        var result = SubtitleManager.SelectAudioLanguages(detected, AudioLanguageSelection.PrimaryOnly);
+        Assert.Equal(new[] { "de" }, result);
+    }
+
+    // ---- Works over any IReadOnlyList, not just arrays ------------------------------------------
+
+    [Fact]
+    public void PrimaryOnly_AcceptsListInput()
+    {
+        var detected = new List<string> { "ja", "en" };
+        var result = SubtitleManager.SelectAudioLanguages(detected, AudioLanguageSelection.PrimaryOnly);
+        Assert.Equal(new[] { "ja" }, result);
+    }
+}

--- a/WhisperSubs.Tests/ConfigurationTests.cs
+++ b/WhisperSubs.Tests/ConfigurationTests.cs
@@ -77,6 +77,35 @@ public class ConfigurationTests
     }
 
     [Fact]
+    public void AudioLanguageSelection_DefaultsToAll()
+    {
+        // Default All = transcribe every audio-track language (existing behavior) — an upgrade must not
+        // silently start dropping secondary-audio subtitles.
+        var config = new PluginConfiguration();
+        Assert.Equal(AudioLanguageSelection.All, config.AudioLanguageSelection);
+    }
+
+    [Fact]
+    public void AudioLanguageSelection_AbsentFromJson_KeepsAll()
+    {
+        // Existing installs' config has no key — deserialization must land on the safe All default.
+        var config = JsonSerializer.Deserialize<PluginConfiguration>("{}");
+        Assert.NotNull(config);
+        Assert.Equal(AudioLanguageSelection.All, config!.AudioLanguageSelection);
+    }
+
+    [Fact]
+    public void AudioLanguageSelection_SerializesByName_AndRoundTrips()
+    {
+        // Serializes by NAME over the config REST API ([JsonStringEnumConverter]); the config page uses
+        // the string option value.
+        var json = JsonSerializer.Serialize(new PluginConfiguration { AudioLanguageSelection = AudioLanguageSelection.PrimaryOnly });
+        Assert.Contains("\"PrimaryOnly\"", json);
+        var back = JsonSerializer.Deserialize<PluginConfiguration>(json);
+        Assert.Equal(AudioLanguageSelection.PrimaryOnly, back!.AudioLanguageSelection);
+    }
+
+    [Fact]
     public void PluginConfiguration_DefaultValues()
     {
         var config = new PluginConfiguration();


### PR DESCRIPTION
Bead **whisper-subs-v00**. With `DefaultLanguage=auto` the plugin already transcribes EVERY audio-track language (one `.<lang>.generated.srt` each) — this documents that + adds an explicit toggle.

- **Config `AudioLanguageSelection`** (enum `All`=default | `PrimaryOnly`, JsonStringEnumConverter). Default All = current behaviour, so existing installs are unchanged.
- **Pure `SubtitleManager.SelectAudioLanguages(detected, selection)`** wired at the finalized `passLanguages` list feeding `foreach (var lang in passLanguages)` (full + forced passes). `PrimaryOnly` → `[detected[0]]`; only the auto=all multi-element case is narrowed (a specific DefaultLanguage or the no-tags `auto` fallback is single-element → untouched). Translation pass still sees the full list.
- **Docs**: README (Multiple audio languages note), CLAUDE.md (Language Detection), config-page dropdown + help.
- **Tests**: AudioLanguageSelectionTests (9) + ConfigurationTests (3). **961 pass, 0 warnings.**