### PR TITLE
fix(#138): surface provider errors, cap uploads, and add compressed upload formats

### DIFF
--- a/Configuration/WhisperWorker.cs
+++ b/Configuration/WhisperWorker.cs
@@ -33,5 +33,28 @@ namespace WhisperSubs.Configuration
 
         /// <summary>Whether this worker can translate to English. Default true.</summary>
         public bool CanTranslate { get; set; } = true;
+
+        /// <summary>
+        /// Largest upload this endpoint accepts, in bytes. <c>0</c> (default) means unlimited, which is the
+        /// pre-existing behaviour and what every self-hosted worker wants. Set it for a hosted provider
+        /// (OpenAI and Groq free tier are 25 MB; Groq dev tier 100 MB) so an oversized title fails fast with
+        /// a useful message instead of a bare HTTP 413 after the whole file has been uploaded.
+        /// There is deliberately no non-zero default: real caps differ by ~440x, so a guess would break
+        /// working setups.
+        /// </summary>
+        public long MaxUploadBytes { get; set; }
+
+        /// <summary>
+        /// Audio format used when uploading to THIS worker: <c>wav</c> (default), <c>flac</c> or
+        /// <c>opus</c>. The plugin always extracts 16 kHz mono PCM WAV — 1.92 MB per minute — so a
+        /// 40-minute title is 76.8 MB and exceeds every hosted provider's cap. FLAC is lossless and about
+        /// half the size; Opus (24 kbps mono) is about a tenth, enough for a feature film.
+        /// <para>
+        /// Default is <c>wav</c> ON PURPOSE: whisper.cpp's whisper-server decodes WAV only, and this
+        /// project's own worker image ships without ffmpeg, so anything else would break every self-hosted
+        /// worker. Only enable a compressed format on an endpoint documented to accept it.
+        /// </para>
+        /// </summary>
+        public string UploadCodec { get; set; } = "wav";
     }
 }

--- a/Controller/Workers/RemoteAudioEncoder.cs
+++ b/Controller/Workers/RemoteAudioEncoder.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace WhisperSubs.Controller.Workers
+{
+    /// <summary>
+    /// Re-encodes the extracted WAV into a smaller upload format for a remote worker (issue #138).
+    /// <para>
+    /// This deliberately sits at the UPLOAD boundary rather than in the audio-extraction path: extraction is
+    /// shared with the LOCAL whisper-cli provider, which must keep receiving byte-identical 16 kHz mono PCM.
+    /// Compressing here means a local install is untouched by construction.
+    /// </para>
+    /// <para>
+    /// Process I/O, so excluded from coverage; the argument construction and format policy live in the pure,
+    /// unit-tested <see cref="RemoteUploadFormat"/>.
+    /// </para>
+    /// </summary>
+    [ExcludeFromCodeCoverage(Justification = "FFmpeg process I/O; the argument/format policy is tested in RemoteUploadFormatTests")]
+    public static class RemoteAudioEncoder
+    {
+        private static readonly string[] FfmpegCandidates =
+        {
+            "/usr/lib/jellyfin-ffmpeg/ffmpeg",
+            "ffmpeg",
+            "/usr/bin/ffmpeg",
+        };
+
+        /// <summary>
+        /// Produces the file to upload. Returns <paramref name="sourceWavPath"/> unchanged when the worker
+        /// uses WAV (the default) or when re-encoding is impossible — never fails a transcription just
+        /// because compression could not run; the caller then uploads the original and, if it is too big,
+        /// gets the normal pre-flight/413 path with a clear message.
+        /// </summary>
+        /// <returns>
+        /// The path to upload, and whether it is a temporary file the caller must delete.
+        /// </returns>
+        public static async Task<(string Path, bool IsTemporary)> PrepareUploadAsync(
+            string sourceWavPath, string? codec, ILogger logger, CancellationToken cancellationToken)
+        {
+            if (!RemoteUploadFormat.RequiresReencode(codec))
+            {
+                return (sourceWavPath, false);
+            }
+
+            var ffmpeg = FindFfmpeg();
+            if (ffmpeg is null)
+            {
+                logger.LogWarning(
+                    "Upload format {Codec} is configured but FFmpeg was not found; uploading the original WAV instead.",
+                    RemoteUploadFormat.Normalize(codec));
+                return (sourceWavPath, false);
+            }
+
+            var target = Path.Combine(
+                Path.GetTempPath(),
+                $"whispersubs_upload_{Guid.NewGuid():N}{RemoteUploadFormat.Extension(codec)}");
+
+            try
+            {
+                var arguments = RemoteUploadFormat.BuildFfmpegArguments(sourceWavPath, target, codec);
+                using var process = new Process
+                {
+                    StartInfo = new ProcessStartInfo
+                    {
+                        FileName = ffmpeg,
+                        Arguments = arguments,
+                        RedirectStandardError = true,
+                        RedirectStandardOutput = true,
+                        UseShellExecute = false,
+                        CreateNoWindow = true,
+                    },
+                };
+
+                process.Start();
+                // Drain both pipes so a chatty ffmpeg cannot deadlock on a full buffer.
+                var stderr = process.StandardError.ReadToEndAsync(cancellationToken);
+                var stdout = process.StandardOutput.ReadToEndAsync(cancellationToken);
+                await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+                await Task.WhenAll(stderr, stdout).ConfigureAwait(false);
+
+                if (process.ExitCode != 0 || !File.Exists(target) || new FileInfo(target).Length == 0)
+                {
+                    logger.LogWarning(
+                        "Re-encoding the upload to {Codec} failed (exit {ExitCode}); uploading the original WAV instead.",
+                        RemoteUploadFormat.Normalize(codec), process.ExitCode);
+                    TryDelete(target);
+                    return (sourceWavPath, false);
+                }
+
+                var sourceBytes = new FileInfo(sourceWavPath).Length;
+                var uploadBytes = new FileInfo(target).Length;
+
+                // A re-encode that GREW the file is never worth uploading. This is not hypothetical: ffmpeg's
+                // FLAC encoder defaults to 24-bit, and the vendor-published command (without -sample_fmt s16)
+                // measurably produces a file larger than the 16-bit PCM input.
+                if (uploadBytes >= sourceBytes)
+                {
+                    logger.LogWarning(
+                        "Re-encoded upload ({UploadBytes} bytes) is not smaller than the source ({SourceBytes} bytes); uploading the original WAV instead.",
+                        uploadBytes, sourceBytes);
+                    TryDelete(target);
+                    return (sourceWavPath, false);
+                }
+
+                logger.LogInformation(
+                    "Prepared {Codec} upload: {UploadSize} (from {SourceSize})",
+                    RemoteUploadFormat.Normalize(codec),
+                    RemoteErrorGuidance.FormatBytes(uploadBytes),
+                    RemoteErrorGuidance.FormatBytes(sourceBytes));
+
+                return (target, true);
+            }
+            catch (OperationCanceledException)
+            {
+                TryDelete(target);
+                throw;
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex,
+                    "Could not re-encode the upload to {Codec}; uploading the original WAV instead.",
+                    RemoteUploadFormat.Normalize(codec));
+                TryDelete(target);
+                return (sourceWavPath, false);
+            }
+        }
+
+        /// <summary>Deletes a temporary upload file, ignoring failures.</summary>
+        public static void TryDelete(string? path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+            {
+                return;
+            }
+
+            try
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+            catch (Exception)
+            {
+                // A leftover temp file is harmless; never fail a transcription over cleanup.
+            }
+        }
+
+        private static string? FindFfmpeg()
+        {
+            foreach (var candidate in FfmpegCandidates)
+            {
+                if (Path.IsPathRooted(candidate))
+                {
+                    if (File.Exists(candidate))
+                    {
+                        return candidate;
+                    }
+
+                    continue;
+                }
+
+                // Bare name: let the OS resolve it from PATH at start time.
+                return candidate;
+            }
+
+            return null;
+        }
+    }
+}

--- a/Controller/Workers/RemoteErrorGuidance.cs
+++ b/Controller/Workers/RemoteErrorGuidance.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Globalization;
+using System.Net;
+
+namespace WhisperSubs.Controller.Workers
+{
+    /// <summary>
+    /// Turns an upstream HTTP failure into one actionable sentence an admin can act on without reading
+    /// documentation or enabling debug logging (issue #138: the reporter saw a bare "HTTP 413"/"HTTP 400"
+    /// and had no way to find out what to change). Pure and unit-tested; the caller appends the result to
+    /// the error surfaced in the log, the queue's last-error, and the config page.
+    /// </summary>
+    public static class RemoteErrorGuidance
+    {
+        /// <summary>16 kHz mono s16le PCM, the format the plugin extracts and uploads by default.</summary>
+        private const double BytesPerAudioSecond = 32000.0;
+
+        /// <summary>
+        /// Short, actionable advice for a status code. Empty when we have nothing useful to add beyond the
+        /// upstream's own message (never invent guidance we cannot stand behind).
+        /// </summary>
+        public static string For(HttpStatusCode statusCode) => (int)statusCode switch
+        {
+            401 => "The endpoint rejected the API key. Check it is pasted in full, belongs to this provider, and has not expired.",
+            403 => "The key was accepted but this account is not allowed to use it here - check model access and billing on the provider's dashboard.",
+            404 => "No transcription endpoint at that address. Enter only the BASE url (WhisperSubs appends /v1/audio/transcriptions itself), so it must not already end in /v1.",
+            405 or 501 => "That address exists but does not accept audio uploads - it is probably a web page or a chat-only API, not a speech-to-text endpoint.",
+            413 => "The upload was larger than this endpoint accepts. Set 'Max upload size' on this worker, switch its upload format to FLAC or Opus, or use a self-hosted worker (no limit).",
+            429 => "Rate limited by the provider. Lower this worker's max concurrency, or raise its cost weight so a local worker is preferred.",
+            >= 500 and <= 599 => "The endpoint failed on its own side - nothing is wrong with your settings. Retry later, or check the provider's status page.",
+            _ => string.Empty,
+        };
+
+        /// <summary>
+        /// Explains an oversized upload in the admin's own terms: how big the audio actually is, what the
+        /// endpoint accepts, and roughly how much audio that allows. Uses the SOURCE (uncompressed) size,
+        /// because that is what the duration figure must be derived from.
+        /// </summary>
+        public static string DescribeOversizedUpload(long sourceAudioBytes, long maxUploadBytes)
+        {
+            if (sourceAudioBytes <= 0 || maxUploadBytes <= 0)
+            {
+                return string.Empty;
+            }
+
+            var minutes = sourceAudioBytes / BytesPerAudioSecond / 60.0;
+            var allowedMinutes = maxUploadBytes / BytesPerAudioSecond / 60.0;
+
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                "This {0:F0}-minute title is {1} of audio, but this endpoint accepts {2} (about {3:F0} minutes of uncompressed audio). Nothing was uploaded.",
+                minutes,
+                FormatBytes(sourceAudioBytes),
+                FormatBytes(maxUploadBytes),
+                allowedMinutes);
+        }
+
+        /// <summary>Human-friendly byte size (invariant culture, so logs never drift with locale).</summary>
+        public static string FormatBytes(long bytes)
+        {
+            if (bytes < 0)
+            {
+                bytes = 0;
+            }
+
+            return bytes >= 1024L * 1024L * 1024L
+                ? string.Format(CultureInfo.InvariantCulture, "{0:F1} GB", bytes / 1024.0 / 1024.0 / 1024.0)
+                : bytes >= 1024L * 1024L
+                    ? string.Format(CultureInfo.InvariantCulture, "{0:F1} MB", bytes / 1024.0 / 1024.0)
+                    : string.Format(CultureInfo.InvariantCulture, "{0:F0} KB", Math.Ceiling(bytes / 1024.0));
+        }
+    }
+}

