### PR TITLE
feat: hot-add workers to the live pool without a Jellyfin restart (whisper-subs-9gq)

### DIFF
--- a/Api/SubtitleController.cs
+++ b/Api/SubtitleController.cs
@@ -507,6 +507,28 @@ namespace WhisperSubs.Api
         }
 
         /// <summary>
+        /// Hot-reloads the worker pool from the current configuration WITHOUT a Jellyfin restart
+        /// (whisper-subs-9gq): grows the live pool so a just-added worker joins the running drain immediately,
+        /// within one drain cycle and without dropping in-flight jobs on the other workers. A manual fallback
+        /// to the automatic on-config-change trigger, and makes the feature verifiable without a config
+        /// round-trip. Admin-only via the class-level RequiresElevation policy (mirrors Workers/TestConnection).
+        /// </summary>
+        [HttpPost("Workers/Reload")]
+        public ActionResult ReloadWorkers()
+        {
+            try
+            {
+                var count = SubtitleQueueService.Instance.ReconcileWorkers(Plugin.Instance.Configuration, _loggerFactory);
+                return Ok(new { message = "Worker pool reconciled", workers = count });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error reloading worker pool");
+                return StatusCode(500, new { error = ex.Message });
+            }
+        }
+
+        /// <summary>
         /// Lists all user subtitle requests (admin), newest first — for the config-page approval panel.
         /// Returns item names + state only; never a filesystem path. (Issue #112.)
         /// </summary>

--- a/Controller/SubtitleQueueService.cs
+++ b/Controller/SubtitleQueueService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -132,6 +133,13 @@ namespace WhisperSubs.Controller
         private WorkerPool? _pool;
         private readonly object _poolGate = new();
 
+        // The worker "signature" the current _pool was built or last reconciled from (whisper-subs-9gq): a
+        // stable string over the CONFIGURED workers (composition plan + each row's routing-key / url / model /
+        // concurrency / cost / translate). ReconcileWorkers skips the provider-constructing rebuild when this
+        // is unchanged, so an unrelated config save — e.g. toggling PauseOnPlayback — does not needlessly news
+        // up RemoteWhisperProvider/HttpClient instances. Guarded by _poolGate, alongside _pool.
+        private string? _workersSignature;
+
         /// <summary>
         /// The shared worker pool for the current (or next) drain session, (re)built from config. Rebuilt at a
         /// session start only when the OTHER consumer is idle AND no jobs are in flight, so a rebuild never
@@ -149,9 +157,90 @@ namespace WhisperSubs.Controller
                 if (_pool == null || (otherConsumerIdle && _pool.ActiveJobs == 0))
                 {
                     _pool = new WorkerPool(WorkerRegistry.BuildWorkers(config, loggerFactory));
+                    // Keep the reconcile signature in step with the config the live pool was just built from,
+                    // so a subsequent unchanged config save is a no-op in ReconcileWorkers. (whisper-subs-9gq.)
+                    _workersSignature = ComputeWorkersSignature(config);
                 }
                 return _pool;
             }
+        }
+
+        /// <summary>
+        /// Hot-applies a Workers-config change to the LIVE pool without a Jellyfin restart (whisper-subs-9gq).
+        /// Under <see cref="_poolGate"/> (the lock guarding <see cref="_pool"/>): when a pool exists and the
+        /// configured workers actually changed, it rebuilds the desired worker set from <paramref name="config"/>
+        /// and GROWS the pool via <see cref="WorkerPool.Reconcile"/> so a just-added worker joins the running
+        /// drain immediately — without disturbing in-flight jobs on the other workers, and preserving the
+        /// sole-dispatch invariant (Reconcile mutates the pool under the pool's own gate). When no pool exists
+        /// yet this is a no-op: the next <see cref="GetPool"/> builds fresh from the new config anyway. A cheap
+        /// workers-signature comparison skips the (provider-constructing) rebuild when the worker set is
+        /// unchanged, so an unrelated config save does not churn HttpClients. Returns the live worker count.
+        /// </summary>
+        [ExcludeFromCodeCoverage(Justification = "Builds providers from config via WorkerRegistry — orchestration; the signature (ComputeWorkersSignature) and WorkerPool.Reconcile are unit-tested")]
+        public int ReconcileWorkers(PluginConfiguration config, ILoggerFactory loggerFactory)
+        {
+            lock (_poolGate)
+            {
+                if (_pool == null)
+                {
+                    // Nothing live to grow — GetPool will build fresh from this config on the next drain.
+                    return 0;
+                }
+
+                var signature = ComputeWorkersSignature(config);
+                if (signature == _workersSignature)
+                {
+                    return _pool.WorkerCount;   // workers unchanged — skip the provider rebuild
+                }
+
+                var count = _pool.Reconcile(WorkerRegistry.BuildWorkers(config, loggerFactory));
+                _workersSignature = signature;
+                return count;
+            }
+        }
+
+        /// <summary>
+        /// A stable signature of the CONFIGURED transcription workers (whisper-subs-9gq): the backward-compat
+        /// composition decision (<see cref="WorkerPlan.Decide"/>) plus, per contributing worker, its routing
+        /// key, URL, model, MaxConcurrency, cost and translate capability — everything that changes which
+        /// workers the pool would contain or their capacity. <see cref="ReconcileWorkers"/> compares it to
+        /// detect whether the worker set actually changed, so an unrelated config save is a cheap no-op.
+        /// Mirrors <see cref="WorkerRegistry.BuildWorkers"/>' enabled+non-blank filter and key derivation so
+        /// the signature tracks the workers the pool would really contain. Pure and internal so it is
+        /// unit-testable without a live pool.
+        /// </summary>
+        internal static string ComputeWorkersSignature(PluginConfiguration config)
+        {
+            var (source, addLocal) = WorkerPlan.Decide(
+                config.Workers?.Count ?? 0,
+                !string.IsNullOrWhiteSpace(config.RemoteWhisperApiUrl),
+                config.EnableLocalWorker);
+
+            var sb = new StringBuilder();
+            sb.Append("src=").Append(source).Append(";local=").Append(addLocal).Append(';');
+
+            if (source == WorkerSource.ExplicitList && config.Workers != null)
+            {
+                foreach (var w in config.Workers)
+                {
+                    if (!w.Enabled || string.IsNullOrWhiteSpace(w.ApiUrl)) continue;
+                    var id = string.IsNullOrWhiteSpace(w.Id) ? w.ApiUrl : w.Id;
+                    sb.Append("w[").Append(id).Append('|')
+                      .Append(w.ApiUrl.Trim()).Append('|')
+                      .Append((w.Model ?? string.Empty).Trim()).Append('|')
+                      .Append(w.MaxConcurrency < 1 ? 1 : w.MaxConcurrency).Append('|')
+                      .Append(w.CostWeight.ToString(System.Globalization.CultureInfo.InvariantCulture)).Append('|')
+                      .Append(w.CanTranslate).Append("];");
+                }
+            }
+            else if (source == WorkerSource.LegacyRemote)
+            {
+                sb.Append("remote[")
+                  .Append((config.RemoteWhisperApiUrl ?? string.Empty).Trim()).Append('|')
+                  .Append((config.RemoteWhisperModel ?? string.Empty).Trim()).Append("];");
+            }
+
+            return sb.ToString();
         }
 
         /// <summary>

