### PR TITLE
docs: thank supporters in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,6 +555,11 @@ See [ROADMAP.md](ROADMAP.md) for planned features and design details.
 - [jellyfin-telegram-channel-sync](https://github.com/GeiserX/jellyfin-telegram-channel-sync) — Sync Jellyfin access with Telegram channel membership
 
 
+## Supporters
+
+> This project is made possible by generous supporters:
+> **yskaa001**
+
 ## License
 
 This project is licensed under the **GNU General Public License v3.0**. See the [LICENSE](LICENSE) file for the full text.


### PR DESCRIPTION
Adds a short Supporters section to the README, matching the format used in Telegram-Archive:

```
## Supporters

> This project is made possible by generous supporters:
> **yskaa001**
```

Placed just before the License section. Docs-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a “Supporters” section to the README recognizing a project supporter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->