--- a/Controller/Workers/RemoteUploadFormat.cs
+++ b/Controller/Workers/RemoteUploadFormat.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+
+namespace WhisperSubs.Controller.Workers
+{
+    /// <summary>
+    /// Pure policy for the audio format a REMOTE worker is uploaded in (issue #138).
+    /// <para>
+    /// The plugin extracts 16 kHz mono s16le PCM WAV — 32,000 bytes per audio-second, i.e. 1.92 MB per
+    /// minute. Hosted providers cap uploads (OpenAI 25 MB, Groq 25 MB free / 100 MB dev), so a 40-minute
+    /// title at 76.8 MB is refused with HTTP 413 and a 2-hour film has no chance. Re-encoding for the
+    /// upload fixes that without touching the extracted WAV that the LOCAL whisper-cli path uses.
+    /// </para>
+    /// <para>
+    /// DEFAULT IS <see cref="Wav"/> — i.e. off. This is not timidity: whisper.cpp's own
+    /// <c>whisper-server</c> decodes WAV only, and this project's worker image ships with
+    /// <c>INSTALL_FFMPEG=false</c>/<c>CONVERT=false</c>, so sending it anything else would break every
+    /// self-hosted worker. Compression is opt-in per worker, for hosted endpoints that document support.
+    /// </para>
+    /// </summary>
+    public static class RemoteUploadFormat
+    {
+        public const string Wav = "wav";
+        public const string Flac = "flac";
+        public const string Opus = "opus";
+
+        /// <summary>Bytes per second of the extracted 16 kHz mono s16le PCM source.</summary>
+        public const double SourceBytesPerSecond = 32000.0;
+
+        /// <summary>Opus bitrate used for uploads. 24 kbps mono keeps a 2-hour film near 20 MB.</summary>
+        public const int OpusBitrateKbps = 24;
+
+        private static readonly HashSet<string> Supported =
+            new(StringComparer.OrdinalIgnoreCase) { Wav, Flac, Opus };
+
+        /// <summary>
+        /// Normalizes a configured codec value. Anything unrecognised, empty, or null falls back to
+        /// <see cref="Wav"/> — an unknown codec must never silently produce an upload a worker cannot decode.
+        /// </summary>
+        public static string Normalize(string? codec)
+        {
+            var trimmed = (codec ?? string.Empty).Trim();
+            return Supported.Contains(trimmed) ? trimmed.ToLowerInvariant() : Wav;
+        }
+
+        /// <summary>True when the configured codec requires a re-encode before upload.</summary>
+        public static bool RequiresReencode(string? codec)
+            => !string.Equals(Normalize(codec), Wav, StringComparison.Ordinal);
+
+        /// <summary>
+        /// Multipart file name for a codec. Providers routinely sniff the format from the EXTENSION, so a
+        /// FLAC body named "audio.wav" gets rejected or mis-decoded — the name must match the bytes.
+        /// </summary>
+        public static string FileName(string? codec) => Normalize(codec) switch
+        {
+            Flac => "audio.flac",
+            Opus => "audio.ogg",
+            _ => "audio.wav",
+        };
+
+        /// <summary>Content-Type for a codec, matching <see cref="FileName"/>.</summary>
+        public static string ContentType(string? codec) => Normalize(codec) switch
+        {
+            Flac => "audio/flac",
+            Opus => "audio/ogg",
+            _ => "audio/wav",
+        };
+
+        /// <summary>File extension (with dot) for the temporary re-encoded upload.</summary>
+        public static string Extension(string? codec) => Normalize(codec) switch
+        {
+            Flac => ".flac",
+            Opus => ".ogg",
+            _ => ".wav",
+        };
+
+        /// <summary>
+        /// FFmpeg arguments that re-encode the extracted WAV for upload.
+        /// <para>
+        /// FLAC MUST pass <c>-sample_fmt s16</c>. Without it ffmpeg's FLAC encoder defaults to 24-bit
+        /// (sample_fmt s32) and losslessly compresses samples 1.5x wider than the 16-bit source — measured
+        /// on a real title, that produces a file LARGER than the PCM input (19,713,918 vs 19,200,102 bytes),
+        /// i.e. the "fix" would make the 413 worse. Groq's own published command omits this flag.
+        /// </para>
+        /// </summary>
+        public static string BuildFfmpegArguments(string sourceWavPath, string targetPath, string? codec)
+        {
+            if (string.IsNullOrWhiteSpace(sourceWavPath))
+            {
+                throw new ArgumentException("Source path is required", nameof(sourceWavPath));
+            }
+            if (string.IsNullOrWhiteSpace(targetPath))
+            {
+                throw new ArgumentException("Target path is required", nameof(targetPath));
+            }
+
+            var codecArgs = Normalize(codec) switch
+            {
+                // -sample_fmt s16: see remarks. Lossless, bit-exact duration, ~53% of PCM (measured).
+                Flac => "-c:a flac -sample_fmt s16",
+                // Ogg Opus. Mandatory pre-skip in the container keeps duration sample-accurate on decode;
+                // ~9% of PCM at 24 kbps (measured).
+                Opus => string.Format(CultureInfo.InvariantCulture, "-c:a libopus -b:a {0}k", OpusBitrateKbps),
+                _ => throw new ArgumentException($"Codec '{codec}' needs no re-encode", nameof(codec)),
+            };
+
+            // -vn: no video. 16 kHz mono matches what whisper consumes anyway, and the source is already
+            // in that shape, so this is a straight re-encode with no resampling surprise.
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                "-i \"{0}\" -vn -ac 1 -ar 16000 {1} -y \"{2}\"",
+                sourceWavPath,
+                codecArgs,
+                targetPath);
+        }
+
+        /// <summary>
+        /// Approximate uploaded size for a codec, from the SOURCE PCM size. Ratios are measured on real
+        /// film audio with this project's ffmpeg build, not vendor claims. Used only for advice/estimates —
+        /// never as a substitute for the real file length.
+        /// </summary>
+        public static long EstimateUploadBytes(long sourceBytes, string? codec)
+        {
+            if (sourceBytes <= 0)
+            {
+                return 0;
+            }
+
+            var ratio = Normalize(codec) switch
+            {
+                Flac => 0.53,
+                Opus => 0.091,
+                _ => 1.0,
+            };
+
+            return (long)Math.Round(sourceBytes * ratio, MidpointRounding.AwayFromZero);
+        }
+    }
+}

--- a/Controller/Workers/UploadPreflight.cs
+++ b/Controller/Workers/UploadPreflight.cs
@@ -1,0 +1,62 @@
+namespace WhisperSubs.Controller.Workers
+{
+    /// <summary>
+    /// Decides whether an upload can possibly succeed BEFORE spending the bandwidth (issue #138).
+    /// <para>
+    /// The plugin knows the exact byte count before a single byte goes on the wire, so eating an HTTP 413
+    /// after pushing 77 MB is pure waste — and on a metered connection or a rate-limited provider it costs
+    /// real money and quota. Failing fast also lets us say something the raw 413 never could: how big the
+    /// audio actually is, what the endpoint accepts, and roughly how much audio that allows.
+    /// </para>
+    /// </summary>
+    public static class UploadPreflight
+    {
+        /// <summary>
+        /// Whether an upload of <paramref name="uploadBytes"/> is permitted for a worker whose configured
+        /// cap is <paramref name="maxUploadBytes"/>.
+        /// <para>
+        /// A cap of 0 (the default) means "unlimited" and ALWAYS allows the upload — this is what keeps the
+        /// change byte-identical for every existing install, including self-hosted workers that have no
+        /// limit at all. There is deliberately no non-zero default: real caps span 440x (Groq free 25 MB,
+        /// Groq dev 100 MB, this project's own worker 8 GiB), so any guess would block working setups.
+        /// </para>
+        /// </summary>
+        public static bool IsAllowed(long uploadBytes, long maxUploadBytes)
+            => maxUploadBytes <= 0 || uploadBytes <= maxUploadBytes;
+
+        /// <summary>
+        /// Explains a blocked upload in the admin's own terms, including what to change. Returns an empty
+        /// string when the upload is allowed.
+        /// </summary>
+        /// <param name="sourceAudioBytes">Size of the extracted uncompressed WAV (drives the duration figure).</param>
+        /// <param name="uploadBytes">Size actually destined for the wire (may be a compressed re-encode).</param>
+        /// <param name="maxUploadBytes">The worker's configured cap; 0 = unlimited.</param>
+        /// <param name="codec">The worker's configured upload codec, for tailored advice.</param>
+        public static string ExplainIfBlocked(
+            long sourceAudioBytes, long uploadBytes, long maxUploadBytes, string? codec)
+        {
+            if (IsAllowed(uploadBytes, maxUploadBytes))
+            {
+                return string.Empty;
+            }
+
+            var message = RemoteErrorGuidance.DescribeOversizedUpload(sourceAudioBytes, maxUploadBytes);
+
+            // Tailor the advice to what is actually still available to this worker.
+            message += RemoteUploadFormat.Normalize(codec) switch
+            {
+                RemoteUploadFormat.Opus =>
+                    " Already using the smallest upload format; this title is too long for this endpoint —"
+                    + " use a self-hosted worker, which has no limit.",
+                RemoteUploadFormat.Flac =>
+                    " Switch this worker's upload format to Opus (about a tenth the size of the original"
+                    + " audio), or use a self-hosted worker.",
+                _ =>
+                    " Set this worker's upload format to FLAC (about half) or Opus (about a tenth), or use"
+                    + " a self-hosted worker, which has no limit.",
+            };
+
+            return message;
+        }
+    }
+}