--- a/Controller/SubtitleQueueService.cs
+++ b/Controller/SubtitleQueueService.cs
@@ -156,7 +156,9 @@ namespace WhisperSubs.Controller
                 var otherConsumerIdle = forTask ? _isDraining == 0 : _taskIsRunning == 0;
                 if (_pool == null || (otherConsumerIdle && _pool.ActiveJobs == 0))
                 {
-                    _pool = new WorkerPool(WorkerRegistry.BuildWorkers(config, loggerFactory));
+                    _pool = new WorkerPool(
+                        WorkerRegistry.BuildWorkers(config, loggerFactory),
+                        loggerFactory.CreateLogger<WorkerPool>());
                     // Keep the reconcile signature in step with the config the live pool was just built from,
                     // so a subsequent unchanged config save is a no-op in ReconcileWorkers. (whisper-subs-9gq.)
                     _workersSignature = ComputeWorkersSignature(config);
@@ -176,6 +178,13 @@ namespace WhisperSubs.Controller
         /// workers-signature comparison skips the (provider-constructing) rebuild when the worker set is
         /// unchanged, so an unrelated config save does not churn HttpClients. Returns the live worker count.
         /// </summary>
+        /// <remarks>
+        /// GROW-ONLY (see <see cref="WorkerPool.Reconcile"/>): a newly-added worker joins the live drain
+        /// immediately, but REMOVING a worker — or EDITING the URL/Id of an existing one — takes effect only on
+        /// the next idle <see cref="GetPool"/> rebuild or a restart. Editing the URL of a blank-Id worker
+        /// re-keys it, so both the old and edited worker run until that rebuild. The added / removed workers are
+        /// logged by <see cref="WorkerPool.Reconcile"/>.
+        /// </remarks>
         [ExcludeFromCodeCoverage(Justification = "Builds providers from config via WorkerRegistry — orchestration; the signature (ComputeWorkersSignature) and WorkerPool.Reconcile are unit-tested")]
         public int ReconcileWorkers(PluginConfiguration config, ILoggerFactory loggerFactory)
         {
@@ -221,17 +230,21 @@ namespace WhisperSubs.Controller
 
             if (source == WorkerSource.ExplicitList && config.Workers != null)
             {
+                // Collect each contributing row's segment, then append them SORTED (whisper-subs-9gq L1) so that
+                // merely reordering worker rows in the config does not flip the signature — which would run a
+                // needless no-op provider rebuild. Same fields/format as before; only per-row ordering is stable.
+                var segments = new List<string>();
                 foreach (var w in config.Workers)
                 {
                     if (!w.Enabled || string.IsNullOrWhiteSpace(w.ApiUrl)) continue;
                     var id = string.IsNullOrWhiteSpace(w.Id) ? w.ApiUrl : w.Id;
-                    sb.Append("w[").Append(id).Append('|')
-                      .Append(w.ApiUrl.Trim()).Append('|')
-                      .Append((w.Model ?? string.Empty).Trim()).Append('|')
-                      .Append(w.MaxConcurrency < 1 ? 1 : w.MaxConcurrency).Append('|')
-                      .Append(w.CostWeight.ToString(System.Globalization.CultureInfo.InvariantCulture)).Append('|')
-                      .Append(w.CanTranslate).Append("];");
+                    segments.Add(
+                        $"w[{id}|{w.ApiUrl.Trim()}|{(w.Model ?? string.Empty).Trim()}|" +
+                        $"{(w.MaxConcurrency < 1 ? 1 : w.MaxConcurrency)}|" +
+                        $"{w.CostWeight.ToString(System.Globalization.CultureInfo.InvariantCulture)}|{w.CanTranslate}];");
                 }
+                foreach (var seg in segments.OrderBy(s => s, System.StringComparer.Ordinal))
+                    sb.Append(seg);
             }
             else if (source == WorkerSource.LegacyRemote)
             {

--- a/Controller/Workers/WorkerPool.cs
+++ b/Controller/Workers/WorkerPool.cs
@@ -37,28 +37,85 @@ namespace WhisperSubs.Controller.Workers
         {
             if (workers == null) throw new ArgumentNullException(nameof(workers));
 
+            var keys = ComputeKeys(workers);
             var capacity = 0;
             for (var i = 0; i < workers.Count; i++)
             {
-                var w = workers[i];
-                // Guarantee a unique routing key even if two configured workers collide on Id — a
-                // duplicate would otherwise make the reverse Id→worker lookup ambiguous. The key is only
-                // used internally for slot accounting; WorkerSlot.Id still carries it for the deterministic
-                // ordinal tiebreak in WorkerScheduling.Pick.
-                var key = _byKey.ContainsKey(w.Id) ? $"{w.Id}#{i}" : w.Id;
-                _keys.Add(key);
-                _byKey[key] = w;
-                _inFlight[key] = 0;
-                _current[key] = new List<string>();
-                capacity += w.Capabilities.MaxConcurrency < 1 ? 1 : w.Capabilities.MaxConcurrency;
+                InitWorkerSlot(keys[i], workers[i]);
+                capacity += Cap(workers[i]);
             }
 
             TotalCapacity = capacity < 1 ? 1 : capacity;
-            _slots = new SemaphoreSlim(TotalCapacity, TotalCapacity);
+            // Single-arg (UNCAPPED) SemaphoreSlim — deliberately NOT the two-arg (max-capped) form: Reconcile
+            // grows the live pool via _slots.Release(delta), which the two-arg ctor would reject with
+            // SemaphoreFullException once past its initial max. Normal dispatch keeps Acquire/Release strictly
+            // 1:1, so it can never over-release past TotalCapacity — only Reconcile ever grows it. (whisper-subs-9gq.)
+            _slots = new SemaphoreSlim(TotalCapacity);
         }
 
-        /// <summary>Summed MaxConcurrency across all workers (≥1): how many jobs may run at once.</summary>
-        public int TotalCapacity { get; }
+        /// <summary>Summed MaxConcurrency across all workers (≥1): how many jobs may run at once. Grows when
+        /// <see cref="Reconcile"/> hot-adds a worker to the live pool. (whisper-subs-9gq.)</summary>
+        public int TotalCapacity { get; private set; }
+
+        // Initialise one worker's per-slot state (routing key → descriptor + zeroed in-flight / current-items).
+        // ONE source of truth shared by the constructor (object not yet published) and Reconcile (under _gate),
+        // so a hot-added worker is set up byte-identically to a constructor-time one. (whisper-subs-9gq.)
+        private void InitWorkerSlot(string key, ITranscriptionWorker w)
+        {
+            _keys.Add(key);
+            _byKey[key] = w;
+            _inFlight[key] = 0;
+            _current[key] = new List<string>();
+        }
+
+        // One worker's slot contribution: MaxConcurrency floored to 1 (a nonsense concurrency still gets one slot).
+        private static int Cap(ITranscriptionWorker w)
+            => w.Capabilities.MaxConcurrency < 1 ? 1 : w.Capabilities.MaxConcurrency;
+
+        // Canonical, collision-safe routing keys for a worker list — the SAME scheme the constructor and
+        // Reconcile share: the first worker with a given Id keeps its Id; a later duplicate gets "{Id}#{index}"
+        // so the reverse key→worker lookup stays unambiguous (the key is internal slot accounting; WorkerSlot.Id
+        // still carries it for the deterministic ordinal tiebreak in WorkerScheduling.Pick). Computed against a
+        // FRESH seen-set (independent of the live pool) so Reconcile can diff the result against the current
+        // keys. (whisper-subs-9gq.)
+        private static List<string> ComputeKeys(IReadOnlyList<ITranscriptionWorker> workers)
+        {
+            var keys = new List<string>(workers.Count);
+            var seen = new HashSet<string>();
+            for (var i = 0; i < workers.Count; i++)
+            {
+                var id = workers[i].Id;
+                var key = seen.Contains(id) ? $"{id}#{i}" : id;
+                keys.Add(key);
+                seen.Add(key);
+            }
+            return keys;
+        }
+
+        /// <summary>
+        /// Pure grow-only diff (whisper-subs-9gq), factored out of <see cref="Reconcile"/> so the add / keep /
+        /// ignore-removal decision is unit-testable without a live pool. Given the pool's current routing keys
+        /// and a desired worker list, returns the desired keys NOT yet present (to ADD) and the current keys
+        /// absent from desired (REMOVED — reported for observability but intentionally NOT acted on by the
+        /// grow-only reconcile). Uses the SAME collision-safe key scheme as the constructor via <see cref="ComputeKeys"/>.
+        /// </summary>
+        internal static (IReadOnlyList<string> Added, IReadOnlyList<string> Removed) DiffWorkers(
+            IReadOnlyCollection<string> currentKeys, IReadOnlyList<ITranscriptionWorker> desired)
+        {
+            var current = new HashSet<string>(currentKeys);
+            var desiredKeys = ComputeKeys(desired);
+            var desiredSet = new HashSet<string>(desiredKeys);
+
+            var added = new List<string>();
+            foreach (var k in desiredKeys)
+                if (!current.Contains(k)) added.Add(k);
+
+            var removed = new List<string>();
+            foreach (var k in currentKeys)
+                if (!desiredSet.Contains(k)) removed.Add(k);
+
+            return (added, removed);
+        }
 
         /// <summary>Number of workers in the pool.</summary>
         public int WorkerCount => _keys.Count;
@@ -188,6 +245,50 @@ namespace WhisperSubs.Controller.Workers
                     _inFlight[leaseKey] = n - 1;
             }
             _slots.Release();
+        }
+
+        /// <summary>
+        /// Hot-adds newly-configured workers to the LIVE pool without a restart (whisper-subs-9gq) — the
+        /// "add a worker mid-backlog" case (e.g. a just-provisioned Mac mini). GROW-ONLY: every worker in
+        /// <paramref name="desired"/> not already present is added (its per-slot state initialised exactly as
+        /// the constructor does) and the backpressure semaphore is grown by the added capacity, so the new
+        /// slot(s) become dispatchable immediately — even while a drain is in flight. Workers already in the
+        /// pool are LEFT UNTOUCHED: their in-flight counts and "what's running" lists survive, so no running
+        /// job is disturbed. A worker that DISAPPEARED from the config is deliberately NOT removed here — live
+        /// removal needs permit-shrink accounting that is out of scope for this change; a removed worker simply
+        /// stops receiving new jobs on the next idle <c>GetPool</c> rebuild. Returns the resulting worker count.
+        ///
+        /// Concurrency: the map mutation runs under <see cref="_gate"/> — the SAME lock <see cref="PickLocked"/>
+        /// and <see cref="Release"/> take — so a dispatcher observes the old-or-new worker set atomically, never
+        /// a partial one. The semaphore is grown AFTER the maps are mutated and OUTSIDE the lock, so a waiter
+        /// woken by the new permit is guaranteed to see the added worker when it re-enters PickLocked.
+        /// </summary>
+        public int Reconcile(IReadOnlyList<ITranscriptionWorker> desired)
+        {
+            if (desired == null) throw new ArgumentNullException(nameof(desired));
+
+            var addedPermits = 0;
+            int workerCount;
+            lock (_gate)
+            {
+                var desiredKeys = ComputeKeys(desired);
+                for (var i = 0; i < desired.Count; i++)
+                {
+                    var key = desiredKeys[i];
+                    if (_byKey.ContainsKey(key)) continue;   // already live → leave its in-flight state alone
+                    InitWorkerSlot(key, desired[i]);
+                    var cap = Cap(desired[i]);
+                    TotalCapacity += cap;
+                    addedPermits += cap;
+                }
+                workerCount = _keys.Count;
+            }
+
+            // Release the added permits OUTSIDE _gate (never release inside a lock). The uncapped semaphore
+            // makes Release(delta) legal; the map-add-BEFORE-release ordering means the woken waiter sees the
+            // newly-added workers in PickLocked.
+            if (addedPermits > 0) _slots.Release(addedPermits);
+            return workerCount;
         }
 
         // Caller holds _gate. Snapshots each worker as a WorkerSlot (keyed by the unique routing key), asks

--- a/Controller/Workers/WorkerPool.cs
+++ b/Controller/Workers/WorkerPool.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace WhisperSubs.Controller.Workers
 {
@@ -32,10 +34,14 @@ namespace WhisperSubs.Controller.Workers
         // sees "what's running where" (a worker with MaxConcurrency > 1 can hold several). (v4.0.)
         private readonly Dictionary<string, List<string>> _current = new();
         private readonly SemaphoreSlim _slots;
+        // Production passes a real logger (SubtitleQueueService.GetPool); the unit tests construct the pool
+        // without one (NullLogger). Used for the diagnostic over-release tripwire and hot-add / removal logging.
+        private readonly ILogger _logger;
 
-        public WorkerPool(IReadOnlyList<ITranscriptionWorker> workers)
+        public WorkerPool(IReadOnlyList<ITranscriptionWorker> workers, ILogger? logger = null)
         {
             if (workers == null) throw new ArgumentNullException(nameof(workers));
+            _logger = logger ?? NullLogger.Instance;
 
             var keys = ComputeKeys(workers);
             var capacity = 0;
@@ -211,7 +217,7 @@ namespace WhisperSubs.Controller.Workers
                 // A slot freed but only incapable workers are free (heterogeneous-capability case). Give the
                 // slot back and wait briefly for the capable-but-busy worker to free — the HasCapableWorker
                 // guard guarantees one exists, so this terminates.
-                _slots.Release();
+                ReleaseSlots();
                 await Task.Delay(100, cancellationToken).ConfigureAwait(false);
             }
         }
@@ -244,7 +250,7 @@ namespace WhisperSubs.Controller.Workers
                 if (_inFlight.TryGetValue(leaseKey, out var n) && n > 0)
                     _inFlight[leaseKey] = n - 1;
             }
