### PR TITLE
fix: allow-list GenerateAll targets + document de-dup invariant (whisper-subs-czk, whisper-subs-qv4)

### DIFF
--- a/Api/SubtitleController.cs
+++ b/Api/SubtitleController.cs
@@ -227,10 +227,13 @@ namespace WhisperSubs.Api
                     return NotFound(new { error = "Item not found" });
                 }
 
-                // Guard against enqueuing an entire library: only specific media or season/series containers.
-                if (MediaItemResolver.IsWholeLibraryContainer(parent))
+                // Allow-list the only kinds we may fan out over: media leaves (movie/episode/audio) and the
+                // intended containers (series/season/album). Everything else — library roots, BoxSet
+                // collections, MusicArtist, plain folders — is rejected so GenerateAll(Recursive) can't flood
+                // the whole library with an uncapped descendant sweep.
+                if (!MediaItemResolver.IsAllowedGenerateTarget(parent))
                 {
-                    return BadRequest(new { error = "Select a specific movie, episode, season, or series." });
+                    return BadRequest(new { error = "This item type cannot be used as a GenerateAll target. Select a movie, episode, series, season, album, or a single media item." });
                 }
 
                 var config = Plugin.Instance.Configuration;

--- a/Api/SubtitleRequestController.cs
+++ b/Api/SubtitleRequestController.cs
@@ -94,9 +94,11 @@ namespace WhisperSubs.Api
                 return NotFound(new { error = "Item not found" });
             }
 
-            if (MediaItemResolver.IsWholeLibraryContainer(item))
+            // Allow-list the only kinds a request may target — media leaves + series/season/album — so a
+            // BoxSet, MusicArtist, plain folder, or library root can't fan out over the whole library.
+            if (!MediaItemResolver.IsAllowedGenerateTarget(item))
             {
-                return BadRequest(new { error = "Select a specific movie, episode, season, or series." });
+                return BadRequest(new { error = "This item type cannot be requested. Select a movie, episode, series, season, or album." });
             }
 
             var lang = RequestValidation.NormalizeLanguage(language, config.DefaultLanguage);