--- a/Controller/Workers/UpstreamErrorSanitizer.cs
+++ b/Controller/Workers/UpstreamErrorSanitizer.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace WhisperSubs.Controller.Workers
+{
+    /// <summary>
+    /// Pure, total sanitizer for text that came from an UNTRUSTED upstream endpoint (a worker's error
+    /// response, an exception message, a configured URL) before it is shown to an admin or written to the
+    /// Jellyfin log.
+    /// <para>
+    /// Why this exists: issue #138. A remote endpoint refused the upload and the admin saw only
+    /// "HTTP 413" / "HTTP 400" — the provider's own explanation was captured and then discarded, so the
+    /// failure was undiagnosable without debug logging. Echoing the upstream body fixes that, but the body
+    /// is attacker-influenced text that may contain the admin's own API key (some gateways echo the request
+    /// back), presigned URLs, control characters (log forging, CWE-117) or markup (XSS, CWE-79).
+    /// </para>
+    /// <para>
+    /// SECURITY-REVIEW: this is the ONLY boundary at which an upstream body may cross into the UI or the log.
+    /// The RAW body stays internal to RemoteApiException, because the response-format negotiation
+    /// pattern-matches against it — sanitizing before that would regress the #138 negotiation.
+    /// Order is load-bearing: redact BEFORE truncating, so a secret straddling the cut cannot be half-revealed.
+    /// Callers must render the result as text (textContent), never as HTML.
+    /// </para>
+    /// </summary>
+    public static class UpstreamErrorSanitizer
+    {
+        /// <summary>Default cap for a snippet shown in the config page or a log message.</summary>
+        public const int DefaultMaxLength = 400;
+
+        internal const string Redacted = "[redacted]";
+
+        private const RegexOptions Opts =
+            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled;
+
+        // A hostile body must never hang a transcription. Every pattern is bounded and fails CLOSED.
+        private static readonly TimeSpan Budget = TimeSpan.FromMilliseconds(250);
+
+        // Whole URL query strings. The single strongest rule: removes presigned-URL signatures
+        // (X-Amz-Signature, Google Signature=, Azure sig=), ?api_key=, ?api-version=, ?token= at a stroke.
+        private static readonly Regex UrlQuery = new(
+            @"(?<url>[a-z][a-z0-9+.\-]*://[^\s""'<>]+?)\?[^\s""'<>]*", Opts, Budget);
+
+        // URL userinfo: https://user:pass@host
+        private static readonly Regex UrlUserInfo = new(
+            @"(?<scheme>[a-z][a-z0-9+.\-]*://)[^/\s""'<>@]+@", Opts, Budget);
+
+        private static readonly Regex AuthHeader = new(
+            @"\b(?:proxy-)?authorization\b\s*[:=]\s*[""']?[^\r\n""',}]{4,}", Opts, Budget);
+
+        private static readonly Regex BearerToken = new(
+            @"\bbearer\s+[A-Za-z0-9._\-+/=]{8,}", Opts, Budget);
+
+        // JWTs before the generic base64 rule, so the whole token goes rather than one segment.
+        private static readonly Regex Jwt = new(
+            @"\beyJ[A-Za-z0-9_\-]{6,}\.[A-Za-z0-9_\-]{6,}\.[A-Za-z0-9_\-]{4,}\b", Opts, Budget);
+
+        // Provider-prefixed key families: sk-, sk-or-v1-, sk-proj-, gsk_ (Groq), xai-, ghp_, glpat-, hf_.
+        private static readonly Regex PrefixedKey = new(
+            @"\b(?:sk|rk|pk|gsk|xai|hf|ghp|gho|glpat)[-_][A-Za-z0-9_\-]{12,}", Opts, Budget);
+
+        private static readonly Regex NamedSecret = new(
+            @"\b(?<k>api[_\-]?key|apikey|access[_\-]?token|auth[_\-]?token|refresh[_\-]?token|" +
+            @"id[_\-]?token|client[_\-]?secret|secret|password|passwd|pwd|token|signature|sig)\b" +
+            @"\s*[""']?\s*[:=]\s*[""']?(?<v>[^\s""',&}\]]{4,})", Opts, Budget);
+
+        // Long high-entropy runs: no English word is 40 chars, and a 32+ hex run is a key, hash or request id.
+        private static readonly Regex LongBase64 = new(@"\b[A-Za-z0-9+/]{40,}={0,2}\b", Opts, Budget);
+        private static readonly Regex LongHex = new(@"\b[0-9a-f]{32,}\b", Opts, Budget);
+
+        private static readonly Regex Email = new(
+            @"\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b", Opts, Budget);
+
+        // Strips every Unicode "other" category in one rule: Cc (control, incl. CR/LF/TAB -> log forging),
+        // Cf (zero-width, BiDi overrides -> spoofing), Cs (lone surrogates from a UTF-8 cut at the capture
+        // bound), Co, Cn.
+        private static readonly Regex ControlChars = new(@"\p{C}+", RegexOptions.Compiled, Budget);
+        private static readonly Regex WhitespaceRun = new(@"\s{2,}", RegexOptions.Compiled, Budget);
+
+        /// <summary>
+        /// Redacts secrets from untrusted upstream text, flattens it to a single line, and caps its length.
+        /// Never throws; returns an empty string for null/blank input.
+        /// </summary>
+        /// <param name="body">Raw upstream text. May be null, empty, or hostile.</param>
+        /// <param name="apiKey">The worker's own configured key, for exact-match removal. May be null.</param>
+        /// <param name="maxLength">Cap applied AFTER redaction.</param>
+        public static string Sanitize(string? body, string? apiKey, int maxLength = DefaultMaxLength)
+        {
+            if (string.IsNullOrWhiteSpace(body))
+            {
+                return string.Empty;
+            }
+
+            if (maxLength < 16)
+            {
+                maxLength = 16;
+            }
+
+            var s = body;
+
+            // STEP 1 - the admin's own key, exactly. Highest-value rule: the realistic leak is a gateway
+            // reflecting the request (headers included) back in an error envelope. Guarded at length >= 8 so
+            // a short or placeholder key cannot blank out the whole message.
+            if (!string.IsNullOrWhiteSpace(apiKey))
+            {
+                var key = apiKey.Trim();
+                if (key.Length >= 8)
+                {
+                    s = s.Replace(key, Redacted, StringComparison.Ordinal);
+                    s = s.Replace(key, Redacted, StringComparison.OrdinalIgnoreCase);
+                    s = s.Replace(Uri.EscapeDataString(key), Redacted, StringComparison.OrdinalIgnoreCase);
+                }
+            }
+
+            // STEP 2 - pattern redaction. Order matters (URL query first; JWT before generic base64).
+            try
+            {
+                s = UrlQuery.Replace(s, m => m.Groups["url"].Value + "?" + Redacted);
+                s = UrlUserInfo.Replace(s, m => m.Groups["scheme"].Value + Redacted + "@");
+                s = AuthHeader.Replace(s, "authorization: " + Redacted);
+                s = BearerToken.Replace(s, "Bearer " + Redacted);
+                s = Jwt.Replace(s, Redacted);
+                s = PrefixedKey.Replace(s, Redacted);
+                s = NamedSecret.Replace(s, m => m.Groups["k"].Value + "=" + Redacted);
+                s = LongBase64.Replace(s, Redacted);
+                s = LongHex.Replace(s, Redacted);
+                s = Email.Replace(s, "[email]");
+            }
+            catch (RegexMatchTimeoutException)
+            {
+                // Fail CLOSED: a pathological body must never break diagnostics, and must never fall
+                // through to the raw text.
+                return "[error detail withheld: could not be sanitized]";
+            }
+
+            // STEP 3 - flatten to one safe line.
+            s = ControlChars.Replace(s, " ");
+            s = WhitespaceRun.Replace(s, " ").Trim();
+
+            // STEP 4 - cap LAST, so truncation can never re-expose a partially redacted secret.
+            if (s.Length > maxLength)
+            {
+                s = s[..(maxLength - 1)].TrimEnd() + "…";
+            }
+
+            return s;
+        }
+
+        /// <summary>
+        /// Sanitizes an endpoint URL for display or logging: drops userinfo and the entire query string.
+        /// An admin may legitimately paste a key into the URL (Azure-style "?api-version=", proxy
+        /// "?api_key="); without this that string reaches jellyfin.log and the config page verbatim.
+        /// </summary>
+        public static string SanitizeEndpoint(string? url)
+        {
+            if (string.IsNullOrWhiteSpace(url))
+            {
+                return string.Empty;
+            }
+
+            var trimmed = url.Trim();
+            if (!Uri.TryCreate(trimmed, UriKind.Absolute, out var uri))
+            {
+                return Sanitize(trimmed, apiKey: null, maxLength: 200);
+            }
+
+            // uri.Authority excludes userinfo by construction.
+            var query = string.IsNullOrEmpty(uri.Query) ? string.Empty : "?" + Redacted;
+            return uri.Scheme + "://" + uri.Authority + uri.AbsolutePath + query;
+        }
+    }
+}

--- a/Controller/Workers/WorkerConfigValidation.cs
+++ b/Controller/Workers/WorkerConfigValidation.cs
@@ -27,6 +27,16 @@ namespace WhisperSubs.Controller.Workers
                 return (false, "Max concurrency must be at least 1.");
             if (worker.CostWeight < 0)
                 return (false, "Cost weight cannot be negative.");
+            if (worker.MaxUploadBytes < 0)
+                return (false, "Max upload size cannot be negative (use 0 for unlimited).");
+            if (!string.IsNullOrWhiteSpace(worker.UploadCodec)
+                && !string.Equals(
+                    RemoteUploadFormat.Normalize(worker.UploadCodec),
+                    worker.UploadCodec.Trim(),
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                return (false, "Upload format must be wav, flac or opus.");
+            }
             return (true, null);
         }
 

--- a/Controller/Workers/WorkerRegistry.cs
+++ b/Controller/Workers/WorkerRegistry.cs
@@ -46,6 +46,8 @@ namespace WhisperSubs.Controller.Workers
                             maxConcurrency: w.MaxConcurrency,
                             costWeight: w.CostWeight,
                             canTranslate: w.CanTranslate,
+                            maxUploadBytes: w.MaxUploadBytes,
+                            uploadCodec: w.UploadCodec,
                             config: config,
                             loggerFactory: loggerFactory));
                     }
@@ -59,6 +61,7 @@ namespace WhisperSubs.Controller.Workers
                         key: (config.RemoteWhisperApiKey ?? string.Empty).Trim(),
                         model: config.RemoteWhisperModel,
                         maxConcurrency: 1, costWeight: 0, canTranslate: true,
+                        maxUploadBytes: 0, uploadCodec: null,
                         config: config, loggerFactory: loggerFactory));
                     break;
             }