-            _slots.Release();
+            ReleaseSlots();
         }
 
         /// <summary>
@@ -263,14 +269,29 @@ namespace WhisperSubs.Controller.Workers
         /// a partial one. The semaphore is grown AFTER the maps are mutated and OUTSIDE the lock, so a waiter
         /// woken by the new permit is guaranteed to see the added worker when it re-enters PickLocked.
         /// </summary>
+        /// <remarks>
+        /// GROW-ONLY, and the caller must understand the limits: a newly-added worker joins the LIVE pool
+        /// immediately, but REMOVING a worker — or EDITING the URL/Id of an existing one — does NOT take effect
+        /// here; it applies only on the next idle <c>GetPool</c> rebuild or a Jellyfin restart. In particular,
+        /// editing the URL of a worker row whose Id is BLANK re-keys it (the routing key derives from the URL
+        /// when Id is blank), so the reconcile sees a NEW worker and transiently runs BOTH the old and the
+        /// edited one until the next idle rebuild. Removed / re-keyed workers are surfaced via a warning log
+        /// for visibility (they are diffed but intentionally not applied — live removal is out of scope).
+        /// </remarks>
         public int Reconcile(IReadOnlyList<ITranscriptionWorker> desired)
         {
             if (desired == null) throw new ArgumentNullException(nameof(desired));
 
             var addedPermits = 0;
             int workerCount;
+            IReadOnlyList<string> added;
+            IReadOnlyList<string> removed;
             lock (_gate)
             {
+                // Diff BEFORE mutating _keys so added/removed describe the PRE-reconcile pool. Grow-only:
+                // 'added' is applied by the loop below; 'removed' (a dropped or re-keyed worker) is only reported.
+                (added, removed) = DiffWorkers(_keys, desired);
+
                 var desiredKeys = ComputeKeys(desired);
                 for (var i = 0; i < desired.Count; i++)
                 {
@@ -286,9 +307,34 @@ namespace WhisperSubs.Controller.Workers
 
             // Release the added permits OUTSIDE _gate (never release inside a lock). The uncapped semaphore
             // makes Release(delta) legal; the map-add-BEFORE-release ordering means the woken waiter sees the
-            // newly-added workers in PickLocked.
-            if (addedPermits > 0) _slots.Release(addedPermits);
+            // newly-added workers in PickLocked. Routed through ReleaseSlots so the over-release tripwire runs.
+            if (addedPermits > 0) ReleaseSlots(addedPermits);
+
+            // Surface the reconcile outcome (whisper-subs-9gq hardening): a hot-add is expected; a removal or
+            // re-key is a known foot-gun (grow-only leaves it live until the next idle rebuild), so warn on it.
+            if (added.Count > 0)
+                _logger.LogInformation("WorkerPool hot-add: added workers [{Added}]", string.Join(",", added));
+            if (removed.Count > 0)
+                _logger.LogWarning(
+                    "WorkerPool: worker(s) [{Removed}] were removed from config but stay live until the next idle pool rebuild / restart (live removal not yet supported)",
+                    string.Join(",", removed));
+
             return workerCount;
+        }
+
+        // Central choke-point for every semaphore Release (whisper-subs-9gq hardening). The ctor now uses the
+        // UNCAPPED SemaphoreSlim (so Reconcile can Release(delta) to grow capacity), which removed the
+        // SemaphoreFullException that used to catch a double-release. This restores that tripwire as a LOG
+        // (never a throw — a diagnostic must not crash dispatch): if the permit count ever exceeds the current
+        // TotalCapacity ceiling, a Release was not paired 1:1 with an Acquire. TotalCapacity is read AFTER
+        // Reconcile grows it under _gate, so the comparison always uses the current ceiling.
+        private void ReleaseSlots(int n = 1)
+        {
+            _slots.Release(n);
+            if (_slots.CurrentCount > TotalCapacity)
+                _logger.LogError(
+                    "WorkerPool permit over-release: CurrentCount {C} > TotalCapacity {T}",
+                    _slots.CurrentCount, TotalCapacity);
         }
 
         // Caller holds _gate. Snapshots each worker as a WorkerSlot (keyed by the unique routing key), asks

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Text.RegularExpressions;
 using WhisperSubs.Configuration;
+using WhisperSubs.Controller;
 using WhisperSubs.Web;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Plugins;
@@ -17,6 +18,7 @@ namespace WhisperSubs
     {
         private readonly IApplicationPaths _appPaths;
         private readonly ILogger<Plugin> _logger;
+        private readonly ILoggerFactory _loggerFactory;
 
         internal const string ScriptTag = "<script src=\"configurationpage?name=whisperSubs.js\"></script>";
 
@@ -46,14 +48,39 @@ namespace WhisperSubs
         public Plugin(
             IApplicationPaths applicationPaths,
             IXmlSerializer xmlSerializer,
-            ILogger<Plugin> logger)
+            ILogger<Plugin> logger,
+            ILoggerFactory loggerFactory)
             : base(applicationPaths, xmlSerializer)
         {
             _appPaths = applicationPaths;
             _logger = logger;
+            _loggerFactory = loggerFactory;
             Instance = this;
 
+            // Hot-add workers to the LIVE pool when the admin saves a Workers-config change, so a newly-added
+            // worker joins mid-backlog without a Jellyfin restart (whisper-subs-9gq). BasePlugin raises
+            // ConfigurationChanged from UpdateConfiguration after the new config is persisted; the handler
+            // swallows+logs any failure so a config save can never throw.
+            ConfigurationChanged += OnConfigurationChanged;
+
             InjectClientScript();
+        }
+
+        /// <summary>
+        /// Reconciles the live worker pool after a configuration change (whisper-subs-9gq) so a worker added
+        /// to the config joins the running pool without a restart. Never throws — a config save must not fail.
+        /// </summary>
+        private void OnConfigurationChanged(object? sender, BasePluginConfiguration configuration)
+        {
+            try
+            {
+                var count = SubtitleQueueService.Instance.ReconcileWorkers(Configuration, _loggerFactory);
+                _logger.LogDebug("WhisperSubs: reconciled worker pool after configuration change ({Count} worker(s))", count);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "WhisperSubs: failed to reconcile workers after a configuration change");
+            }
         }
 
         public static Plugin Instance { get; private set; } = null!;

--- a/WhisperSubs.Tests/WorkerPoolReconcileTests.cs
+++ b/WhisperSubs.Tests/WorkerPoolReconcileTests.cs
@@ -1,0 +1,174 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using WhisperSubs.Controller.Workers;
+using WhisperSubs.Providers;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+/// <summary>
+/// whisper-subs-9gq: hot-adding a worker to the LIVE pool without a restart. Pins the grow-only diff, the
+/// capacity/semaphore growth (the uncapped SemaphoreSlim actually hands out the extra slots), that a waiter
+/// blocked on a full pool is unblocked by the new permit and routed to the added worker, and — the safety
+/// one — that a worker already running a job keeps its in-flight state across a Reconcile (no teardown).
+/// </summary>
+public class WorkerPoolReconcileTests
+{
+    private sealed class FakeProvider : ISubtitleProvider
+    {
+        public string Name => "fake";
+        public bool UsesVad => false;
+        public Task<string> TranscribeAsync(string audioPath, string language, CancellationToken ct, bool translate = false)
+            => Task.FromResult(string.Empty);
+        public Task<(string Language, float Probability)> DetectLanguageAsync(string audioPath, CancellationToken ct)
+            => Task.FromResult(("en", 1f));
+    }
+
+    private static ITranscriptionWorker Worker(string id, int maxConcurrency = 1, double cost = 0, bool canTranslate = true)
+        => new TranscriptionWorker(id, id, new FakeProvider(), new WorkerCapabilities
+        {
+            MaxConcurrency = maxConcurrency,
+            CostWeight = cost,
+            CanTranslate = canTranslate,
+            IsLocal = cost == 0
+        });
+
+    private static readonly JobRequirements AnyJob = new(Translate: false, RequiredModel: null);
+
+    [Fact]
+    public void Reconcile_AddsNewWorker_GrowsCapacityAndAppearsInSnapshot()
+    {
+        var pool = new WorkerPool(new[] { Worker("local", 1) });
+        Assert.Equal(1, pool.TotalCapacity);
+        Assert.Equal(1, pool.WorkerCount);
+
+        var count = pool.Reconcile(new[] { Worker("local", 1), Worker("mini", 2) });
+
+        Assert.Equal(2, count);
+        Assert.Equal(2, pool.WorkerCount);
+        Assert.Equal(3, pool.TotalCapacity);   // 1 + 2
+
+        var snap = pool.Snapshot();
+        Assert.Equal(2, snap.Count);
+        Assert.Contains(snap, s => s.Id == "mini" && s.MaxConcurrency == 2);
+        Assert.Contains(snap, s => s.Id == "local");
+    }
+
+    [Fact]
+    public async Task Reconcile_UncappedSemaphore_HandsOutFullGrownCapacity()
+    {
+        var pool = new WorkerPool(new[] { Worker("a", 2) });   // N = 2
+        Assert.Equal(2, pool.TotalCapacity);
+
+        var count = pool.Reconcile(new[] { Worker("a", 2), Worker("b", 3) });   // + M = 3
+        Assert.Equal(2, count);
+        Assert.Equal(5, pool.TotalCapacity);   // N + M — the semaphore max grew live
+
+        // Prove the uncapped semaphore really grew: 5 concurrent acquires all succeed, the 6th blocks.
+        var leases = new List<WorkerLease>();
+        for (var i = 0; i < 5; i++) leases.Add(await pool.AcquireAsync(AnyJob, default));
+        Assert.Equal(5, pool.ActiveJobs);
+
+        var sixth = pool.AcquireAsync(AnyJob, default);
+        Assert.False(sixth.IsCompleted);   // capacity reached ⇒ blocks
+
+        foreach (var l in leases) pool.Release(l.Key);
+        var s = await sixth;   // a slot freed ⇒ unblocks
+        pool.Release(s.Key);
+        Assert.Equal(0, pool.ActiveJobs);
+    }
+
+    [Fact]
+    public async Task Reconcile_UnblocksAWaiter_MidDrain_RoutesToNewWorker()
+    {
+        var pool = new WorkerPool(new[] { Worker("a", 1) });   // capacity 1
+        var a = await pool.AcquireAsync(AnyJob, default);
+        Assert.Equal(1, pool.ActiveJobs);
+
+        // The only slot is taken — a second acquire blocks, exactly like a saturated live pool mid-backlog.
+        var blocked = pool.AcquireAsync(AnyJob, default);
+        Assert.False(blocked.IsCompleted);
+
+        // Hot-add a second worker: the new permit must wake the waiter, and PickLocked must see the new
+        // worker (map-add precedes the Release) and route to it since "a" is still busy.
+        pool.Reconcile(new[] { Worker("a", 1), Worker("b", 1) });
+
+        var b = await blocked;
+        Assert.Equal(2, pool.ActiveJobs);
+        Assert.Equal("b", b.Worker.Id);
+
+        pool.Release(a.Key);
+        pool.Release(b.Key);
+        Assert.Equal(0, pool.ActiveJobs);
+    }
+
+    [Fact]
+    public void Reconcile_UnchangedWorkerSet_IsNoOp()
+    {
+        var pool = new WorkerPool(new[] { Worker("a", 1), Worker("b", 2) });
+        Assert.Equal(3, pool.TotalCapacity);
+
+        var count = pool.Reconcile(new[] { Worker("a", 1), Worker("b", 2) });   // same keys
+
+        Assert.Equal(2, count);
+        Assert.Equal(2, pool.WorkerCount);
+        Assert.Equal(3, pool.TotalCapacity);   // unchanged — no permit added
+    }
+
+    [Fact]
+    public async Task Reconcile_PreservesExistingWorkerInFlight_NoTeardown()
+    {
+        var pool = new WorkerPool(new[] { Worker("busy", 1) });
+        var lease = await pool.AcquireAsync(AnyJob, default);
+        pool.SetCurrent(lease.Key, "Film A");
+        Assert.Equal(1, pool.ActiveJobs);
+
+        // Add another worker while "busy" holds a job — its in-flight count and current item must survive.
+        pool.Reconcile(new[] { Worker("busy", 1), Worker("fresh", 1) });
+
+        var busy = pool.Snapshot().Single(s => s.Id == "busy");
+        Assert.Equal(1, busy.InFlight);                 // untouched by the reconcile
+        Assert.Contains("Film A", busy.CurrentItems);   // "what's running" preserved
+        var fresh = pool.Snapshot().Single(s => s.Id == "fresh");
+        Assert.Equal(0, fresh.InFlight);
+
+        // The original lease is still valid and releasable — slot accounting stayed intact.
+        pool.Release(lease.Key, "Film A");
+        Assert.Equal(0, pool.ActiveJobs);
+    }
+
+    [Fact]
+    public void DiffWorkers_IdentifiesAdds_PreservesExisting_IgnoresRemovals()
+    {
+        var (added, removed) = WorkerPool.DiffWorkers(
+            new[] { "local" },
+            new[] { Worker("local", 1), Worker("mini", 1) });
+
+        Assert.Equal(new[] { "mini" }, added);   // local already present → not re-added
+        Assert.Empty(removed);
+
+        // A worker dropped from desired is reported as removed — but Reconcile ignores it (grow-only).
+        var (added2, removed2) = WorkerPool.DiffWorkers(
+            new[] { "local", "gone" },
+            new[] { Worker("local", 1) });
+
+        Assert.Empty(added2);
+        Assert.Equal(new[] { "gone" }, removed2);
+    }
+
+    [Fact]
+    public void DiffWorkers_DuplicateIds_GetCollisionSuffix_SoBothAreAddable()
+    {
+        // Two desired workers colliding on Id must diff to two distinct keys (the ctor's "{id}#{i}" scheme),
+        // so both can be hot-added rather than one silently swallowing the other.
+        var (added, _) = WorkerPool.DiffWorkers(
+            System.Array.Empty<string>(),
+            new[] { Worker("dup", 1), Worker("dup", 1) });
+
+        Assert.Equal(2, added.Count);
+        Assert.Contains("dup", added);
+        Assert.Contains("dup#1", added);
+    }
+}

--- a/WhisperSubs.Tests/WorkerPoolReconcileTests.cs
+++ b/WhisperSubs.Tests/WorkerPoolReconcileTests.cs
@@ -171,4 +171,23 @@ public class WorkerPoolReconcileTests
         Assert.Contains("dup", added);
         Assert.Contains("dup#1", added);
     }