--- a/Controller/MediaItemResolver.cs
+++ b/Controller/MediaItemResolver.cs
@@ -19,9 +19,20 @@ namespace WhisperSubs.Controller
     [ExcludeFromCodeCoverage(Justification = "Thin resolver over ILibraryManager + Jellyfin runtime item types")]
     public static class MediaItemResolver
     {
-        /// <summary>A top-level library container that must never be enqueued wholesale.</summary>
-        public static bool IsWholeLibraryContainer(BaseItem item)
-            => item is CollectionFolder || item is UserView || item is AggregateFolder;
+        /// <summary>
+        /// The only item kinds an admin GenerateAll / user request may target: media leaves
+        /// (Video and its subclasses Movie/Episode/MusicVideo/Trailer; Audio) and the intended
+        /// containers (Series, Season, MusicAlbum). Everything else — library roots, BoxSet
+        /// collections, MusicArtist, plain Folders — is rejected to prevent an uncapped recursive
+        /// fan-out over the whole library. This allow-list subsumes the old whole-library-container
+        /// reject-list (a CollectionFolder / UserView / AggregateFolder is none of these types).
+        /// </summary>
+        public static bool IsAllowedGenerateTarget(BaseItem item)
+            => item is Video
+            || item is MediaBrowser.Controller.Entities.Audio.Audio
+            || item is MediaBrowser.Controller.Entities.TV.Series
+            || item is MediaBrowser.Controller.Entities.TV.Season
+            || item is MediaBrowser.Controller.Entities.Audio.MusicAlbum;
 
         /// <summary>
         /// Resolves the supported leaf media items (Video, or Audio when lyrics are enabled) under

--- a/Controller/SubtitleQueueService.cs
+++ b/Controller/SubtitleQueueService.cs
@@ -403,6 +403,11 @@ namespace WhisperSubs.Controller
         [ExcludeFromCodeCoverage(Justification = "Requires BaseItem + Plugin.Instance for persistence")]
         public bool Enqueue(BaseItem item, string language, PriorityTier tier = PriorityTier.High, bool force = false)
         {
+            // De-dup invariant: Enqueue only READS _inFlight; the in-flight reservation happens once,
+            // at drain-entry (TryDequeuePriority → TryReserve), and every releaser lives in
+            // DispatchDrainAsync. So a failed/never-started drain leaves items in the lanes (pending,
+            // persisted), never orphaned in _inFlight — correctness here depends on PersistQueue
+            // swallowing (not propagating) its exceptions, which it does.
             var key = IdentityKey(item.Id, language);
 
             // Under _dispatchGate so the in-flight check and the lane-add are atomic with the dispatcher's

--- a/WhisperSubs.Tests/MediaItemResolverTests.cs
+++ b/WhisperSubs.Tests/MediaItemResolverTests.cs
@@ -1,0 +1,77 @@
+using WhisperSubs.Controller;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+/// <summary>
+/// Locks the allow-list contract of <see cref="MediaItemResolver.IsAllowedGenerateTarget"/> — the guard
+/// both the admin GenerateAll path and the user-request path use to decide what a "Generate all" may fan
+/// out over. Only media leaves (Video and its subclasses Movie/Episode; Audio) and the intended containers
+/// (Series, Season, MusicAlbum) are allowed; a BoxSet collection, MusicArtist, plain Folder, or a
+/// whole-library container (CollectionFolder / UserView / AggregateFolder) is rejected so an admin can't
+/// trigger an uncapped recursive fan-out over the entire library. Entity types are the concrete Jellyfin
+/// runtime classes (fully qualified to sidestep the Entities.Audio namespace-vs-type name collision).
+/// </summary>
+public class MediaItemResolverTests
+{
+    // ── Allowed: media leaves ────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Video_IsAllowed()
+        => Assert.True(MediaItemResolver.IsAllowedGenerateTarget(new MediaBrowser.Controller.Entities.Video()));
+
+    [Fact]
+    public void Movie_IsAllowed()
+        // Movie : Video — the single-movie case.
+        => Assert.True(MediaItemResolver.IsAllowedGenerateTarget(new MediaBrowser.Controller.Entities.Movies.Movie()));
+
+    [Fact]
+    public void Episode_IsAllowed()
+        // Episode : Video — the single-episode case.
+        => Assert.True(MediaItemResolver.IsAllowedGenerateTarget(new MediaBrowser.Controller.Entities.TV.Episode()));
+
+    [Fact]
+    public void Audio_IsAllowed()
+        // Audio leaf — only actually enqueued when lyrics generation is enabled, but the type is allowed.
+        => Assert.True(MediaItemResolver.IsAllowedGenerateTarget(new MediaBrowser.Controller.Entities.Audio.Audio()));
+
+    // ── Allowed: intended containers ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Series_IsAllowed()
+        => Assert.True(MediaItemResolver.IsAllowedGenerateTarget(new MediaBrowser.Controller.Entities.TV.Series()));
+
+    [Fact]
+    public void Season_IsAllowed()
+        => Assert.True(MediaItemResolver.IsAllowedGenerateTarget(new MediaBrowser.Controller.Entities.TV.Season()));
+
+    [Fact]
+    public void MusicAlbum_IsAllowed()
+        => Assert.True(MediaItemResolver.IsAllowedGenerateTarget(new MediaBrowser.Controller.Entities.Audio.MusicAlbum()));
+
+    // ── Rejected: collection/artist/folder floods ────────────────────────────────────────────────
+
+    [Fact]
+    public void BoxSet_IsRejected()
+        // A collection derives from Folder, not Video/Audio — GenerateAll on it would sweep every member.
+        => Assert.False(MediaItemResolver.IsAllowedGenerateTarget(new MediaBrowser.Controller.Entities.Movies.BoxSet()));
+
+    [Fact]
+    public void MusicArtist_IsRejected()
+        // MusicArtist : Folder (NOT MusicAlbum) — rejecting it caps the fan-out at album granularity.
+        => Assert.False(MediaItemResolver.IsAllowedGenerateTarget(new MediaBrowser.Controller.Entities.Audio.MusicArtist()));
+
+    [Fact]
+    public void Folder_IsRejected()
+        => Assert.False(MediaItemResolver.IsAllowedGenerateTarget(new MediaBrowser.Controller.Entities.Folder()));
+
+    // ── Rejected: whole-library containers (the old reject-list, now subsumed) ────────────────────
+
+    [Fact]
+    public void CollectionFolder_IsRejected()
+        => Assert.False(MediaItemResolver.IsAllowedGenerateTarget(new MediaBrowser.Controller.Entities.CollectionFolder()));
+
+    [Fact]
+    public void AggregateFolder_IsRejected()
+        => Assert.False(MediaItemResolver.IsAllowedGenerateTarget(new MediaBrowser.Controller.Entities.AggregateFolder()));
+}


### PR DESCRIPTION
Two PR #96 follow-up beads, re-verified against current v4-dev by an architect pass.

## czk — allow-list GenerateAll targets (was a reject-list)
The `GenerateAll` guard only rejected `CollectionFolder/UserView/AggregateFolder`, so a **BoxSet, MusicArtist, or plain Folder** slipped through and `GenerateAll(Recursive=true)` fanned out (uncapped) over every descendant — an admin foot-gun.
- **`MediaItemResolver.IsWholeLibraryContainer` → replaced by `IsAllowedGenerateTarget(BaseItem)`**: true only for `Video` (incl. Movie/Episode), `Audio`, `Series`, `Season`, `MusicAlbum`. Type names verified against the shipped Jellyfin 10.11.0 assemblies. The allow-list **subsumes** the old reject-list (library roots are none of those), so `IsWholeLibraryContainer` was retired (grep confirmed it had no other callers).
- Guard **inverted at both call sites**: `Api/SubtitleController.cs` (admin `GenerateAll`) + `Api/SubtitleRequestController.cs` (user requests), in lockstep.
- **12 new tests** (`MediaItemResolverTests`): Video/Movie/Episode/Audio/Series/Season/MusicAlbum → allowed; BoxSet/MusicArtist/Folder/CollectionFolder/AggregateFolder → rejected.

**Trade-off (flagged, not resolved):** the stricter allow-list also rejects running GenerateAll directly on a BoxSet collection / MusicArtist — an admin can still target the underlying Series/movies/albums. A future additive option is *allow BoxSet but cap the fan-out*.

## qv4 — de-dup invariant doc-comment (OBSOLETE bug, no functional change)
The reserve-leak this bead described **cannot occur in v4.0**: `Enqueue` only *reads* `_inFlight`; the sole reservation is at drain-entry (`TryDequeuePriority → TryReserve`), with every releaser co-located in `DispatchDrainAsync`. Added an invariant comment at `Enqueue` so a future edit doesn't reintroduce the leak.

## Verification
`dotnet build -c Release` → **0 warnings, 0 errors**. Full suite → **973 passed / 0 failed** (baseline 961; +12).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Subtitle requests now correctly reject unsupported items and only allow specific media types and containers.
  * Improved error messages guide users to choose a valid movie, episode, audio item, or supported series/season/album container.
  * Subtitle generation now follows the same stricter item selection rules, reducing accidental requests on broad library folders.

* **Tests**
  * Added coverage to verify which item types are allowed or rejected for subtitle generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->