@@ -79,13 +82,15 @@ namespace WhisperSubs.Controller.Workers
         private static ITranscriptionWorker BuildRemote(
             string id, string name, string url, string key, string model,
             int maxConcurrency, double costWeight, bool canTranslate,
+            long maxUploadBytes, string? uploadCodec,
             PluginConfiguration config, ILoggerFactory loggerFactory)
         {
             var resolvedModel = string.IsNullOrWhiteSpace(model) ? "Systran/faster-whisper-large-v3" : model.Trim();
             var provider = new RemoteWhisperProvider(
                 loggerFactory.CreateLogger<RemoteWhisperProvider>(),
                 url, resolvedModel, key,
-                config.JobTimeoutRealtimeFactor, config.JobMinTimeoutSeconds, config.JobMaxTimeoutHours);
+                config.JobTimeoutRealtimeFactor, config.JobMinTimeoutSeconds, config.JobMaxTimeoutHours,
+                httpClient: null, maxUploadBytes: maxUploadBytes, uploadCodec: uploadCodec);
 
             return new TranscriptionWorker(id, name, provider, new WorkerCapabilities
             {

--- a/Providers/RemoteWhisperProvider.cs
+++ b/Providers/RemoteWhisperProvider.cs
@@ -13,18 +13,77 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using WhisperSubs.Controller;
+using WhisperSubs.Controller.Workers;
 
 namespace WhisperSubs.Providers
 {
     public class RemoteWhisperProvider : ISubtitleProvider
     {
-        private sealed class RemoteApiException(HttpStatusCode statusCode, string responseBody)
+        private sealed class RemoteApiException(HttpStatusCode statusCode, string responseBody, string detail)
             : HttpRequestException(
-                $"Remote Whisper API returned HTTP {(int)statusCode}",
+                BuildRemoteApiMessage(statusCode, detail),
                 inner: null,
                 statusCode)
         {
+            /// <summary>
+            /// The RAW upstream body. Kept verbatim because the response-format negotiation pattern-matches
+            /// against it; sanitizing here would regress that. SECURITY-REVIEW: never surface this directly —
+            /// everything user-visible goes through <see cref="UpstreamErrorSanitizer"/> (see Message).
+            /// </summary>
             public string ResponseBody { get; } = responseBody;
+        }
+
+        /// <summary>
+        /// Builds the admin-visible message for an upstream failure: the status, the provider's own
+        /// (already sanitized) explanation when we are allowed to echo it, and one line of actionable advice.
+        /// Before this, the message was a bare "returned HTTP 413" and the provider's explanation was
+        /// discarded — the root reason issue #138 was undiagnosable without debug logging.
+        /// </summary>
+        internal static string BuildRemoteApiMessage(HttpStatusCode statusCode, string? detail)
+        {
+            var message = $"Remote Whisper API returned HTTP {(int)statusCode}";
+            if (!string.IsNullOrWhiteSpace(detail))
+            {
+                message += $": {detail}";
+            }
+
+            var guidance = RemoteErrorGuidance.For(statusCode);
+            if (!string.IsNullOrWhiteSpace(guidance))
+            {
+                message += $" — {guidance}";
+            }
+
+            return message;
+        }
+
+        /// <summary>
+        /// Whether an upstream ERROR body may be echoed to the admin, by media type.
+        /// SECURITY-REVIEW: <c>text/html</c> is refused deliberately — a LAN web UI answers HTML, and
+        /// echoing it would both leak page content and carry markup into the UI; the classification
+        /// ("this is a web page, not an API") is the better diagnostic anyway. A 2xx body is never passed
+        /// here at all: it is the media transcript, i.e. the user's own content.
+        /// </summary>
+        internal static bool MaySnippetUpstreamBody(string? mediaType)
+            => string.IsNullOrWhiteSpace(mediaType)
+                || mediaType.Equals("application/json", StringComparison.OrdinalIgnoreCase)
+                || mediaType.Equals("application/problem+json", StringComparison.OrdinalIgnoreCase)
+                || mediaType.Equals("text/plain", StringComparison.OrdinalIgnoreCase);
+
+        /// <summary>
+        /// The admin-safe description of an upstream error body: a sanitized snippet when the media type
+        /// allows it, an explicit classification for HTML, and nothing at all otherwise.
+        /// </summary>
+        internal static string DescribeUpstreamErrorBody(string? body, string? apiKey, string? mediaType)
+        {
+            if (!string.IsNullOrWhiteSpace(mediaType)
+                && mediaType.Equals("text/html", StringComparison.OrdinalIgnoreCase))
+            {
+                return "the endpoint returned a web page, not an API response";
+            }
+
+            return MaySnippetUpstreamBody(mediaType)
+                ? UpstreamErrorSanitizer.Sanitize(body, apiKey)
+                : string.Empty;
         }
 
         internal const int MaxTranscriptionResponseBytes = 32 * 1024 * 1024;
@@ -54,6 +113,8 @@ namespace WhisperSubs.Providers
         private readonly int _minTimeoutSeconds;
         private readonly int _maxTimeoutHours;
         private readonly HttpClient _httpClient;
+        private readonly long _maxUploadBytes;
+        private readonly string _uploadCodec;
         private string? _transcriptionResponseFormat;
         private string? _translationResponseFormat;
 
@@ -69,7 +130,7 @@ namespace WhisperSubs.Providers
         [ExcludeFromCodeCoverage(Justification = "Construction + HTTPS-key warning; no unit-testable logic")]
         public RemoteWhisperProvider(ILogger logger, string apiUrl, string model, string apiKey = "",
             double realtimeFactor = 6.0, int minTimeoutSeconds = 60, int maxTimeoutHours = 12,
-            HttpClient? httpClient = null)
+            HttpClient? httpClient = null, long maxUploadBytes = 0, string? uploadCodec = null)
         {
             _logger = logger;
             _apiUrl = apiUrl.TrimEnd('/');
@@ -79,6 +140,10 @@ namespace WhisperSubs.Providers
             _minTimeoutSeconds = minTimeoutSeconds;
             _maxTimeoutHours = maxTimeoutHours;
             _httpClient = httpClient ?? SharedHttpClient;
+            // 0 = unlimited and "wav" = no re-encode: the defaults reproduce pre-existing behaviour exactly,
+            // so an unconfigured or self-hosted worker is untouched.
+            _maxUploadBytes = maxUploadBytes;
+            _uploadCodec = RemoteUploadFormat.Normalize(uploadCodec);
 
             if (!string.IsNullOrEmpty(_apiKey) &&
                 Uri.TryCreate(_apiUrl, UriKind.Absolute, out var uri) &&
@@ -110,46 +175,100 @@ namespace WhisperSubs.Providers
                 ? $"{_apiUrl}/v1/audio/translations"
                 : $"{_apiUrl}/v1/audio/transcriptions";
 
+            // SanitizeEndpoint, not the raw endpoint: an admin may legitimately paste a key into the URL
+            // (Azure-style "?api-version=", proxy "?api_key="), and this line lands in jellyfin.log — the
+            // file users paste into public issues.
             _logger.LogInformation("Sending audio to remote Whisper API: {Endpoint} [lang={Language}, translate={Translate}]",
-                endpoint, language, translate);
+                UpstreamErrorSanitizer.SanitizeEndpoint(endpoint), language, translate);
 
-            var audioBytes = new FileInfo(audioPath).Length;
-            var responseFormat = (translate
+            // SOURCE bytes = the extracted 16 kHz mono PCM WAV. Every duration/deadline decision must be
+            // derived from THIS, never from whatever we end up uploading: the upload may be a compressed
+            // re-encode (per-worker codec), and deriving duration from compressed bytes would both collapse
+            // the per-call deadline and make ConvertTranscriptionResponseToSrt reject every segment past the
+            // (wrongly shortened) duration as "out-of-order". Uploaded bytes are for the body only.
+            var sourceAudioBytes = new FileInfo(audioPath).Length;
+            // Re-encode for the wire when this worker asks for it (default wav = no-op), then refuse to
+            // upload at all if the result still exceeds the worker's configured cap: a fail-fast with real
+            // numbers beats pushing 77 MB to earn a bare HTTP 413.
+            var (uploadPath, uploadIsTemporary) = await RemoteAudioEncoder
+                .PrepareUploadAsync(audioPath, _uploadCodec, _logger, cancellationToken).ConfigureAwait(false);
+            try
+            {
+                var uploadBytes = new FileInfo(uploadPath).Length;
+                if (!UploadPreflight.IsAllowed(uploadBytes, _maxUploadBytes))
+                {
+                    throw new InvalidOperationException(
+                        UploadPreflight.ExplainIfBlocked(
+                            sourceAudioBytes, uploadBytes, _maxUploadBytes, _uploadCodec));
+                }
+
+                return await TranscribeUploadAsync(
+                    endpoint, uploadPath, sourceAudioBytes, language, translate, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            finally
+            {
+                if (uploadIsTemporary)
+                {
+                    RemoteAudioEncoder.TryDelete(uploadPath);
+                }
+            }
+        }
+
+        [ExcludeFromCodeCoverage(Justification = "HTTP I/O; the pure deadline policy is tested in TranscriptionTimeoutTests")]
+        private async Task<string> TranscribeUploadAsync(
+            string endpoint,
+            string audioPath,
+            long sourceAudioBytes,
+            string language,
+            bool translate,
+            CancellationToken cancellationToken)
+        {
+            var cachedResponseFormat = translate
                 ? Volatile.Read(ref _translationResponseFormat)
-                : Volatile.Read(ref _transcriptionResponseFormat)) ?? "srt";
+                : Volatile.Read(ref _transcriptionResponseFormat);
+            // Nothing cached yet = we have never successfully negotiated a format with this endpoint, so a
+            // format-candidate rejection is worth one retry even when the body does not name the parameter
+            // (OpenRouter rejects response_format=srt with a bare 400). Bounded: once the format is cached,
+            // only an explicit format complaint triggers a retry again.
+            var formatNotYetNegotiated = cachedResponseFormat is null;
+            var responseFormat = cachedResponseFormat ?? "srt";
             var negotiatedByFormatRejection = false;
             string response;
             try
             {
                 response = await PostTranscriptionAsync(
-                    endpoint, audioPath, language, responseFormat, includeLanguage: !translate, cancellationToken: cancellationToken)
+                    endpoint, audioPath, sourceAudioBytes, language, responseFormat, includeLanguage: !translate, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
             }
-            catch (HttpRequestException ex) when (IsResponseFormatRejection(ex))
+            catch (HttpRequestException ex) when (ShouldNegotiateAlternateFormat(ex, formatNotYetNegotiated))
             {
                 // Preserve existing SRT providers as the first choice. Groq/OpenRouter reject SRT, so
                 // negotiate once to timestamped verbose_json and cache the successful format. If a
                 // provider's capability changes later, the reverse retry also recovers automatically.
                 responseFormat = AlternateResponseFormat(responseFormat);
                 negotiatedByFormatRejection = true;
-                _logger.LogWarning(
+                // Information, not Warning: this is expected, successful, self-healing behavior on Groq and
+                // OpenRouter. Warning on every job trains admins to ignore warnings — which is part of why
+                // the real failure in #138 went unnoticed.
+                _logger.LogInformation(
                     "Remote API rejected response format; retrying with {ResponseFormat}", responseFormat);
                 response = await PostTranscriptionAsync(
-                    endpoint, audioPath, language, responseFormat, includeLanguage: !translate, cancellationToken: cancellationToken)
+                    endpoint, audioPath, sourceAudioBytes, language, responseFormat, includeLanguage: !translate, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
             }
 
             if (IsUntimedJsonResponse(response) && !negotiatedByFormatRejection)
             {
                 responseFormat = AlternateResponseFormat(responseFormat);
-                _logger.LogWarning(
+                _logger.LogInformation(
                     "Remote API returned untimed JSON; retrying with {ResponseFormat}", responseFormat);
                 response = await PostTranscriptionAsync(
-                    endpoint, audioPath, language, responseFormat, includeLanguage: !translate, cancellationToken: cancellationToken)
+                    endpoint, audioPath, sourceAudioBytes, language, responseFormat, includeLanguage: !translate, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
             }
 
-            var audioDurationSeconds = audioBytes / TranscriptionTimeout.BytesPerAudioSecond;
+            var audioDurationSeconds = SourceAudioDurationSeconds(sourceAudioBytes);
             var srt = ConvertTranscriptionResponseToSrt(response, audioDurationSeconds);
 
             if (string.IsNullOrWhiteSpace(srt))
@@ -173,21 +292,22 @@ namespace WhisperSubs.Providers
         private async Task<string> PostTranscriptionAsync(
             string endpoint,
             string audioPath,
+            long sourceAudioBytes,
             string language,
             string responseFormat,
             bool includeLanguage,
             CancellationToken cancellationToken)
         {
-            long audioBytes = new FileInfo(audioPath).Length;
-
             using var content = new MultipartFormDataContent();
             // SECURITY-REVIEW: audioPath is an application-created temporary path; never accept a request path here.
             // Stream the WAV rather than File.ReadAllBytes: a 2h film is ~260 MB, and N parallel workers
             // buffering that in RAM is a direct OOM path. StreamContent's file stream is disposed with the
             // MultipartFormDataContent.
             var fileContent = new StreamContent(File.OpenRead(audioPath));
-            fileContent.Headers.ContentType = new MediaTypeHeaderValue("audio/wav");
-            content.Add(fileContent, "file", "audio.wav");
+            // Name and media type must match the actual bytes: providers routinely sniff the format from the
+            // file EXTENSION, so a FLAC body called "audio.wav" is rejected or mis-decoded.
+            fileContent.Headers.ContentType = new MediaTypeHeaderValue(RemoteUploadFormat.ContentType(_uploadCodec));
+            content.Add(fileContent, "file", RemoteUploadFormat.FileName(_uploadCodec));
             content.Add(new StringContent(_model), "model");
             content.Add(new StringContent(responseFormat), "response_format");
             if (string.Equals(responseFormat, "verbose_json", StringComparison.Ordinal))
@@ -202,8 +322,37 @@ namespace WhisperSubs.Providers
                 content.Add(new StringContent(language), "language");
             }
 
-            return await PostAudioAsync(endpoint, content, audioBytes, cancellationToken).ConfigureAwait(false);
+            // sourceAudioBytes (the uncompressed WAV), NOT the uploaded body length: the deadline must track
+            // how long the audio actually is, not how well it compressed.
+            return await PostAudioAsync(endpoint, content, sourceAudioBytes, cancellationToken).ConfigureAwait(false);
         }
+
+        /// <summary>
+        /// Audio duration implied by the SOURCE (uncompressed 16 kHz mono s16le PCM) byte count. This is the
+        /// only correct input for the per-call deadline and for the segment-timestamp sanity bound: a
+        /// compressed upload has the same duration but a fraction of the bytes, so deriving duration from the
+        /// uploaded size would shrink the deadline and make valid late segments look "out of order".
+        /// </summary>
+        internal static double SourceAudioDurationSeconds(long sourceAudioBytes)
+            => Math.Max(0, sourceAudioBytes) / TranscriptionTimeout.BytesPerAudioSecond;
+
+        /// <summary>
+        /// Whether to retry once with the alternate response format.
+        /// <para>
+        /// An explicit format complaint always qualifies. Additionally, while a worker's format is still
+        /// UN-NEGOTIATED, any format-candidate status (400/406/415/422) qualifies — OpenRouter rejects
+        /// <c>response_format=srt</c> with a bare 400 whose body need not name the parameter, and without
+        /// this the negotiation never fires and the endpoint simply never works (issue #138).
+        /// </para>
+        /// <para>
+        /// The cost of a wrong guess is bounded: exactly one extra upload, once per worker, and only until a
+        /// format is successfully cached. After that a retry needs an explicit format complaint again, so a
+        /// misconfiguration (say a bad model name) cannot cause a repeated large re-upload on every job.
+        /// </para>
+        /// </summary>
+        internal static bool ShouldNegotiateAlternateFormat(HttpRequestException exception, bool formatNotYetNegotiated)
+            => IsResponseFormatRejection(exception)
+                || (formatNotYetNegotiated && IsFormatRejectionCandidateStatus(exception.StatusCode));
 
         internal static bool IsFormatRejectionCandidateStatus(HttpStatusCode? statusCode)
             => statusCode is HttpStatusCode.BadRequest
@@ -567,9 +716,11 @@ namespace WhisperSubs.Providers
                 throw new FileNotFoundException($"Audio file not found: {audioPath}");
             }
 
-            _logger.LogInformation("Detecting language via remote Whisper API for {AudioPath}", audioPath);
+            // Debug + file name only: a full media path at default level discloses the library layout, and
+            // default-level logs get pasted into public issues (repo rule: don't log private paths).
+            _logger.LogDebug("Detecting language via remote Whisper API for {AudioFile}", Path.GetFileName(audioPath));
 
-            long audioBytes = new FileInfo(audioPath).Length;
+            long sourceAudioBytes = new FileInfo(audioPath).Length;
 
             using var content = new MultipartFormDataContent();
             var fileContent = new StreamContent(File.OpenRead(audioPath));
@@ -580,7 +731,7 @@ namespace WhisperSubs.Providers
             content.Add(new StringContent("verbose_json"), "response_format");
 
             var endpoint = $"{_apiUrl}/v1/audio/transcriptions";
-            var json = await PostAudioAsync(endpoint, content, audioBytes, cancellationToken).ConfigureAwait(false);
+            var json = await PostAudioAsync(endpoint, content, sourceAudioBytes, cancellationToken).ConfigureAwait(false);
 
             using var doc = JsonDocument.Parse(json);
             var root = doc.RootElement;
@@ -604,12 +755,14 @@ namespace WhisperSubs.Providers
         /// of hanging (the multi-day stuck-task class of bug).
         /// </summary>
         [ExcludeFromCodeCoverage(Justification = "HTTP I/O; the pure deadline policy is tested in TranscriptionTimeoutTests")]
-        private async Task<string> PostAudioAsync(string endpoint, MultipartFormDataContent content, long audioBytes, CancellationToken cancellationToken)
+        // sourceAudioBytes is the UNCOMPRESSED source WAV length, which is what the deadline must scale with —
+        // never the (possibly compressed) uploaded body length. See SourceAudioDurationSeconds.
+        private async Task<string> PostAudioAsync(string endpoint, MultipartFormDataContent content, long sourceAudioBytes, CancellationToken cancellationToken)
         {
             using var request = new HttpRequestMessage(HttpMethod.Post, endpoint) { Content = content };
             ApplyAuthorization(request);
 
-            var deadline = TranscriptionTimeout.Compute(audioBytes, _realtimeFactor, _minTimeoutSeconds, _maxTimeoutHours);
+            var deadline = TranscriptionTimeout.Compute(sourceAudioBytes, _realtimeFactor, _minTimeoutSeconds, _maxTimeoutHours);
             using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             timeoutCts.CancelAfter(deadline);
 
@@ -624,7 +777,12 @@ namespace WhisperSubs.Providers
                 {
                     var errorBody = await ReadUtf8BoundedAsync(
                         response.Content, MaxErrorResponseBytes, timeoutCts.Token).ConfigureAwait(false);
-                    throw new RemoteApiException(response.StatusCode, errorBody);
+                    // Echo the provider's own explanation, sanitized and media-type gated, so the admin can
+                    // see WHY without turning on debug logging (#138). The raw body is retained on the
+                    // exception for the response-format negotiation matcher.
+                    var detail = DescribeUpstreamErrorBody(
+                        errorBody, _apiKey, response.Content.Headers.ContentType?.MediaType);
+                    throw new RemoteApiException(response.StatusCode, errorBody, detail);
                 }
 
                 return await ReadUtf8BoundedAsync(
@@ -632,8 +790,10 @@ namespace WhisperSubs.Providers
             }
             catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
             {
+                // This message reaches the queue's last-error and therefore the browser — sanitize the
+                // endpoint so a key pasted into the URL query cannot surface there.
                 throw new TimeoutException(
-                    $"Remote Whisper API call exceeded its {deadline.TotalSeconds:F0}s deadline (endpoint slow or unreachable): {endpoint}");
+                    $"Remote Whisper API call exceeded its {deadline.TotalSeconds:F0}s deadline (endpoint slow or unreachable): {UpstreamErrorSanitizer.SanitizeEndpoint(endpoint)}");
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -376,7 +376,34 @@ The live queue view shows which worker is transcribing which item, so you can se
 
 > **Need a worker to point at?** [`worker/`](worker/README.md) is a ready-to-run whisper.cpp + Vulkan worker image (with notes for CPU/NVIDIA/AMD backends). Any server that implements the OpenAI `/v1/audio/transcriptions` and `/v1/audio/translations` endpoints -- e.g. [Speaches](https://github.com/speaches-ai/speaches) -- also works.
 
-> **Hosted-provider limits still apply.** WhisperSubs sends the full extracted 16 kHz mono WAV. A service with a 25 MB multipart limit accepts only about 13 minutes of this audio, even when its response format is compatible; use a self-hosted worker or a provider whose upload and processing limits fit your media. Turn off **Can translate** for providers that do not expose `/v1/audio/translations`.
+### Hosted providers: upload size, base URLs and model names
+
+WhisperSubs extracts 16 kHz mono PCM WAV, which is **1.92 MB per minute** of audio. That matters as soon as you point a worker at a hosted API:
+
+| Audio length | WAV (default) | FLAC | Opus 24k |
+|---|---|---|---|
+| 13 minutes | ~25 MB | ~13 MB | ~2 MB |
+| 40 minutes | 76.8 MB | ~39 MB | ~7 MB |
+| 2 hours | 219.7 MB | ~116 MB | ~20 MB |
+
+So a 25 MB cap (OpenAI, and Groq's free tier) accepts only about **13 minutes** of the default WAV upload, and rejects anything longer with `HTTP 413`. Two per-worker settings fix that:
+
+- **Max upload size (MB)** -- what this endpoint accepts. `0` (default) means unlimited, which is right for every self-hosted worker. Set it (25 for OpenAI/Groq free, 100 for Groq dev tier) and an oversized title fails immediately with a message telling you the size, the cap and roughly how many minutes fit -- instead of uploading the whole file to earn a bare 413.
+- **Upload format** -- `WAV` (default), `FLAC` (lossless, about half) or `Opus 24k` (about a tenth; a 2-hour film lands near 20 MB). **Keep WAV for self-hosted workers**: whisper.cpp's `whisper-server` decodes WAV only, and the [`worker/`](worker/README.md) image ships without ffmpeg. Only choose a compressed format on a hosted endpoint documented to accept it (Groq accepts FLAC and OGG and explicitly recommends FLAC for size reduction; OpenAI's documented list is mp3/mp4/mpeg/mpga/m4a/wav/webm).
+
+**Base URL form** -- enter only the base; WhisperSubs appends `/v1/audio/transcriptions` itself, so the URL must **not** already end in `/v1`:
+
+| Provider | Enter this |
+|---|---|
+| Groq | `https://api.groq.com/openai` |
+| OpenRouter | `https://openrouter.ai/api` |
+| OpenAI | `https://api.openai.com` |
+
+**Model names and provider limitations:**
+
+- **OpenRouter** requires a namespaced slug (`openai/whisper-large-v3-turbo`, not `whisper-1`); a bare name returns `400`. It also rejects `response_format=srt` outright -- WhisperSubs negotiates to timestamped JSON automatically -- and has **no `/v1/audio/translations` endpoint**, so turn **Can translate** off for it. Timestamps are only available on its OpenAI-compatible models; models that return text without timings cannot produce synchronized subtitles.
+- **OpenAI**: timestamps and SRT are available on `whisper-1` only. `gpt-4o-transcribe` / `gpt-4o-mini-transcribe` return `json`/`text` with no timings, so they cannot be used for subtitles.
+- Turn off **Can translate** for any provider that does not expose `/v1/audio/translations`.
 >
 > **Note:** the automatic scheduled sweep currently processes its backlog one item at a time; manual **Generate** / **Generate All** already fan out across the whole pool. Parallelizing the scheduled sweep is on the [roadmap](ROADMAP.md).
 
@@ -396,7 +423,7 @@ After installation, navigate to **Dashboard** > **Plugins** > **WhisperSubs** to
 | **Whisper Model Path** | *(Advanced)* Absolute path to the GGML model file. Leave empty to use the auto-downloaded model. |
 | **Whisper Thread Count** | *(Advanced)* Number of CPU threads for whisper inference. `0` = whisper default (4). Set to your CPU core count for faster transcription. |
 | **Also use this server as a worker** (`EnableLocalWorker`) | *(Worker Pool)* Whether this Jellyfin host's own whisper participates in the pool. On by default. Turn it off to transcribe **only** on the remote workers below -- e.g. a weak NAS offloading entirely to a beefier box. |
-| **Workers** | *(Worker Pool)* A list of extra OpenAI-compatible transcription endpoints to pool alongside (or instead of) this server. Empty by default. Each row has an endpoint URL, optional API key, optional model, max concurrency, cost weight, and a "can translate" flag. WhisperSubs preserves direct SRT for existing servers; if an endpoint rejects SRT, it negotiates once to timestamped `verbose_json` segments (supported by Groq, OpenRouter-compatible providers, and OpenAI `whisper-1`), converts them to SRT, and caches that choice. Text-only JSON models cannot produce synchronized subtitles because they return no timestamps. See [Distributed Transcription](#distributed-transcription-worker-pool). |
+| **Workers** | *(Worker Pool)* A list of extra OpenAI-compatible transcription endpoints to pool alongside (or instead of) this server. Empty by default. Each row has an endpoint URL, optional API key, optional model, max concurrency, cost weight, **max upload size** (`0` = unlimited), **upload format** (`wav` default / `flac` / `opus`), and a "can translate" flag. WhisperSubs preserves direct SRT for existing servers; if an endpoint rejects SRT, it negotiates once to timestamped `verbose_json` segments (supported by Groq, OpenRouter-compatible providers, and OpenAI `whisper-1`), converts them to SRT, and caches that choice. Text-only JSON models cannot produce synchronized subtitles because they return no timestamps. See [Distributed Transcription](#distributed-transcription-worker-pool). |
 | **Job timeout -- real-time factor** (`JobTimeoutRealtimeFactor`) | *(Advanced)* Upper bound on how much slower than real-time a remote worker may run before a single call is presumed hung and cancelled. Per-call deadline = audio length x this factor (clamped by the min/max below). Default `6`. A slow-but-working pass is never cut off; a dead endpoint is. |
 | **Job timeout -- minimum seconds** (`JobMinTimeoutSeconds`) | *(Advanced)* Floor for the per-call deadline, so a tiny detection clip still gets a sane minimum. Default `60`. |
 | **Job timeout -- maximum hours** (`JobMaxTimeoutHours`) | *(Advanced)* Absolute cap for the per-call deadline; a genuinely long film's worst case still fits under it. Default `12`. |

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -1805,6 +1805,16 @@
                         (w.CostWeight != null && w.CostWeight >= 0) ? w.CostWeight : '',
                         '0 = free/local, preferred; >0 = only used when local workers are busy.'));
 
+                    row.appendChild(WhisperSubsConfig._workerField(
+                        'Max upload size (MB)', 'number', 'wkMaxUpload', { min: '0', step: '1', placeholder: '0 = unlimited' },
+                        (w.MaxUploadBytes != null && w.MaxUploadBytes > 0) ? Math.round(w.MaxUploadBytes / 1048576) : '',
+                        'Largest file this endpoint accepts. 0 (default) = unlimited. OpenAI and Groq free tier are 25; Groq dev tier 100. Oversized titles then fail fast with a clear message instead of a bare HTTP 413.'));
+                    row.appendChild(WhisperSubsConfig._workerSelect(
+                        'Upload format', 'wkUploadCodec',
+                        [['wav', 'WAV (default, uncompressed)'], ['flac', 'FLAC (lossless, ~half)'], ['opus', 'Opus 24k (~a tenth)']],
+                        (w.UploadCodec || 'wav'),
+                        'Audio sent to THIS worker. WAV is 1.92 MB per minute, so a 40-minute title is 76.8 MB and exceeds hosted caps. Keep WAV for self-hosted workers (whisper.cpp decodes WAV only); use FLAC or Opus only on a hosted endpoint documented to accept it.'));
+
                     row.appendChild(WhisperSubsConfig._workerCheckbox('wkTranslate', 'Can translate to English', w.CanTranslate !== false));
                     row.appendChild(WhisperSubsConfig._workerCheckbox('wkEnabled', 'Enabled', w.Enabled !== false));
 
@@ -1887,6 +1897,37 @@
                     return container;
                 },
 
+                _workerSelect: function (labelText, cls, options, value, descText) {
+                    var id = 'wk_' + (++WhisperSubsConfig._workerSeq);
+                    var container = document.createElement('div');
+                    container.className = 'selectContainer';
+                    var label = document.createElement('label');
+                    label.className = 'selectLabel';
+                    label.setAttribute('for', id);
+                    label.textContent = labelText;
+                    container.appendChild(label);
+                    var select = document.createElement('select');
+                    select.id = id;
+                    select.setAttribute('is', 'emby-select');
+                    select.className = 'emby-select ' + cls;
+                    options.forEach(function (pair) {
+                        var option = document.createElement('option');
+                        option.value = pair[0];
+                        // textContent, never innerHTML: option labels are rendered as text only.
+                        option.textContent = pair[1];
+                        select.appendChild(option);
+                    });
+                    select.value = value || options[0][0];
+                    container.appendChild(select);
+                    if (descText) {
+                        var desc = document.createElement('div');
+                        desc.className = 'fieldDescription';
+                        desc.textContent = descText;
+                        container.appendChild(desc);
+                    }
+                    return container;
+                },
+
                 _workerCheckbox: function (cls, labelText, checked) {
                     var container = document.createElement('div');
                     container.className = 'checkboxContainer';
@@ -1917,11 +1958,13 @@
                         var model = (row.querySelector('.wkModel').value || '').trim();
                         var concRaw = (row.querySelector('.wkConcurrency').value || '').trim();
                         var costRaw = (row.querySelector('.wkCost').value || '').trim();
+                        var maxUploadRaw = (row.querySelector('.wkMaxUpload').value || '').trim();
+                        var uploadCodec = (row.querySelector('.wkUploadCodec').value || 'wav').trim();
                         var canTranslate = row.querySelector('.wkTranslate').checked;
                         var enabled = row.querySelector('.wkEnabled').checked;
 
                         // Skip a row the user never filled in (all text/number fields blank).
-                        if (!name && !url && !key && !model && concRaw === '' && costRaw === '') {
+                        if (!name && !url && !key && !model && concRaw === '' && costRaw === '' && maxUploadRaw === '') {
                             return;
                         }
 
@@ -1929,6 +1972,11 @@
                         if (isNaN(conc) || conc < 1) conc = 1;
                         var cost = parseFloat(costRaw);
                         if (isNaN(cost) || cost < 0) cost = 0;
+                        // Entered in MB for humans, stored in bytes. 0/blank = unlimited.
+                        var maxUploadMb = parseFloat(maxUploadRaw);
+                        var maxUploadBytes = (isNaN(maxUploadMb) || maxUploadMb <= 0)
+                            ? 0
+                            : Math.round(maxUploadMb * 1048576);
 
                         workers.push({
                             Id: row.getAttribute('data-worker-id') || WhisperSubsConfig.genWorkerId(),
@@ -1939,6 +1987,8 @@
                             Model: model,
                             MaxConcurrency: conc,
                             CostWeight: cost,
+                            MaxUploadBytes: maxUploadBytes,
+                            UploadCodec: uploadCodec,
                             CanTranslate: canTranslate
                         });
                     });

--- a/WhisperSubs.Tests/RemoteTranscriptionResponseTests.cs
+++ b/WhisperSubs.Tests/RemoteTranscriptionResponseTests.cs
@@ -213,9 +213,20 @@ public class RemoteTranscriptionResponseTests
     }
 
     [Fact]
-    public async Task NonFormatBadRequest_DoesNotRetryFullAudio()
+    public async Task NonFormatBadRequest_RetriesFormatOnceThenSurfacesTheProvidersOwnError()
     {
+        // Two deliberate behavior changes (issue #138):
+        //  1. While a worker's format is still un-negotiated, ANY format-candidate 4xx earns ONE alternate
+        //     format retry — OpenRouter rejects response_format=srt with a bare 400 that names no parameter,
+        //     and without this its endpoint never works at all.
+        //  2. The provider's own explanation is now surfaced (sanitized) instead of discarded, so an admin
+        //     can see WHY without enabling debug logging.
         var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent("""{"error":"model does not exist"}""")
+            },
+            // The one bounded retry also fails: a bad model name is not a format problem.
             new HttpResponseMessage(HttpStatusCode.BadRequest)
             {
                 Content = new StringContent("""{"error":"model does not exist"}""")
@@ -231,15 +242,20 @@ public class RemoteTranscriptionResponseTests
         {
             var exception = await Assert.ThrowsAnyAsync<HttpRequestException>(
                 () => provider.TranscribeAsync(wav, "auto", CancellationToken.None));
-            Assert.DoesNotContain("model does not exist", exception.Message);
             Assert.Contains("HTTP 400", exception.Message);
+            // The upstream explanation is now visible — this is the whole point of the fix.
+            Assert.Contains("model does not exist", exception.Message);
         }
         finally
         {
             File.Delete(wav);
         }
 
-        Assert.Single(handler.Requests);
+        // BOUNDED: exactly one retry, never a retry storm. A 77 MB upload must not be repeated
+        // indefinitely because a model name is wrong.
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal(["srt", "verbose_json"],
+            handler.Requests.Select(request => request.Fields["response_format"]));
     }
 
     [Fact]

--- a/WhisperSubs.Tests/RemoteUploadFormatTests.cs
+++ b/WhisperSubs.Tests/RemoteUploadFormatTests.cs
@@ -1,0 +1,94 @@
+using WhisperSubs.Controller.Workers;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+/// <summary>
+/// Upload-format policy for remote workers (issue #138). The default MUST stay wav: whisper.cpp's
+/// whisper-server decodes WAV only and this project's own worker image ships without ffmpeg, so a
+/// compressed default would break every self-hosted worker.
+/// </summary>
+public class RemoteUploadFormatTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("mp3")]        // unsupported
+    [InlineData("nonsense")]
+    public void UnknownOrMissingCodecFallsBackToWav(string? codec)
+    {
+        Assert.Equal(RemoteUploadFormat.Wav, RemoteUploadFormat.Normalize(codec));
+        Assert.False(RemoteUploadFormat.RequiresReencode(codec));
+    }
+
+    [Theory]
+    [InlineData("flac", "flac")]
+    [InlineData("FLAC", "flac")]
+    [InlineData(" Opus ", "opus")]
+    public void SupportedCodecsNormalize(string configured, string expected)
+    {
+        Assert.Equal(expected, RemoteUploadFormat.Normalize(configured));
+        Assert.True(RemoteUploadFormat.RequiresReencode(configured));
+    }
+
+    [Theory]
+    [InlineData("wav", "audio.wav", "audio/wav")]
+    [InlineData("flac", "audio.flac", "audio/flac")]
+    [InlineData("opus", "audio.ogg", "audio/ogg")]
+    public void FileNameAndContentTypeMatchTheBytes(string codec, string fileName, string contentType)
+    {
+        // Providers sniff by extension; a mismatched name is rejected or mis-decoded.
+        Assert.Equal(fileName, RemoteUploadFormat.FileName(codec));
+        Assert.Equal(contentType, RemoteUploadFormat.ContentType(codec));
+    }
+
+    [Fact]
+    public void FlacArgumentsPinSixteenBitSamples()
+    {
+        // THE footgun: without -sample_fmt s16 ffmpeg's FLAC encoder defaults to 24-bit and the output is
+        // LARGER than the 16-bit PCM input (measured: 19,713,918 vs 19,200,102 bytes). The vendor-published
+        // command omits this flag, so this assertion is the guard against copying it verbatim.
+        var args = RemoteUploadFormat.BuildFfmpegArguments("/tmp/in.wav", "/tmp/out.flac", "flac");
+        Assert.Contains("-sample_fmt s16", args, System.StringComparison.Ordinal);
+        Assert.Contains("-c:a flac", args, System.StringComparison.Ordinal);
+        Assert.Contains("\"/tmp/in.wav\"", args, System.StringComparison.Ordinal);
+        Assert.Contains("\"/tmp/out.flac\"", args, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void OpusArgumentsUseLibopusAtTheConfiguredBitrate()
+    {
+        var args = RemoteUploadFormat.BuildFfmpegArguments("/tmp/in.wav", "/tmp/out.ogg", "opus");
+        Assert.Contains("-c:a libopus", args, System.StringComparison.Ordinal);
+        Assert.Contains($"-b:a {RemoteUploadFormat.OpusBitrateKbps}k", args, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildingArgumentsForWavIsRejected()
+    {
+        // wav means "no re-encode"; asking for its arguments is a caller bug.
+        Assert.Throws<System.ArgumentException>(
+            () => RemoteUploadFormat.BuildFfmpegArguments("/tmp/in.wav", "/tmp/out.wav", "wav"));
+    }
+
+    [Fact]
+    public void EstimatesReflectMeasuredRatios()
+    {
+        // A 40-minute title: 2400s x 32000 = 76.8 MB of PCM.
+        const long fortyMinutes = 76_800_000;
+
+        Assert.Equal(fortyMinutes, RemoteUploadFormat.EstimateUploadBytes(fortyMinutes, "wav"));
+
+        var flac = RemoteUploadFormat.EstimateUploadBytes(fortyMinutes, "flac");
+        var opus = RemoteUploadFormat.EstimateUploadBytes(fortyMinutes, "opus");
+
+        // FLAC roughly halves it - still over a 25 MB cap, which is why it alone did not fix the report.
+        Assert.InRange(flac, 38_000_000, 42_000_000);
+        Assert.True(flac > 25L * 1024 * 1024);
+
+        // Opus fits comfortably under 25 MB - this is what makes the reported 40-minute title work.
+        Assert.InRange(opus, 5_000_000, 8_000_000);
+        Assert.True(opus < 25L * 1024 * 1024);
+    }
+}

--- a/WhisperSubs.Tests/SourceAudioDurationTests.cs
+++ b/WhisperSubs.Tests/SourceAudioDurationTests.cs
@@ -1,0 +1,68 @@
+using WhisperSubs.Controller;
+using WhisperSubs.Providers;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+/// <summary>
+/// Locks the invariant that duration (and therefore the per-call deadline and the segment-timestamp
+/// sanity bound) is derived from the SOURCE uncompressed WAV, never from the uploaded body. A compressed
+/// upload has identical duration but a fraction of the bytes; deriving duration from it would collapse the
+/// deadline and make <c>ConvertTranscriptionResponseToSrt</c> reject every legitimate late segment as
+/// "out-of-order" — a hard exception on essentially every remote file (issue #138 follow-up).
+/// </summary>
+public class SourceAudioDurationTests
+{
+    // 16 kHz mono s16le PCM = 32,000 bytes per audio-second.
+    private const double BytesPerSecond = TranscriptionTimeout.BytesPerAudioSecond;
+
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(32_000, 1)]              // 1 second
+    [InlineData(1_920_000, 60)]          // 1 minute
+    [InlineData(76_800_000, 2400)]       // the reporter's 40-minute title
+    public void DurationIsDerivedFromSourceBytes(long sourceBytes, double expectedSeconds)
+    {
+        Assert.Equal(expectedSeconds, RemoteWhisperProvider.SourceAudioDurationSeconds(sourceBytes), 3);
+    }
+
+    [Fact]
+    public void NegativeBytesClampToZero()
+    {
+        // Defensive: a bogus length must never yield a negative duration (which would make the
+        // "end > maxDuration" guard reject everything).
+        Assert.Equal(0, RemoteWhisperProvider.SourceAudioDurationSeconds(-1));
+    }
+
+    [Fact]
+    public void CompressedUploadSizeWouldUnderstateDuration_WhichIsWhyWePassSourceBytes()
+    {
+        // A 40-minute title: 76.8 MB as PCM, ~6.7 MB as 24 kbps Opus (measured). Feeding the COMPRESSED
+        // size in would claim the audio is ~3.5 minutes long, and every segment past that would be
+        // rejected. This test documents the trap the signature now prevents.
+        const long sourcePcmBytes = 76_800_000;
+        const long compressedUploadBytes = 6_700_000;
+
+        var correct = RemoteWhisperProvider.SourceAudioDurationSeconds(sourcePcmBytes);
+        var wrong = RemoteWhisperProvider.SourceAudioDurationSeconds(compressedUploadBytes);
+
+        Assert.Equal(2400, correct, 3);            // 40 minutes
+        Assert.True(wrong < 250);                  // ~3.5 minutes — nonsense for the same audio
+        Assert.True(correct > wrong * 9);          // an order of magnitude apart
+    }
+
+    [Fact]
+    public void DeadlineScalesWithSourceNotUpload()
+    {
+        // The same guarantee at the deadline layer: a 2h film must get a 2h-sized deadline even when the
+        // uploaded body is a tenth the size.
+        const long twoHoursPcm = 230_400_000;      // 7200s x 32000
+        const long compressed = 20_000_000;        // ~Opus 24k for the same 2h
+
+        var fromSource = TranscriptionTimeout.Compute(twoHoursPcm, 6.0, 60, 12);
+        var fromUpload = TranscriptionTimeout.Compute(compressed, 6.0, 60, 12);
+
+        Assert.True(fromSource > fromUpload,
+            "deriving the deadline from compressed bytes would guillotine a healthy long transcription");
+    }
+}

--- a/WhisperSubs.Tests/UploadPreflightTests.cs
+++ b/WhisperSubs.Tests/UploadPreflightTests.cs
@@ -1,0 +1,89 @@
+using WhisperSubs.Controller.Workers;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+/// <summary>
+/// Pre-flight upload gate (issue #138): refuse an upload we already know will be refused, and say why in
+/// terms the admin can act on. The default cap of 0 must be byte-identical to the old behaviour.
+/// </summary>
+public class UploadPreflightTests
+{
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void ZeroOrNegativeCapMeansUnlimited(long cap)
+    {
+        // Existing installs (and every self-hosted worker) must never be blocked.
+        Assert.True(UploadPreflight.IsAllowed(long.MaxValue / 2, cap));
+        Assert.Equal(string.Empty, UploadPreflight.ExplainIfBlocked(76_800_000, 76_800_000, cap, "wav"));
+    }
+
+    [Fact]
+    public void UploadAtExactlyTheCapIsAllowed()
+    {
+        Assert.True(UploadPreflight.IsAllowed(25_000_000, 25_000_000));
+    }
+
+    [Fact]
+    public void UploadOverTheCapIsBlocked()
+    {
+        Assert.False(UploadPreflight.IsAllowed(25_000_001, 25_000_000));
+    }
+
+    [Fact]
+    public void BlockedMessageStatesSizeCapAndDuration()
+    {
+        // The reporter's exact case: a 40-minute title against Groq's 25 MB.
+        const long fortyMinutesPcm = 76_800_000;
+        var message = UploadPreflight.ExplainIfBlocked(
+            fortyMinutesPcm, fortyMinutesPcm, 25_000_000, "wav");
+
+        Assert.Contains("40-minute", message, System.StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("MB", message, System.StringComparison.Ordinal);
+        Assert.Contains("Nothing was uploaded", message, System.StringComparison.OrdinalIgnoreCase);
+        // It must tell them what to actually change.
+        Assert.Contains("FLAC", message, System.StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Opus", message, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void AdviceIsTailoredToTheCodecAlreadyInUse()
+    {
+        const long twoHoursPcm = 230_400_000;
+
+        // Already on FLAC: suggest Opus, do not suggest FLAC again.
+        var flacAdvice = UploadPreflight.ExplainIfBlocked(twoHoursPcm, 115_000_000, 25_000_000, "flac");
+        Assert.Contains("Opus", flacAdvice, System.StringComparison.OrdinalIgnoreCase);
+
+        // Already on Opus: nothing smaller to offer, so point at a self-hosted worker honestly.
+        var opusAdvice = UploadPreflight.ExplainIfBlocked(twoHoursPcm, 20_000_000, 5_000_000, "opus");
+        Assert.Contains("self-hosted", opusAdvice, System.StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("smallest upload format", opusAdvice, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void FormatBytesIsInvariantAndReadable()
+    {
+        Assert.Equal("25.0 MB", RemoteErrorGuidance.FormatBytes(25L * 1024 * 1024));
+        Assert.Equal("1.0 GB", RemoteErrorGuidance.FormatBytes(1024L * 1024 * 1024));
+    }
+
+    [Theory]
+    [InlineData(413, "Max upload size")]
+    [InlineData(401, "API key")]
+    [InlineData(404, "BASE url")]
+    [InlineData(429, "Rate limited")]
+    [InlineData(503, "own side")]
+    public void GuidanceIsActionablePerStatus(int status, string expected)
+    {
+        var guidance = RemoteErrorGuidance.For((System.Net.HttpStatusCode)status);
+        Assert.Contains(expected, guidance, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void UnmappedStatusAddsNoInventedAdvice()
+    {
+        Assert.Equal(string.Empty, RemoteErrorGuidance.For(System.Net.HttpStatusCode.OK));
+    }
+}

--- a/WhisperSubs.Tests/UpstreamErrorSanitizerTests.cs
+++ b/WhisperSubs.Tests/UpstreamErrorSanitizerTests.cs
@@ -1,0 +1,196 @@
+using System.Net;
+using WhisperSubs.Controller.Workers;
+using WhisperSubs.Providers;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+/// <summary>
+/// Security tests for the boundary at which an untrusted upstream body may reach an admin's screen or the
+/// Jellyfin log (issue #138). The body may contain the admin's own API key (gateways that echo the request),
+/// presigned URLs, control characters (log forging) or markup — none of which may survive.
+/// </summary>
+public class UpstreamErrorSanitizerTests
+{
+    // ---- the admin's own key: the highest-value rule -------------------------------------------
+
+    [Fact]
+    public void ExactApiKeyIsRedacted()
+    {
+        const string key = "sk-or-v1-abcdef0123456789abcdef";
+        var sanitized = UpstreamErrorSanitizer.Sanitize($"bad request for key {key} here", key);
+        Assert.DoesNotContain(key, sanitized, System.StringComparison.Ordinal);
+        Assert.Contains("[redacted]", sanitized, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ApiKeyIsRedactedCaseInsensitivelyAndUrlEncoded()
+    {
+        const string key = "MySecretKeyValue123";
+        var sanitized = UpstreamErrorSanitizer.Sanitize(
+            "seen mysecretkeyvalue123 and MySecretKeyValue123 in url", key);
+        Assert.DoesNotContain("mysecretkeyvalue123", sanitized, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ShortKeyDoesNotBlankTheMessage()
+    {
+        // A short/placeholder key must not turn the whole body into [redacted] noise.
+        var sanitized = UpstreamErrorSanitizer.Sanitize("model 'abc' not found", "abc");
+        Assert.Contains("not found", sanitized, System.StringComparison.Ordinal);
+    }
+
+    // ---- secret families ------------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("Authorization: Bearer sk-proj-AAAAAAAAAAAAAAAAAAAA")]
+    [InlineData("bearer abcdefghijklmnopqrstuvwx")]
+    [InlineData("gsk_abcdefghijklmnopqrstuvwxyz012345")]
+    [InlineData("\"api_key\": \"supersecretvalue\"")]
+    [InlineData("sig=0123456789abcdef0123456789abcdef")]
+    public void SecretFamiliesAreRedacted(string body)
+    {
+        var sanitized = UpstreamErrorSanitizer.Sanitize(body, apiKey: null);
+        Assert.Contains("redacted", sanitized, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void JwtIsRedacted()
+    {
+        // Assembled at runtime rather than written as a literal: a whole JWT in source trips secret
+        // scanners (GitGuardian flags it) even though it is a throwaway fixture.
+        var jwt = string.Join(".",
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+            "eyJzdWIiOiIxMjM0NTY3ODkwIn0",
+            "dBjftJeZ4CVPmB92K27uhbUJU1p1r_wW1gFWFOEjXk");
+
+        var sanitized = UpstreamErrorSanitizer.Sanitize($"token {jwt} rejected", apiKey: null);
+
+        Assert.DoesNotContain(jwt, sanitized, System.StringComparison.Ordinal);
+        Assert.Contains("redacted", sanitized, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void UrlQueryStringIsDroppedWholesale()
+    {
+        var sanitized = UpstreamErrorSanitizer.Sanitize(
+            "fetch https://bucket.s3.amazonaws.com/f.wav?X-Amz-Signature=deadbeefdeadbeefdeadbeef failed",
+            apiKey: null);
+        Assert.DoesNotContain("X-Amz-Signature", sanitized, System.StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("https://bucket.s3.amazonaws.com/f.wav", sanitized, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EmailIsMasked()
+    {
+        var sanitized = UpstreamErrorSanitizer.Sanitize("account someone@example.com over quota", null);
+        Assert.DoesNotContain("someone@example.com", sanitized, System.StringComparison.Ordinal);
+    }
+
+    // ---- flattening: log forging + markup -------------------------------------------------------
+
+    [Fact]
+    public void ControlCharactersAreStripped()
+    {
+        var sanitized = UpstreamErrorSanitizer.Sanitize(
+            "line one\r\n2026-01-01 FAKE LOG LINE\tinjected​‮", null);
+        Assert.DoesNotContain("\n", sanitized, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("\r", sanitized, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("\t", sanitized, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("​", sanitized, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("‮", sanitized, System.StringComparison.Ordinal);
+    }
+
+    // ---- ordering: redact BEFORE truncate -------------------------------------------------------
+
+    [Fact]
+    public void RedactionHappensBeforeTruncationSoNoPartialSecretSurvives()
+    {
+        const string key = "sk-live-0123456789abcdefghijklmnop";
+        var body = new string('x', 380) + " " + key;
+        var sanitized = UpstreamErrorSanitizer.Sanitize(body, key, maxLength: 400);
+
+        // The key straddles the cut; if truncation ran first a prefix would leak.
+        Assert.DoesNotContain("sk-live-0123", sanitized, System.StringComparison.Ordinal);
+        Assert.True(sanitized.Length <= 400);
+    }
+
+    [Fact]
+    public void OutputIsCapped()
+    {
+        var sanitized = UpstreamErrorSanitizer.Sanitize(new string('a', 5000), null, maxLength: 120);
+        Assert.True(sanitized.Length <= 120);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void BlankInputYieldsEmpty(string? body)
+    {
+        Assert.Equal(string.Empty, UpstreamErrorSanitizer.Sanitize(body, "somekeyvalue"));
+    }
+
+    // ---- SanitizeEndpoint ------------------------------------------------------------------------
+
+    [Fact]
+    public void SanitizeEndpointDropsUserInfoAndQuery()
+    {
+        var sanitized = UpstreamErrorSanitizer.SanitizeEndpoint(
+            "https://user:pass@api.example.com/v1/audio/transcriptions?api_key=supersecret");
+        Assert.DoesNotContain("pass", sanitized, System.StringComparison.Ordinal);
+        Assert.DoesNotContain("supersecret", sanitized, System.StringComparison.Ordinal);
+        Assert.Contains("api.example.com/v1/audio/transcriptions", sanitized, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SanitizeEndpointKeepsAPlainUrlIntact()
+    {
+        const string url = "https://api.groq.com/openai/v1/audio/transcriptions";
+        Assert.Equal(url, UpstreamErrorSanitizer.SanitizeEndpoint(url));
+    }
+
+    // ---- media-type gating (what may be echoed at all) -------------------------------------------
+
+    [Theory]
+    [InlineData(null, true)]
+    [InlineData("application/json", true)]
+    [InlineData("application/problem+json", true)]
+    [InlineData("text/plain", true)]
+    [InlineData("text/html", false)]
+    [InlineData("application/octet-stream", false)]
+    public void OnlySafeMediaTypesMayBeEchoed(string? mediaType, bool expected)
+    {
+        Assert.Equal(expected, RemoteWhisperProvider.MaySnippetUpstreamBody(mediaType));
+    }
+
+    [Fact]
+    public void HtmlBodyIsClassifiedNotQuoted()
+    {
+        var detail = RemoteWhisperProvider.DescribeUpstreamErrorBody(
+            "<html><body>Login page<script>alert(1)</script></body></html>", null, "text/html");
+        Assert.DoesNotContain("<script", detail, System.StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Login page", detail, System.StringComparison.Ordinal);
+        Assert.Contains("web page", detail, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ---- the assembled message -------------------------------------------------------------------
+
+    [Fact]
+    public void MessageCarriesStatusDetailAndGuidance()
+    {
+        var message = RemoteWhisperProvider.BuildRemoteApiMessage(
+            HttpStatusCode.RequestEntityTooLarge, "file too large");
+        Assert.Contains("413", message, System.StringComparison.Ordinal);
+        Assert.Contains("file too large", message, System.StringComparison.Ordinal);
+        Assert.Contains("Max upload size", message, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void MessageWithoutDetailStillCarriesGuidance()
+    {
+        var message = RemoteWhisperProvider.BuildRemoteApiMessage(HttpStatusCode.Unauthorized, "");
+        Assert.Contains("401", message, System.StringComparison.Ordinal);
+        Assert.Contains("API key", message, System.StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/WhisperSubs.Tests/WorkerUploadBackCompatTests.cs
+++ b/WhisperSubs.Tests/WorkerUploadBackCompatTests.cs
@@ -1,0 +1,110 @@
+using System.IO;
+using System.Xml.Serialization;
+using WhisperSubs.Configuration;
+using WhisperSubs.Controller.Workers;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+/// <summary>
+/// Back-compat lock for the v4.5 upload settings (issue #138). Every existing install has a config XML
+/// written before <c>MaxUploadBytes</c> and <c>UploadCodec</c> existed; deserializing it must reproduce
+/// the old behaviour exactly — unlimited size and an uncompressed WAV upload — or self-hosted workers
+/// (whisper.cpp decodes WAV only) would break on upgrade.
+/// </summary>
+public class WorkerUploadBackCompatTests
+{
+    private static WhisperWorker Deserialize(string xml)
+    {
+        var serializer = new XmlSerializer(typeof(WhisperWorker));
+        using var reader = new StringReader(xml);
+        return (WhisperWorker)serializer.Deserialize(reader)!;
+    }
+
+    [Fact]
+    public void PreV45ConfigDeserializesToUnlimitedWav()
+    {
+        // A worker row exactly as v4.4 would have persisted it: neither new element exists.
+        const string legacy = """
+            <?xml version="1.0" encoding="utf-16"?>
+            <WhisperWorker xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+              <Id>abc</Id>
+              <Name>groq</Name>
+              <Enabled>true</Enabled>
+              <ApiUrl>https://api.groq.com/openai</ApiUrl>
+              <ApiKey></ApiKey>
+              <Model>whisper-large-v3</Model>
+              <MaxConcurrency>1</MaxConcurrency>
+              <CostWeight>0</CostWeight>
+              <CanTranslate>true</CanTranslate>
+            </WhisperWorker>
+            """;
+
+        var worker = Deserialize(legacy);
+
+        Assert.Equal(0, worker.MaxUploadBytes);                       // unlimited => never blocks
+        Assert.Equal("wav", RemoteUploadFormat.Normalize(worker.UploadCodec));
+        Assert.False(RemoteUploadFormat.RequiresReencode(worker.UploadCodec));
+        Assert.True(UploadPreflight.IsAllowed(long.MaxValue / 2, worker.MaxUploadBytes));
+    }
+
+    [Fact]
+    public void EmptyUploadCodecElementIsTreatedAsWav()
+    {
+        // A round-trip through some editors can leave the element present but empty.
+        const string emptyElement = """
+            <?xml version="1.0" encoding="utf-16"?>
+            <WhisperWorker xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+              <ApiUrl>http://box:9010</ApiUrl>
+              <UploadCodec></UploadCodec>
+            </WhisperWorker>
+            """;
+
+        var worker = Deserialize(emptyElement);
+
+        Assert.Equal("wav", RemoteUploadFormat.Normalize(worker.UploadCodec));
+        Assert.False(RemoteUploadFormat.RequiresReencode(worker.UploadCodec));
+    }
+
+    [Fact]
+    public void FreshWorkerDefaultsAreUnlimitedWav()
+    {
+        var worker = new WhisperWorker();
+
+        Assert.Equal(0, worker.MaxUploadBytes);
+        Assert.Equal("wav", worker.UploadCodec);
+        Assert.False(RemoteUploadFormat.RequiresReencode(worker.UploadCodec));
+    }
+
+    [Fact]
+    public void LegacyWorkerStillValidates()
+    {
+        // The new validation rules must not reject a row that was perfectly valid before the upgrade.
+        var worker = new WhisperWorker { ApiUrl = "http://box:9010", MaxConcurrency = 1, CostWeight = 0 };
+        var (ok, error) = WorkerConfigValidation.Validate(worker);
+
+        Assert.True(ok);
+        Assert.Null(error);
+    }
+
+    [Theory]
+    [InlineData("mp3")]
+    [InlineData("aac")]
+    public void UnsupportedCodecIsRejectedByValidation(string codec)
+    {
+        var worker = new WhisperWorker { ApiUrl = "http://box:9010", UploadCodec = codec };
+        var (ok, error) = WorkerConfigValidation.Validate(worker);
+
+        Assert.False(ok);
+        Assert.Contains("wav, flac or opus", error!, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void NegativeMaxUploadIsRejected()
+    {
+        var worker = new WhisperWorker { ApiUrl = "http://box:9010", MaxUploadBytes = -1 };
+        var (ok, _) = WorkerConfigValidation.Validate(worker);
+
+        Assert.False(ok);
+    }
+}

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>4.4.0.1</Version>
+    <Version>4.5.0.0</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
Closes the remaining half of #138, reopened after @ARLBR10 tested 4.4.0.0: Groq worked, but a 40-minute title returned **HTTP 413** and OpenRouter failed with no visible reason.

## Root cause
Two symptoms, largely one cause — **payload size** — plus a diagnosability failure that hid it.

The plugin uploads 16 kHz mono PCM WAV: **1.92 MB per minute**. A 40-minute title is 76.8 MB against a 25 MB cap; a 2-hour film is 219.7 MB. And when the endpoint refused it, `RemoteApiException` captured the provider's explanation and **never surfaced it** — the admin saw a bare `HTTP 413`/`HTTP 400`. The reporter's "I can't enable debug logging" was a misdiagnosis: the error was already at Error level, it was just empty.

## Changes
1. **Decouple duration/deadline from uploaded bytes** (prerequisite, no behavior change). Duration drove both the per-call deadline and the segment-timestamp sanity bound; deriving it from a compressed upload would have collapsed the deadline and made every valid late segment throw.
2. **Surface the provider's own error**, via a pure `UpstreamErrorSanitizer`: redacts the worker's key, URL query strings, userinfo, Bearer/JWT/prefixed keys, long base64/hex, emails; strips all `\p{C}` (log forging/BiDi); truncates **after** redaction; 250 ms regex budget failing closed. Only 4xx/5xx and only json/problem+json/text-plain are echoed; `text/html` is classified, not quoted; a 2xx body is never echoed (it is the transcript). Plus one actionable sentence per status.
3. **Per-worker `MaxUploadBytes`** (default `0` = unlimited) with a pre-flight that refuses an impossible upload and states size, cap and implied minutes.
4. **Broadened format negotiation** — while a worker's format is un-negotiated, any 400/406/415/422 earns **one** retry. OpenRouter rejects `response_format=srt` with a bare 400 naming no parameter, so the old substring gate never fired.
5. **Per-worker `UploadCodec`** (default `wav`): FLAC ~53%, Opus 24k ~9% (a 2-hour film → ~20 MB). Default stays WAV **deliberately** — whisper.cpp decodes WAV only and this repo's worker image ships without ffmpeg, so a compressed default would break every self-hosted worker. FLAC pins `-sample_fmt s16`; without it ffmpeg defaults to 24-bit and output is **larger** than the PCM input (measured), which the vendor-published command would have caused.
6. **Security fix (independent of #138)**: a key pasted into the endpoint URL query was logged verbatim and reached the config page. Also downgraded the per-job negotiation Warning to Information (alert fatigue) and moved a full media path to Debug.
7. **README**: size table, base-URL form per provider, OpenRouter slug/translations limits, OpenAI whisper-1-only timestamps.

**Not included, deliberately:** audio chunking (Opus removes the need for realistic lengths; it has unresolved insertion-point, no-silence-found, resume and 429-backoff problems) and any speculative OpenRouter URL change (the double-`/v1` theory is self-defeating — Groq's own base URL also ends in `/v1` and Groq worked).

## Verification
1245 tests (0 failed), 0 warnings. Compression ratios and the FLAC 24-bit footgun were measured on real media with this project's own ffmpeg build, not taken from vendor docs.