+
+    [Fact]
+    public void Reconcile_ShrinkingDesiredSet_LeavesExistingWorkersAndCapacityIntact()
+    {
+        // M2/M3 wiring (whisper-subs-9gq): Reconcile now diffs the desired set, but stays GROW-ONLY — a worker
+        // dropped from 'desired' must NOT be removed or shrink capacity (it is reported for observability only;
+        // it stays live until the next idle rebuild / restart). Proves the (now-wired) DiffWorkers 'removed'
+        // path does not disturb existing workers or the concurrency ceiling.
+        var pool = new WorkerPool(new[] { Worker("a", 1), Worker("b", 2) });
+        Assert.Equal(2, pool.WorkerCount);
+        Assert.Equal(3, pool.TotalCapacity);
+
+        var count = pool.Reconcile(new[] { Worker("a", 1) });   // "b" dropped from desired
+
+        Assert.Equal(2, count);
+        Assert.Equal(2, pool.WorkerCount);                       // "b" still live (grow-only)
+        Assert.Equal(3, pool.TotalCapacity);                     // capacity unchanged — no shrink
+        Assert.Contains(pool.Snapshot(), s => s.Id == "b");
+    }
 }

--- a/WhisperSubs.Tests/WorkerPoolTests.cs
+++ b/WhisperSubs.Tests/WorkerPoolTests.cs
@@ -158,4 +158,28 @@ public class WorkerPoolTests
         pool.Release(b.Key);
         Assert.Equal(0, pool.ActiveJobs);            // both released cleanly (would be 1 if released by Id)
     }
+
+    [Fact]
+    public async Task Ctor_DuplicateIds_KeepsBothWorkers_DistinctRoutingKeys_AndSummedCapacity()
+    {
+        // Characterization (whisper-subs-9gq): two workers colliding on Id must NOT collapse — the ctor's
+        // collision-safe scheme keys them "dup" and "dup#1", and capacity is the SUM of their capped
+        // concurrencies. Pins the routing-key behavior so a refactor can't silently merge them (which would
+        // drop a worker / halve capacity). Snapshot still surfaces both (each under its own Id "dup").
+        var pool = new WorkerPool(new[] { Worker("dup", 2), Worker("dup", 3) });
+
+        Assert.Equal(2, pool.WorkerCount);
+        Assert.Equal(5, pool.TotalCapacity);        // 2 + 3
+        Assert.Equal(2, pool.Snapshot().Count);     // both present
+
+        // The internal routing keys are observable via the lease keys: filling all 5 slots must touch BOTH
+        // "dup" and "dup#1", proving the collision suffix keeps the reverse key→worker lookup unambiguous.
+        var leases = new System.Collections.Generic.List<WorkerLease>();
+        for (var i = 0; i < 5; i++) leases.Add(await pool.AcquireAsync(AnyJob, default));
+        var keys = leases.Select(l => l.Key).Distinct().OrderBy(k => k, System.StringComparer.Ordinal).ToList();
+        Assert.Equal(new[] { "dup", "dup#1" }, keys);
+
+        foreach (var l in leases) pool.Release(l.Key);
+        Assert.Equal(0, pool.ActiveJobs);
+    }
 }

--- a/WhisperSubs.Tests/WorkerSignatureTests.cs
+++ b/WhisperSubs.Tests/WorkerSignatureTests.cs
@@ -1,0 +1,82 @@
+using WhisperSubs.Configuration;
+using WhisperSubs.Controller;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+/// <summary>
+/// whisper-subs-9gq: the workers-signature guard that lets ReconcileWorkers skip a provider rebuild when the
+/// configured worker set did not actually change — so an unrelated config save (e.g. toggling PauseOnPlayback)
+/// does not needlessly news up RemoteWhisperProvider/HttpClient instances, while any real worker change (add,
+/// concurrency, URL/model) flips the signature and triggers the reconcile.
+/// </summary>
+public class WorkerSignatureTests
+{
+    [Fact]
+    public void Signature_UnrelatedConfigChange_IsStable()
+    {
+        var a = new PluginConfiguration();
+        var b = new PluginConfiguration { PauseOnPlayback = true, WhisperThreadCount = 8, EnableTranslation = true };
+
+        // No worker fields changed → identical signature → ReconcileWorkers no-ops (no rebuild).
+        Assert.Equal(
+            SubtitleQueueService.ComputeWorkersSignature(a),
+            SubtitleQueueService.ComputeWorkersSignature(b));
+    }
+
+    [Fact]
+    public void Signature_ChangesWhenAWorkerIsAdded()
+    {
+        var before = new PluginConfiguration();
+        var after = new PluginConfiguration();
+        after.Workers.Add(new WhisperWorker { Id = "mini", ApiUrl = "http://192.168.1.10:8080", MaxConcurrency = 2 });
+
+        Assert.NotEqual(
+            SubtitleQueueService.ComputeWorkersSignature(before),
+            SubtitleQueueService.ComputeWorkersSignature(after));
+    }
+
+    [Fact]
+    public void Signature_ChangesWhenWorkerConcurrencyChanges()
+    {
+        var one = new PluginConfiguration();
+        one.Workers.Add(new WhisperWorker { Id = "mini", ApiUrl = "http://x:8080", MaxConcurrency = 1 });
+        var four = new PluginConfiguration();
+        four.Workers.Add(new WhisperWorker { Id = "mini", ApiUrl = "http://x:8080", MaxConcurrency = 4 });
+
+        Assert.NotEqual(
+            SubtitleQueueService.ComputeWorkersSignature(one),
+            SubtitleQueueService.ComputeWorkersSignature(four));
+    }
+
+    [Fact]
+    public void Signature_ChangesWhenEnableLocalWorkerToggles()
+    {
+        var withLocal = new PluginConfiguration { EnableLocalWorker = true };
+        withLocal.Workers.Add(new WhisperWorker { Id = "mini", ApiUrl = "http://x:8080" });
+        var withoutLocal = new PluginConfiguration { EnableLocalWorker = false };
+        withoutLocal.Workers.Add(new WhisperWorker { Id = "mini", ApiUrl = "http://x:8080" });
+
+        Assert.NotEqual(
+            SubtitleQueueService.ComputeWorkersSignature(withLocal),
+            SubtitleQueueService.ComputeWorkersSignature(withoutLocal));
+    }
+
+    [Fact]
+    public void Signature_IgnoresDisabledAndBlankWorkerRows()
+    {
+        // A disabled or URL-less row contributes NO worker to the pool (BuildWorkers filters it), so it must
+        // not alter the signature. Both configs have a non-empty Workers list (⇒ ExplicitList plan) but no
+        // effective workers, so their signatures must match.
+        var twoNoise = new PluginConfiguration { EnableLocalWorker = true };
+        twoNoise.Workers.Add(new WhisperWorker { Id = "off", ApiUrl = "http://x:8080", Enabled = false });
+        twoNoise.Workers.Add(new WhisperWorker { Id = "blank", ApiUrl = "", Enabled = true });
+
+        var oneNoise = new PluginConfiguration { EnableLocalWorker = true };
+        oneNoise.Workers.Add(new WhisperWorker { Id = "off2", ApiUrl = "http://y:9090", Enabled = false });
+
+        Assert.Equal(
+            SubtitleQueueService.ComputeWorkersSignature(twoNoise),
+            SubtitleQueueService.ComputeWorkersSignature(oneNoise));
+    }
+}

--- a/WhisperSubs.Tests/WorkerSignatureTests.cs
+++ b/WhisperSubs.Tests/WorkerSignatureTests.cs
@@ -79,4 +79,67 @@ public class WorkerSignatureTests
             SubtitleQueueService.ComputeWorkersSignature(twoNoise),
             SubtitleQueueService.ComputeWorkersSignature(oneNoise));
     }
+
+    [Fact]
+    public void Signature_TwoEqualWorkerConfigs_ProduceEqualSignature_SoDoubleSaveIsNoOp()
+    {
+        // Double-save no-op: two separately-built but value-equal configs must yield the SAME signature, so a
+        // repeated config save with nothing changed skips the provider-constructing rebuild in ReconcileWorkers.
+        var a = new PluginConfiguration();
+        a.Workers.Add(new WhisperWorker { Id = "a", ApiUrl = "http://x:8080", MaxConcurrency = 2, CostWeight = 1.5 });
+        a.Workers.Add(new WhisperWorker { Id = "b", ApiUrl = "http://y:9090", MaxConcurrency = 1 });
+
+        var b = new PluginConfiguration();
+        b.Workers.Add(new WhisperWorker { Id = "a", ApiUrl = "http://x:8080", MaxConcurrency = 2, CostWeight = 1.5 });
+        b.Workers.Add(new WhisperWorker { Id = "b", ApiUrl = "http://y:9090", MaxConcurrency = 1 });
+
+        Assert.Equal(
+            SubtitleQueueService.ComputeWorkersSignature(a),
+            SubtitleQueueService.ComputeWorkersSignature(b));
+    }
+
+    [Fact]
+    public void Signature_IsOrderInsensitive_RowReorderProducesSameSignature()
+    {
+        // L1: merely reordering worker rows must NOT change the signature (else a no-op save runs a needless,
+        // HttpClient-churning rebuild). Same workers, different row order → identical signature.
+        var ab = new PluginConfiguration();
+        ab.Workers.Add(new WhisperWorker { Id = "a", ApiUrl = "http://x:8080", MaxConcurrency = 2 });
+        ab.Workers.Add(new WhisperWorker { Id = "b", ApiUrl = "http://y:9090", MaxConcurrency = 1 });
+
+        var ba = new PluginConfiguration();
+        ba.Workers.Add(new WhisperWorker { Id = "b", ApiUrl = "http://y:9090", MaxConcurrency = 1 });
+        ba.Workers.Add(new WhisperWorker { Id = "a", ApiUrl = "http://x:8080", MaxConcurrency = 2 });
+
+        Assert.Equal(
+            SubtitleQueueService.ComputeWorkersSignature(ab),
+            SubtitleQueueService.ComputeWorkersSignature(ba));
+    }
+
+    [Fact]
+    public void Signature_OrderInsensitive_StillChangesOnRealEdits()
+    {
+        // L1 guard: order-insensitivity must not swallow a REAL change — a url/concurrency edit or an added
+        // worker still flips the signature so ReconcileWorkers rebuilds.
+        var baseCfg = new PluginConfiguration();
+        baseCfg.Workers.Add(new WhisperWorker { Id = "a", ApiUrl = "http://x:8080", MaxConcurrency = 2 });
+        baseCfg.Workers.Add(new WhisperWorker { Id = "b", ApiUrl = "http://y:9090", MaxConcurrency = 1 });
+        var baseSig = SubtitleQueueService.ComputeWorkersSignature(baseCfg);
+
+        var urlChanged = new PluginConfiguration();
+        urlChanged.Workers.Add(new WhisperWorker { Id = "a", ApiUrl = "http://x:8080", MaxConcurrency = 2 });
+        urlChanged.Workers.Add(new WhisperWorker { Id = "b", ApiUrl = "http://CHANGED:9090", MaxConcurrency = 1 });
+        Assert.NotEqual(baseSig, SubtitleQueueService.ComputeWorkersSignature(urlChanged));
+
+        var concurrencyChanged = new PluginConfiguration();
+        concurrencyChanged.Workers.Add(new WhisperWorker { Id = "a", ApiUrl = "http://x:8080", MaxConcurrency = 4 });
+        concurrencyChanged.Workers.Add(new WhisperWorker { Id = "b", ApiUrl = "http://y:9090", MaxConcurrency = 1 });
+        Assert.NotEqual(baseSig, SubtitleQueueService.ComputeWorkersSignature(concurrencyChanged));
+
+        var added = new PluginConfiguration();
+        added.Workers.Add(new WhisperWorker { Id = "a", ApiUrl = "http://x:8080", MaxConcurrency = 2 });
+        added.Workers.Add(new WhisperWorker { Id = "b", ApiUrl = "http://y:9090", MaxConcurrency = 1 });
+        added.Workers.Add(new WhisperWorker { Id = "c", ApiUrl = "http://z:7070", MaxConcurrency = 1 });
+        Assert.NotEqual(baseSig, SubtitleQueueService.ComputeWorkersSignature(added));
+    }
 }


### PR DESCRIPTION
Bead **whisper-subs-9gq** (P2). A worker added to config mid-backlog never joined the live pool (`GetPool` only rebuilds when idle + `ActiveJobs==0`), so the only way to activate e.g. a newly-added Mac mini worker was a Jellyfin restart. This makes it join the **live** pool on config-save, no restart, without dropping in-flight jobs on other workers.

## What changed
- **`WorkerPool`**: backpressure semaphore ctor `new SemaphoreSlim(cap, cap)` → **`new SemaphoreSlim(cap)`** (uncapped) so `Release(delta)` can grow capacity live. `TotalCapacity` now `private set`. Extracted `ComputeKeys`/`InitWorkerSlot`/`Cap` shared by ctor + reconcile (ctor behavior unchanged). New pure `DiffWorkers(currentKeys, desired)` + **`Reconcile(desired)`** — **grow-only**: under the pool `_gate` it adds new workers (existing untouched), grows `TotalCapacity`, then `Release(addedPermits)` **outside** the lock. Live *removal* is deferred (diffed, not applied).
- **`SubtitleQueueService.ReconcileWorkers(config, loggerFactory)`**: under `_poolGate`; no-op if no pool; **skips when a workers-signature is unchanged** (`ComputeWorkersSignature`) so unrelated config saves don't churn providers; else `Reconcile(WorkerRegistry.BuildWorkers(...))`. `GetPool` records the signature on (re)build.
- **Trigger**: `Plugin` subscribes `ConfigurationChanged` (ctor gains DI `ILoggerFactory`) → `ReconcileWorkers` (swallow+log). Plus an admin `[HttpPost("Workers/Reload")]` endpoint as a manual fallback / verification hook.

## Concurrency safety
Reconcile mutates worker maps under `_gate` (same lock as `PickLocked`/`Release`) → dispatcher sees old-or-new atomically. Map-add precedes `Release(addedPermits)` → a waiter woken by the new permit sees the added worker. Per-job `Acquire`/`Release` stays 1:1 (Reconcile is the only `Release(delta>1)`), so the uncapped semaphore can't be over-released. `_dispatchGate` dequeue+reserve and `queue.json` crash-durability untouched. Grow-only ⇒ no permit-shrink accounting. Independent of the single-drain (ezg) bead — safety derives from `_gate`.

## Verification
`dotnet build -c Release` → **0 warnings**. Full suite → **985 passed / 0 failed** (973 + 12 new: capacity/semaphore growth, mid-drain waiter routed to the new worker, no-op on unchanged set, no-teardown of in-flight worker, DiffWorkers incl. duplicate-Id collision, signature guard).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin-only option to reload transcription workers without restarting the application.
  * Worker configuration changes now apply automatically after saving, including increased capacity and newly added workers.
  * Added clear status reporting and logging for successful or failed worker reloads.

* **Bug Fixes**
  * Improved handling of duplicate worker identifiers to keep workers distinct and correctly track capacity.

* **Tests**
  * Added coverage for worker reconciliation, capacity expansion, configuration changes, and duplicate identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->