### PR TITLE
fix(#138): correct upload labelling, bound the blind retry, and surface the fix before the detail

### DIFF
--- a/Controller/Workers/RemoteAudioEncoder.cs
+++ b/Controller/Workers/RemoteAudioEncoder.cs
@@ -23,12 +23,7 @@ namespace WhisperSubs.Controller.Workers
     [ExcludeFromCodeCoverage(Justification = "FFmpeg process I/O; the argument/format policy is tested in RemoteUploadFormatTests")]
     public static class RemoteAudioEncoder
     {
-        private static readonly string[] FfmpegCandidates =
-        {
-            "/usr/lib/jellyfin-ffmpeg/ffmpeg",
-            "ffmpeg",
-            "/usr/bin/ffmpeg",
-        };
+        private const string BundledFfmpeg = "/usr/lib/jellyfin-ffmpeg/ffmpeg";
 
         /// <summary>
         /// Produces the file to upload. Returns <paramref name="sourceWavPath"/> unchanged when the worker
@@ -37,23 +32,17 @@ namespace WhisperSubs.Controller.Workers
         /// gets the normal pre-flight/413 path with a clear message.
         /// </summary>
         /// <returns>
-        /// The path to upload, and whether it is a temporary file the caller must delete.
+        /// The path to upload, whether it is a temporary file the caller must delete, and the codec the
+        /// returned file is ACTUALLY in. The last one matters: every fallback below returns the untouched
+        /// source WAV, and labelling those bytes with the configured codec would send RIFF/WAVE data as
+        /// <c>audio.ogg</c> — the exact mislabelling that makes providers reject or mis-decode an upload.
         /// </returns>
-        public static async Task<(string Path, bool IsTemporary)> PrepareUploadAsync(
+        public static async Task<(string Path, bool IsTemporary, string EffectiveCodec)> PrepareUploadAsync(
             string sourceWavPath, string? codec, ILogger logger, CancellationToken cancellationToken)
         {
             if (!RemoteUploadFormat.RequiresReencode(codec))
             {
-                return (sourceWavPath, false);
-            }
-
-            var ffmpeg = FindFfmpeg();
-            if (ffmpeg is null)
-            {
-                logger.LogWarning(
-                    "Upload format {Codec} is configured but FFmpeg was not found; uploading the original WAV instead.",
-                    RemoteUploadFormat.Normalize(codec));
-                return (sourceWavPath, false);
+                return (sourceWavPath, false, RemoteUploadFormat.Wav);
             }
 
             var target = Path.Combine(
@@ -67,7 +56,7 @@ namespace WhisperSubs.Controller.Workers
                 {
                     StartInfo = new ProcessStartInfo
                     {
-                        FileName = ffmpeg,
+                        FileName = FindFfmpeg(),
                         Arguments = arguments,
                         RedirectStandardError = true,
                         RedirectStandardOutput = true,
@@ -80,7 +69,27 @@ namespace WhisperSubs.Controller.Workers
                 // Drain both pipes so a chatty ffmpeg cannot deadlock on a full buffer.
                 var stderr = process.StandardError.ReadToEndAsync(cancellationToken);
                 var stdout = process.StandardOutput.ReadToEndAsync(cancellationToken);
-                await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    // WaitForExitAsync abandons the wait but does NOT stop ffmpeg. Without this the process
+                    // keeps running at full speed and TryDelete unlinks a file it still holds open, so the
+                    // space stays allocated (on Unraid /tmp that is RAM) until the orphan exits.
+                    try
+                    {
+                        process.Kill(entireProcessTree: true);
+                    }
+                    catch (Exception)
+                    {
+                        // Already gone, or not permitted - nothing further we can do.
+                    }
+
+                    throw;
+                }
+
                 await Task.WhenAll(stderr, stdout).ConfigureAwait(false);
 
                 if (process.ExitCode != 0 || !File.Exists(target) || new FileInfo(target).Length == 0)
@@ -89,7 +98,7 @@ namespace WhisperSubs.Controller.Workers
                         "Re-encoding the upload to {Codec} failed (exit {ExitCode}); uploading the original WAV instead.",
                         RemoteUploadFormat.Normalize(codec), process.ExitCode);
                     TryDelete(target);
-                    return (sourceWavPath, false);
+                    return (sourceWavPath, false, RemoteUploadFormat.Wav);
                 }
 
                 var sourceBytes = new FileInfo(sourceWavPath).Length;
@@ -104,7 +113,7 @@ namespace WhisperSubs.Controller.Workers
                         "Re-encoded upload ({UploadBytes} bytes) is not smaller than the source ({SourceBytes} bytes); uploading the original WAV instead.",
                         uploadBytes, sourceBytes);
                     TryDelete(target);
-                    return (sourceWavPath, false);
+                    return (sourceWavPath, false, RemoteUploadFormat.Wav);
                 }
 
                 logger.LogInformation(
@@ -113,7 +122,7 @@ namespace WhisperSubs.Controller.Workers
                     RemoteErrorGuidance.FormatBytes(uploadBytes),
                     RemoteErrorGuidance.FormatBytes(sourceBytes));
 
-                return (target, true);
+                return (target, true, RemoteUploadFormat.Normalize(codec));
             }
             catch (OperationCanceledException)
             {
@@ -126,7 +135,7 @@ namespace WhisperSubs.Controller.Workers
                     "Could not re-encode the upload to {Codec}; uploading the original WAV instead.",
                     RemoteUploadFormat.Normalize(codec));
                 TryDelete(target);
-                return (sourceWavPath, false);
+                return (sourceWavPath, false, RemoteUploadFormat.Wav);
             }
         }
 
@@ -151,25 +160,12 @@ namespace WhisperSubs.Controller.Workers
             }
         }
 
-        private static string? FindFfmpeg()
-        {
-            foreach (var candidate in FfmpegCandidates)
-            {
-                if (Path.IsPathRooted(candidate))
-                {
-                    if (File.Exists(candidate))
-                    {
-                        return candidate;
-                    }
-
-                    continue;
-                }
-
-                // Bare name: let the OS resolve it from PATH at start time.
-                return candidate;
-            }
-
-            return null;
-        }
+        /// <summary>
+        /// Jellyfin's bundled ffmpeg when present, otherwise the bare name so the OS resolves it from PATH.
+        /// Never null: if ffmpeg is genuinely absent, Process.Start throws and the caller falls back to
+        /// uploading the original WAV.
+        /// </summary>
+        private static string FindFfmpeg()
+            => File.Exists(BundledFfmpeg) ? BundledFfmpeg : "ffmpeg";
     }
 }

--- a/Controller/Workers/RemoteErrorGuidance.cs
+++ b/Controller/Workers/RemoteErrorGuidance.cs
@@ -55,7 +55,13 @@ namespace WhisperSubs.Controller.Workers
                 allowedMinutes);
         }
 
-        /// <summary>Human-friendly byte size (invariant culture, so logs never drift with locale).</summary>
+        /// <summary>
+        /// Human-friendly byte size (invariant culture, so logs never drift with locale). DECIMAL units, to
+        /// match how providers quote their limits ("25 MB"), how the README states sizes, and how the config
+        /// page converts its "max upload size (MB)" field. Using binary units here would print a different
+        /// number than the docs for the same file, and would set a cap ~5% larger than the admin intended -
+        /// enough to let an upload through pre-flight and still earn a real 413.
+        /// </summary>
         public static string FormatBytes(long bytes)
         {
             if (bytes < 0)
@@ -63,11 +69,11 @@ namespace WhisperSubs.Controller.Workers
                 bytes = 0;
             }
 
-            return bytes >= 1024L * 1024L * 1024L
-                ? string.Format(CultureInfo.InvariantCulture, "{0:F1} GB", bytes / 1024.0 / 1024.0 / 1024.0)
-                : bytes >= 1024L * 1024L
-                    ? string.Format(CultureInfo.InvariantCulture, "{0:F1} MB", bytes / 1024.0 / 1024.0)
-                    : string.Format(CultureInfo.InvariantCulture, "{0:F0} KB", Math.Ceiling(bytes / 1024.0));
+            return bytes >= 1_000_000_000L
+                ? string.Format(CultureInfo.InvariantCulture, "{0:F1} GB", bytes / 1_000_000_000.0)
+                : bytes >= 1_000_000L
+                    ? string.Format(CultureInfo.InvariantCulture, "{0:F1} MB", bytes / 1_000_000.0)
+                    : string.Format(CultureInfo.InvariantCulture, "{0:F0} KB", Math.Ceiling(bytes / 1000.0));
         }
     }
 }

--- a/Controller/Workers/RemoteUploadFormat.cs
+++ b/Controller/Workers/RemoteUploadFormat.cs
@@ -25,9 +25,6 @@ namespace WhisperSubs.Controller.Workers
         public const string Flac = "flac";
         public const string Opus = "opus";
 
-        /// <summary>Bytes per second of the extracted 16 kHz mono s16le PCM source.</summary>
-        public const double SourceBytesPerSecond = 32000.0;
-
         /// <summary>Opus bitrate used for uploads. 24 kbps mono keeps a 2-hour film near 20 MB.</summary>
         public const int OpusBitrateKbps = 24;
 
@@ -113,28 +110,6 @@ namespace WhisperSubs.Controller.Workers
                 sourceWavPath,
                 codecArgs,
                 targetPath);
-        }
-
-        /// <summary>
-        /// Approximate uploaded size for a codec, from the SOURCE PCM size. Ratios are measured on real
-        /// film audio with this project's ffmpeg build, not vendor claims. Used only for advice/estimates —
-        /// never as a substitute for the real file length.
-        /// </summary>
-        public static long EstimateUploadBytes(long sourceBytes, string? codec)
-        {
-            if (sourceBytes <= 0)
-            {
-                return 0;
-            }
-
-            var ratio = Normalize(codec) switch
-            {
-                Flac => 0.53,
-                Opus => 0.091,
-                _ => 1.0,
-            };
-
-            return (long)Math.Round(sourceBytes * ratio, MidpointRounding.AwayFromZero);
         }
     }
 }

--- a/Controller/Workers/UpstreamErrorSanitizer.cs
+++ b/Controller/Workers/UpstreamErrorSanitizer.cs
@@ -63,8 +63,10 @@ namespace WhisperSubs.Controller.Workers
             @"id[_\-]?token|client[_\-]?secret|secret|password|passwd|pwd|token|signature|sig)\b" +
             @"\s*[""']?\s*[:=]\s*[""']?(?<v>[^\s""',&}\]]{4,})", Opts, Budget);
 
-        // Long high-entropy runs: no English word is 40 chars, and a 32+ hex run is a key, hash or request id.
-        private static readonly Regex LongBase64 = new(@"\b[A-Za-z0-9+/]{40,}={0,2}\b", Opts, Budget);
+        // Long high-entropy runs: no English word is 40 chars, and a 32+ hex run is a key, hash or request
+        // id. '/' is deliberately NOT in the class — including it made any long URL path match, so a
+        // perfectly innocent endpoint path was redacted out of the message the admin needed to read.
+        private static readonly Regex LongBase64 = new(@"\b[A-Za-z0-9+]{40,}={0,2}\b", Opts, Budget);
         private static readonly Regex LongHex = new(@"\b[0-9a-f]{32,}\b", Opts, Budget);
 
         private static readonly Regex Email = new(
@@ -124,6 +126,11 @@ namespace WhisperSubs.Controller.Workers
                 s = LongBase64.Replace(s, Redacted);
                 s = LongHex.Replace(s, Redacted);
                 s = Email.Replace(s, "[email]");
+
+                // STEP 3 - flatten to one safe line. Inside the try: these carry the same regex budget, and
+                // a timeout escaping here would propagate out past the caller's status handling.
+                s = ControlChars.Replace(s, " ");
+                s = WhitespaceRun.Replace(s, " ").Trim();
             }
             catch (RegexMatchTimeoutException)
             {
@@ -131,10 +138,6 @@ namespace WhisperSubs.Controller.Workers
                 // through to the raw text.
                 return "[error detail withheld: could not be sanitized]";
             }
-
-            // STEP 3 - flatten to one safe line.
-            s = ControlChars.Replace(s, " ");
-            s = WhitespaceRun.Replace(s, " ").Trim();
 
             // STEP 4 - cap LAST, so truncation can never re-expose a partially redacted secret.
             if (s.Length > maxLength)
@@ -149,6 +152,12 @@ namespace WhisperSubs.Controller.Workers
         /// Sanitizes an endpoint URL for display or logging: drops userinfo and the entire query string.
         /// An admin may legitimately paste a key into the URL (Azure-style "?api-version=", proxy
         /// "?api_key="); without this that string reaches jellyfin.log and the config page verbatim.
+        /// <para>
+        /// Scope, stated honestly: this covers the userinfo and query-string forms only. A credential
+        /// embedded in the PATH (some gateways use /v1/&lt;account&gt;/…) is preserved, because the path is
+        /// usually the single most useful thing in a "wrong endpoint" diagnosis and blanket-masking it
+        /// would hide exactly what the admin needs.
+        /// </para>
         /// </summary>
         public static string SanitizeEndpoint(string? url)
         {

--- a/Providers/RemoteWhisperProvider.cs
+++ b/Providers/RemoteWhisperProvider.cs
@@ -42,15 +42,19 @@ namespace WhisperSubs.Providers
         internal static string BuildRemoteApiMessage(HttpStatusCode statusCode, string? detail)
         {
             var message = $"Remote Whisper API returned HTTP {(int)statusCode}";
-            if (!string.IsNullOrWhiteSpace(detail))
-            {
-                message += $": {detail}";
-            }
 
+            // Guidance FIRST: this message is surfaced through the queue's last-error, which the config page
+            // truncates. Appending the advice after up to 400 characters of upstream detail meant the admin
+            // reliably saw the diagnosis and never the fix — the opposite of the point.
             var guidance = RemoteErrorGuidance.For(statusCode);
             if (!string.IsNullOrWhiteSpace(guidance))
             {
                 message += $" — {guidance}";
+            }
+
+            if (!string.IsNullOrWhiteSpace(detail))
+            {
+                message += $" [endpoint said: {detail}]";
             }
 
             return message;
@@ -75,8 +79,14 @@ namespace WhisperSubs.Providers
         /// </summary>
         internal static string DescribeUpstreamErrorBody(string? body, string? apiKey, string? mediaType)
         {
-            if (!string.IsNullOrWhiteSpace(mediaType)
-                && mediaType.Equals("text/html", StringComparison.OrdinalIgnoreCase))
+            // Classify by CONTENT as well as header: proxies and load balancers routinely return an HTML
+            // error page with no Content-Type at all, which would otherwise sail through the allow-list.
+            var trimmed = (body ?? string.Empty).TrimStart();
+            if ((!string.IsNullOrWhiteSpace(mediaType)
+                    && mediaType.Equals("text/html", StringComparison.OrdinalIgnoreCase))
+                || trimmed.StartsWith("<!DOCTYPE", StringComparison.OrdinalIgnoreCase)
+                || trimmed.StartsWith("<html", StringComparison.OrdinalIgnoreCase)
+                || trimmed.StartsWith("<", StringComparison.Ordinal))
             {
                 return "the endpoint returned a web page, not an API response";
             }
@@ -115,6 +125,11 @@ namespace WhisperSubs.Providers
         private readonly HttpClient _httpClient;
         private readonly long _maxUploadBytes;
         private readonly string _uploadCodec;
+        // Set once a blind (body-didn't-say-so) format retry has been spent for this provider instance.
+        // The cached format only fills on SUCCESS, so without this a worker that always 4xxs — e.g. the bare
+        // OpenRouter model slug this release's README warns about — would upload the full audio twice on
+        // EVERY job, and the queue retries each item JobMaxRetries times on top of that.
+        private int _blindNegotiationSpent;
         private string? _transcriptionResponseFormat;
         private string? _translationResponseFormat;
 
@@ -190,7 +205,10 @@ namespace WhisperSubs.Providers
             // Re-encode for the wire when this worker asks for it (default wav = no-op), then refuse to
             // upload at all if the result still exceeds the worker's configured cap: a fail-fast with real
             // numbers beats pushing 77 MB to earn a bare HTTP 413.
-            var (uploadPath, uploadIsTemporary) = await RemoteAudioEncoder
+            // effectiveCodec is what the file ACTUALLY is, which differs from _uploadCodec whenever the
+            // re-encode fell back to the source WAV (no ffmpeg, encode failed, or output was not smaller).
+            // Labelling WAV bytes as audio.ogg would be rejected or mis-decoded by the provider.
+            var (uploadPath, uploadIsTemporary, effectiveCodec) = await RemoteAudioEncoder
                 .PrepareUploadAsync(audioPath, _uploadCodec, _logger, cancellationToken).ConfigureAwait(false);
             try
             {
@@ -199,11 +217,11 @@ namespace WhisperSubs.Providers
                 {
                     throw new InvalidOperationException(
                         UploadPreflight.ExplainIfBlocked(
-                            sourceAudioBytes, uploadBytes, _maxUploadBytes, _uploadCodec));
+                            sourceAudioBytes, uploadBytes, _maxUploadBytes, effectiveCodec));
                 }
 
                 return await TranscribeUploadAsync(
-                    endpoint, uploadPath, sourceAudioBytes, language, translate, cancellationToken)
+                    endpoint, uploadPath, sourceAudioBytes, effectiveCodec, language, translate, cancellationToken)
                     .ConfigureAwait(false);
             }
             finally
@@ -220,6 +238,7 @@ namespace WhisperSubs.Providers
             string endpoint,
             string audioPath,
             long sourceAudioBytes,
+            string uploadCodec,
             string language,
             bool translate,
             CancellationToken cancellationToken)
@@ -231,14 +250,15 @@ namespace WhisperSubs.Providers
             // format-candidate rejection is worth one retry even when the body does not name the parameter
             // (OpenRouter rejects response_format=srt with a bare 400). Bounded: once the format is cached,
             // only an explicit format complaint triggers a retry again.
-            var formatNotYetNegotiated = cachedResponseFormat is null;
+            var formatNotYetNegotiated =
+                cachedResponseFormat is null && Volatile.Read(ref _blindNegotiationSpent) == 0;
             var responseFormat = cachedResponseFormat ?? "srt";
             var negotiatedByFormatRejection = false;
             string response;
             try
             {
                 response = await PostTranscriptionAsync(
-                    endpoint, audioPath, sourceAudioBytes, language, responseFormat, includeLanguage: !translate, cancellationToken: cancellationToken)
+                    endpoint, audioPath, sourceAudioBytes, uploadCodec, language, responseFormat, includeLanguage: !translate, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
             }
             catch (HttpRequestException ex) when (ShouldNegotiateAlternateFormat(ex, formatNotYetNegotiated))
@@ -246,6 +266,13 @@ namespace WhisperSubs.Providers
                 // Preserve existing SRT providers as the first choice. Groq/OpenRouter reject SRT, so
                 // negotiate once to timestamped verbose_json and cache the successful format. If a
                 // provider's capability changes later, the reverse retry also recovers automatically.
+                // Spend the blind-retry budget before re-posting, so a permanently-failing endpoint cannot
+                // double every future upload.
+                if (formatNotYetNegotiated && !IsResponseFormatRejection(ex))
+                {
+                    Interlocked.Exchange(ref _blindNegotiationSpent, 1);
+                }
+
                 responseFormat = AlternateResponseFormat(responseFormat);
                 negotiatedByFormatRejection = true;
                 // Information, not Warning: this is expected, successful, self-healing behavior on Groq and
@@ -254,7 +281,7 @@ namespace WhisperSubs.Providers
                 _logger.LogInformation(
                     "Remote API rejected response format; retrying with {ResponseFormat}", responseFormat);
                 response = await PostTranscriptionAsync(
-                    endpoint, audioPath, sourceAudioBytes, language, responseFormat, includeLanguage: !translate, cancellationToken: cancellationToken)
+                    endpoint, audioPath, sourceAudioBytes, uploadCodec, language, responseFormat, includeLanguage: !translate, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
             }
 
@@ -264,7 +291,7 @@ namespace WhisperSubs.Providers
                 _logger.LogInformation(
                     "Remote API returned untimed JSON; retrying with {ResponseFormat}", responseFormat);
                 response = await PostTranscriptionAsync(
-                    endpoint, audioPath, sourceAudioBytes, language, responseFormat, includeLanguage: !translate, cancellationToken: cancellationToken)
+                    endpoint, audioPath, sourceAudioBytes, uploadCodec, language, responseFormat, includeLanguage: !translate, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
             }
 
@@ -293,6 +320,7 @@ namespace WhisperSubs.Providers
             string endpoint,
             string audioPath,
             long sourceAudioBytes,
+            string uploadCodec,
             string language,
             string responseFormat,
             bool includeLanguage,
@@ -306,8 +334,8 @@ namespace WhisperSubs.Providers
             var fileContent = new StreamContent(File.OpenRead(audioPath));
             // Name and media type must match the actual bytes: providers routinely sniff the format from the
             // file EXTENSION, so a FLAC body called "audio.wav" is rejected or mis-decoded.
-            fileContent.Headers.ContentType = new MediaTypeHeaderValue(RemoteUploadFormat.ContentType(_uploadCodec));
-            content.Add(fileContent, "file", RemoteUploadFormat.FileName(_uploadCodec));
+            fileContent.Headers.ContentType = new MediaTypeHeaderValue(RemoteUploadFormat.ContentType(uploadCodec));
+            content.Add(fileContent, "file", RemoteUploadFormat.FileName(uploadCodec));
             content.Add(new StringContent(_model), "model");
             content.Add(new StringContent(responseFormat), "response_format");
             if (string.Equals(responseFormat, "verbose_json", StringComparison.Ordinal))
@@ -345,9 +373,9 @@ namespace WhisperSubs.Providers
         /// this the negotiation never fires and the endpoint simply never works (issue #138).
         /// </para>
         /// <para>
-        /// The cost of a wrong guess is bounded: exactly one extra upload, once per worker, and only until a
-        /// format is successfully cached. After that a retry needs an explicit format complaint again, so a
-        /// misconfiguration (say a bad model name) cannot cause a repeated large re-upload on every job.
+        /// The cost of a wrong guess is bounded twice over: at most ONE extra upload within a job, and the
+        /// blind form is spent at most once per provider instance (see _blindNegotiationSpent). A worker
+        /// that always 4xxs therefore pays the double upload once, not on every job.
         /// </para>
         /// </summary>
         internal static bool ShouldNegotiateAlternateFormat(HttpRequestException exception, bool formatNotYetNegotiated)
@@ -776,7 +804,7 @@ namespace WhisperSubs.Providers
                 if (!response.IsSuccessStatusCode)
                 {
                     var errorBody = await ReadUtf8BoundedAsync(
-                        response.Content, MaxErrorResponseBytes, timeoutCts.Token).ConfigureAwait(false);
+                        response.Content, MaxErrorResponseBytes, timeoutCts.Token, truncate: true).ConfigureAwait(false);
                     // Echo the provider's own explanation, sanitized and media-type gated, so the admin can
                     // see WHY without turning on debug logging (#138). The raw body is retained on the
                     // exception for the response-format negotiation matcher.
@@ -797,14 +825,23 @@ namespace WhisperSubs.Providers
             }
         }
 
+        /// <param name="truncate">
+        /// When true, an oversized body is TRUNCATED to <paramref name="maxBytes"/> instead of throwing.
+        /// Use this for ERROR bodies only: an endpoint behind a proxy answers a failure with a multi-KB HTML
+        /// page, and throwing there loses the status code, the guidance and the format negotiation (the
+        /// thrown type is not HttpRequestException, so the negotiation catch never runs) — which defeats the
+        /// entire point of surfacing provider errors. A TRANSCRIPT must still throw: silently truncating one
+        /// would produce subtitles that are quietly missing their tail.
+        /// </param>
         internal static async Task<string> ReadUtf8BoundedAsync(
-            HttpContent content, int maxBytes, CancellationToken cancellationToken)
+            HttpContent content, int maxBytes, CancellationToken cancellationToken, bool truncate = false)
         {
             if (maxBytes < 1)
             {
                 throw new ArgumentOutOfRangeException(nameof(maxBytes));
             }
-            if (content.Headers.ContentLength is long declaredLength && declaredLength > maxBytes)
+            if (!truncate
+                && content.Headers.ContentLength is long declaredLength && declaredLength > maxBytes)
             {
                 throw new InvalidOperationException("Remote Whisper API response exceeded the size limit");
             }
@@ -824,7 +861,19 @@ namespace WhisperSubs.Providers
                 }
                 if (output.Length + read > maxBytes)
                 {
-                    throw new InvalidOperationException("Remote Whisper API response exceeded the size limit");
+                    if (!truncate)
+                    {
+                        throw new InvalidOperationException("Remote Whisper API response exceeded the size limit");
+                    }
+
+                    // Keep what fits and stop reading; the sanitizer caps it far shorter anyway.
+                    var remaining = (int)(maxBytes - output.Length);
+                    if (remaining > 0)
+                    {
+                        output.Write(buffer, 0, remaining);
+                    }
+
+                    break;
                 }
                 output.Write(buffer, 0, read);
             }

--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ So a 25 MB cap (OpenAI, and Groq's free tier) accepts only about **13 minutes** 
 - **OpenRouter** requires a namespaced slug (`openai/whisper-large-v3-turbo`, not `whisper-1`); a bare name returns `400`. It also rejects `response_format=srt` outright -- WhisperSubs negotiates to timestamped JSON automatically -- and has **no `/v1/audio/translations` endpoint**, so turn **Can translate** off for it. Timestamps are only available on its OpenAI-compatible models; models that return text without timings cannot produce synchronized subtitles.
 - **OpenAI**: timestamps and SRT are available on `whisper-1` only. `gpt-4o-transcribe` / `gpt-4o-mini-transcribe` return `json`/`text` with no timings, so they cannot be used for subtitles.
 - Turn off **Can translate** for any provider that does not expose `/v1/audio/translations`.
->
+
 > **Note:** the automatic scheduled sweep currently processes its backlog one item at a time; manual **Generate** / **Generate All** already fan out across the whole pool. Parallelizing the scheduled sweep is on the [roadmap](ROADMAP.md).
 
 ## Configuration

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -1807,7 +1807,7 @@
 
                     row.appendChild(WhisperSubsConfig._workerField(
                         'Max upload size (MB)', 'number', 'wkMaxUpload', { min: '0', step: '1', placeholder: '0 = unlimited' },
-                        (w.MaxUploadBytes != null && w.MaxUploadBytes > 0) ? Math.round(w.MaxUploadBytes / 1048576) : '',
+                        (w.MaxUploadBytes != null && w.MaxUploadBytes > 0) ? Math.round(w.MaxUploadBytes / 1000000) : '',
                         'Largest file this endpoint accepts. 0 (default) = unlimited. OpenAI and Groq free tier are 25; Groq dev tier 100. Oversized titles then fail fast with a clear message instead of a bare HTTP 413.'));
                     row.appendChild(WhisperSubsConfig._workerSelect(
                         'Upload format', 'wkUploadCodec',
@@ -1976,7 +1976,7 @@
                         var maxUploadMb = parseFloat(maxUploadRaw);
                         var maxUploadBytes = (isNaN(maxUploadMb) || maxUploadMb <= 0)
                             ? 0
-                            : Math.round(maxUploadMb * 1048576);
+                            : Math.round(maxUploadMb * 1000000);
 
                         workers.push({
                             Id: row.getAttribute('data-worker-id') || WhisperSubsConfig.genWorkerId(),

--- a/WhisperSubs.Tests/BoundedResponseReadTests.cs
+++ b/WhisperSubs.Tests/BoundedResponseReadTests.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -79,5 +80,72 @@ public class BoundedResponseReadTests
 
         Assert.True(RemoteWhisperProvider.IsResponseFormatRejection(
             System.Net.HttpStatusCode.BadRequest, read));
+    }
+
+    [Fact]
+    public async Task TruncationWritesThePartialBufferWhenTheLimitIsNotBufferAligned()
+    {
+        // maxBytes > the 8 KB read buffer, so the overflowing read must contribute its first N bytes
+        // rather than being dropped whole — otherwise the snippet would silently lose up to 8 KB.
+        var content = Content(new string('z', 40_000));
+
+        var read = await RemoteWhisperProvider.ReadUtf8BoundedAsync(
+            content, maxBytes: 10_000, CancellationToken.None, truncate: true);
+
+        Assert.Equal(10_000, read.Length);
+    }
+
+    [Fact]
+    public async Task UndeclaredLengthTranscriptStillThrowsWhenItOverflows()
+    {
+        // No Content-Length (a chunked/streamed response), so the declared-length short-circuit cannot
+        // fire and the in-loop guard is what has to stop an unbounded transcript read.
+        var content = new StreamContent(new NonSeekableStream(
+            System.Text.Encoding.UTF8.GetBytes(new string('s', 40_000))));
+        Assert.Null(content.Headers.ContentLength);
+
+        await Assert.ThrowsAsync<System.InvalidOperationException>(
+            () => RemoteWhisperProvider.ReadUtf8BoundedAsync(
+                content, maxBytes: 10_000, CancellationToken.None));
+    }
+
+    /// <summary>A forward-only stream, so StreamContent cannot infer a Content-Length from it.</summary>
+    private sealed class NonSeekableStream(byte[] data) : Stream
+    {
+        private readonly MemoryStream _inner = new(data);
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new System.NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new System.NotSupportedException();
+            set => throw new System.NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+
+        public override void Flush() => _inner.Flush();
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new System.NotSupportedException();
+
+        public override void SetLength(long value) => throw new System.NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new System.NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _inner.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
     }
 }

--- a/WhisperSubs.Tests/BoundedResponseReadTests.cs
+++ b/WhisperSubs.Tests/BoundedResponseReadTests.cs
@@ -1,0 +1,83 @@
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using WhisperSubs.Providers;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+/// <summary>
+/// Covers the error-body read policy added in 4.5.0.1.
+/// <para>
+/// An endpoint behind a proxy answers a failure with a multi-KB HTML page. Throwing on that lost the status
+/// code, the guidance AND the format negotiation — the thrown type is not <see cref="HttpRequestException"/>,
+/// so the negotiation catch never ran. Error bodies therefore truncate. A TRANSCRIPT must still throw:
+/// silently truncating one would ship subtitles quietly missing their tail.
+/// </para>
+/// </summary>
+public class BoundedResponseReadTests
+{
+    private static HttpContent Content(string body) => new StringContent(body);
+
+    [Fact]
+    public async Task OversizedErrorBodyIsTruncatedNotThrown()
+    {
+        var huge = new string('e', 20_000);
+
+        var read = await RemoteWhisperProvider.ReadUtf8BoundedAsync(
+            Content(huge), maxBytes: 4096, CancellationToken.None, truncate: true);
+
+        Assert.Equal(4096, read.Length);
+    }
+
+    [Fact]
+    public async Task OversizedTranscriptStillThrows()
+    {
+        var huge = new string('t', 20_000);
+
+        await Assert.ThrowsAsync<System.InvalidOperationException>(
+            () => RemoteWhisperProvider.ReadUtf8BoundedAsync(
+                Content(huge), maxBytes: 4096, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task DeclaredOversizeLengthIsAlsoTruncatedWhenTruncating()
+    {
+        // StringContent sets Content-Length, so this exercises the declared-length short-circuit too.
+        var content = Content(new string('x', 10_000));
+        Assert.NotNull(content.Headers.ContentLength);
+
+        var read = await RemoteWhisperProvider.ReadUtf8BoundedAsync(
+            content, maxBytes: 512, CancellationToken.None, truncate: true);
+
+        Assert.Equal(512, read.Length);
+    }
+
+    [Fact]
+    public async Task BodyUnderTheLimitIsReturnedWhole()
+    {
+        const string body = """{"error":"model does not exist"}""";
+
+        var truncating = await RemoteWhisperProvider.ReadUtf8BoundedAsync(
+            Content(body), maxBytes: 4096, CancellationToken.None, truncate: true);
+        var strict = await RemoteWhisperProvider.ReadUtf8BoundedAsync(
+            Content(body), maxBytes: 4096, CancellationToken.None);
+
+        Assert.Equal(body, truncating);
+        Assert.Equal(body, strict);
+    }
+
+    [Fact]
+    public async Task TruncatedErrorBodyStillFeedsTheFormatNegotiation()
+    {
+        // The point of truncating: a huge body that happens to mention the format must still be matchable,
+        // rather than blowing up and skipping negotiation entirely.
+        var body = """{"error":"response_format srt is not supported"}""" + new string(' ', 20_000);
+
+        var read = await RemoteWhisperProvider.ReadUtf8BoundedAsync(
+            Content(body), maxBytes: 4096, CancellationToken.None, truncate: true);
+
+        Assert.True(RemoteWhisperProvider.IsResponseFormatRejection(
+            System.Net.HttpStatusCode.BadRequest, read));
+    }
+}

--- a/WhisperSubs.Tests/RemoteUploadEdgeCaseTests.cs
+++ b/WhisperSubs.Tests/RemoteUploadEdgeCaseTests.cs
@@ -1,0 +1,226 @@
+using System.Net;
+using WhisperSubs.Configuration;
+using WhisperSubs.Controller.Workers;
+using WhisperSubs.Providers;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+/// <summary>
+/// Branch coverage for the defensive edges of the v4.5 upload/diagnostics code (issue #138). These are the
+/// paths that only run when something is already wrong — a blank URL, a caller passing the wrong codec, a
+/// zero-length file — which is exactly when they must not throw or misreport.
+/// </summary>
+public class RemoteUploadEdgeCaseTests
+{
+    // ---- UpstreamErrorSanitizer edges ----------------------------------------------------------
+
+    [Fact]
+    public void AbsurdlySmallMaxLengthIsClampedNotHonoured()
+    {
+        // A caller asking for 3 characters must still get a usable, safely-terminated string.
+        var sanitized = UpstreamErrorSanitizer.Sanitize(new string('x', 200), null, maxLength: 3);
+        Assert.True(sanitized.Length is > 3 and <= 16);
+    }
+
+    [Fact]
+    public void ShortInputIsReturnedWithoutTruncationMarker()
+    {
+        var sanitized = UpstreamErrorSanitizer.Sanitize("model not found", null);
+        Assert.Equal("model not found", sanitized);
+        Assert.DoesNotContain("…", sanitized, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LongProseIsTruncatedWithAMarker()
+    {
+        // Deliberately ORDINARY prose: a long run of a single character would be swallowed by the
+        // high-entropy redaction rule and never reach the truncation branch at all (which is exactly the
+        // trap an earlier version of this test fell into).
+        var body = string.Join(" ", System.Linq.Enumerable.Repeat("the endpoint refused this request", 40));
+
+        var sanitized = UpstreamErrorSanitizer.Sanitize(body, null, maxLength: 120);
+
+        Assert.True(sanitized.Length <= 120);
+        Assert.EndsWith("…", sanitized, System.StringComparison.Ordinal);
+        Assert.StartsWith("the endpoint refused", sanitized, System.StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void SanitizeEndpointHandlesBlank(string? url)
+    {
+        Assert.Equal(string.Empty, UpstreamErrorSanitizer.SanitizeEndpoint(url));
+    }
+
+    [Fact]
+    public void SanitizeEndpointFallsBackForNonAbsoluteInput()
+    {
+        // Not a parseable absolute URL (a typo an admin can realistically save) — must not throw, and must
+        // still scrub anything secret-shaped.
+        var sanitized = UpstreamErrorSanitizer.SanitizeEndpoint("not a url api_key=supersecretvalue");
+        Assert.DoesNotContain("supersecretvalue", sanitized, System.StringComparison.Ordinal);
+    }
+
+    // ---- RemoteUploadFormat edges ---------------------------------------------------------------
+
+    [Theory]
+    [InlineData("wav", ".wav")]
+    [InlineData("flac", ".flac")]
+    [InlineData("opus", ".ogg")]
+    [InlineData("bogus", ".wav")]
+    public void ExtensionMatchesTheCodec(string codec, string expected)
+    {
+        Assert.Equal(expected, RemoteUploadFormat.Extension(codec));
+    }
+
+    [Theory]
+    [InlineData("", "/tmp/out.flac")]
+    [InlineData("   ", "/tmp/out.flac")]
+    public void BuildArgumentsRejectsBlankSource(string source, string target)
+    {
+        Assert.Throws<System.ArgumentException>(
+            () => RemoteUploadFormat.BuildFfmpegArguments(source, target, "flac"));
+    }
+
+    [Theory]
+    [InlineData("/tmp/in.wav", "")]
+    [InlineData("/tmp/in.wav", "   ")]
+    public void BuildArgumentsRejectsBlankTarget(string source, string target)
+    {
+        Assert.Throws<System.ArgumentException>(
+            () => RemoteUploadFormat.BuildFfmpegArguments(source, target, "flac"));
+    }
+
+    // ---- RemoteErrorGuidance edges ---------------------------------------------------------------
+
+    [Theory]
+    [InlineData(403, "billing")]
+    [InlineData(405, "audio uploads")]
+    [InlineData(501, "audio uploads")]
+    public void MoreStatusesCarryGuidance(int status, string expected)
+    {
+        Assert.Contains(expected, RemoteErrorGuidance.For((HttpStatusCode)status),
+            System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData(0, 25_000_000)]
+    [InlineData(76_800_000, 0)]
+    [InlineData(-5, -5)]
+    public void OversizedDescriptionIsEmptyWithoutUsableNumbers(long sourceBytes, long maxBytes)
+    {
+        // Never emit a nonsense sentence like "this 0-minute title is 0 KB".
+        Assert.Equal(string.Empty, RemoteErrorGuidance.DescribeOversizedUpload(sourceBytes, maxBytes));
+    }
+
+    [Fact]
+    public void SmallSizesRenderAsKilobytes()
+    {
+        Assert.Equal("1 KB", RemoteErrorGuidance.FormatBytes(1000));
+        Assert.Equal("0 KB", RemoteErrorGuidance.FormatBytes(0));
+        Assert.Equal("0 KB", RemoteErrorGuidance.FormatBytes(-10));   // clamped, never negative
+    }
+
+    // ---- Negotiation decision (pure) --------------------------------------------------------------
+
+    [Theory]
+    [InlineData(HttpStatusCode.BadRequest, true)]
+    [InlineData(HttpStatusCode.NotAcceptable, true)]
+    [InlineData(HttpStatusCode.UnsupportedMediaType, true)]
+    [InlineData(HttpStatusCode.UnprocessableEntity, true)]
+    [InlineData(HttpStatusCode.Unauthorized, false)]      // a bad key is not a format problem
+    [InlineData(HttpStatusCode.RequestEntityTooLarge, false)] // nor is an oversized upload
+    [InlineData(HttpStatusCode.InternalServerError, false)]
+    public void UnnegotiatedWorkerRetriesOnlyOnFormatCandidateStatuses(HttpStatusCode status, bool expected)
+    {
+        var exception = new System.Net.Http.HttpRequestException("boom", null, status);
+        Assert.Equal(expected,
+            RemoteWhisperProvider.ShouldNegotiateAlternateFormat(exception, formatNotYetNegotiated: true));
+    }
+
+    [Fact]
+    public void OnceNegotiatedOnlyAnExplicitFormatComplaintRetries()
+    {
+        // The bound that stops a wrong model name causing a repeated large re-upload on every job.
+        var opaque = new System.Net.Http.HttpRequestException(
+            "boom", null, HttpStatusCode.BadRequest);
+        Assert.False(
+            RemoteWhisperProvider.ShouldNegotiateAlternateFormat(opaque, formatNotYetNegotiated: false));
+
+        var explicitComplaint = new System.Net.Http.HttpRequestException(
+            "response_format srt is not supported", null, HttpStatusCode.BadRequest);
+        Assert.True(
+            RemoteWhisperProvider.ShouldNegotiateAlternateFormat(explicitComplaint, formatNotYetNegotiated: false));
+    }
+
+    // ---- Validation edges --------------------------------------------------------------------------
+
+    [Fact]
+    public void NullWorkerIsRejected()
+    {
+        var (ok, error) = WorkerConfigValidation.Validate(null!);
+        Assert.False(ok);
+        Assert.NotNull(error);
+    }
+
+    [Fact]
+    public void DuplicateEndpointCheckToleratesNull()
+    {
+        Assert.Empty(WorkerConfigValidation.CheckDuplicateEndpoints(null));
+    }
+
+    [Fact]
+    public void BlankUploadCodecIsAccepted()
+    {
+        // Blank means "unset" and is normalized to wav elsewhere; it must not fail validation.
+        var worker = new WhisperWorker { ApiUrl = "http://box:9010", UploadCodec = "" };
+        var (ok, _) = WorkerConfigValidation.Validate(worker);
+        Assert.True(ok);
+    }
+
+    // ---- 4.5.0.1 review findings -----------------------------------------------------------------
+
+    [Fact]
+    public void LegitimateUrlPathIsNotRedactedAway()
+    {
+        // '/' used to be in the high-entropy class, so any long URL path matched and the endpoint the admin
+        // needs to read was replaced by [redacted].
+        const string body = "upstream https://gw.example.com/v1/abcd1234abcd/audio/transcriptions failed";
+        var sanitized = UpstreamErrorSanitizer.Sanitize(body, apiKey: null);
+
+        Assert.Contains("gw.example.com", sanitized, System.StringComparison.Ordinal);
+        Assert.Contains("/audio/transcriptions", sanitized, System.StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HtmlWithoutContentTypeIsStillClassifiedNotQuoted()
+    {
+        // Proxies and load balancers answer failures with an HTML page and often no Content-Type at all,
+        // which slipped straight through the media-type allow-list.
+        var detail = RemoteWhisperProvider.DescribeUpstreamErrorBody(
+            "<html><body><script>alert(1)</script>502 Bad Gateway</body></html>", null, mediaType: null);
+
+        Assert.DoesNotContain("<script", detail, System.StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("502 Bad Gateway", detail, System.StringComparison.Ordinal);
+        Assert.Contains("web page", detail, System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void GuidanceComesBeforeTheUpstreamDetail()
+    {
+        // The queue's last-error is truncated in the UI. With the advice appended last, the admin saw the
+        // diagnosis and never the fix.
+        var message = RemoteWhisperProvider.BuildRemoteApiMessage(
+            HttpStatusCode.RequestEntityTooLarge, new string('d', 300));
+
+        var guidanceAt = message.IndexOf("Max upload size", System.StringComparison.OrdinalIgnoreCase);
+        var detailAt = message.IndexOf("endpoint said", System.StringComparison.OrdinalIgnoreCase);
+
+        Assert.True(guidanceAt > 0, "guidance must be present");
+        Assert.True(detailAt > guidanceAt, "guidance must precede the upstream detail");
+        Assert.True(guidanceAt < 160, "guidance must survive a 160-character truncation");
+    }
+}

--- a/WhisperSubs.Tests/RemoteUploadFormatTests.cs
+++ b/WhisperSubs.Tests/RemoteUploadFormatTests.cs
@@ -71,24 +71,4 @@ public class RemoteUploadFormatTests
         Assert.Throws<System.ArgumentException>(
             () => RemoteUploadFormat.BuildFfmpegArguments("/tmp/in.wav", "/tmp/out.wav", "wav"));
     }
-
-    [Fact]
-    public void EstimatesReflectMeasuredRatios()
-    {
-        // A 40-minute title: 2400s x 32000 = 76.8 MB of PCM.
-        const long fortyMinutes = 76_800_000;
-
-        Assert.Equal(fortyMinutes, RemoteUploadFormat.EstimateUploadBytes(fortyMinutes, "wav"));
-
-        var flac = RemoteUploadFormat.EstimateUploadBytes(fortyMinutes, "flac");
-        var opus = RemoteUploadFormat.EstimateUploadBytes(fortyMinutes, "opus");
-
-        // FLAC roughly halves it - still over a 25 MB cap, which is why it alone did not fix the report.
-        Assert.InRange(flac, 38_000_000, 42_000_000);
-        Assert.True(flac > 25L * 1024 * 1024);
-
-        // Opus fits comfortably under 25 MB - this is what makes the reported 40-minute title work.
-        Assert.InRange(opus, 5_000_000, 8_000_000);
-        Assert.True(opus < 25L * 1024 * 1024);
-    }
 }

--- a/WhisperSubs.Tests/UploadCodecFallbackTests.cs
+++ b/WhisperSubs.Tests/UploadCodecFallbackTests.cs
@@ -129,4 +129,55 @@ public class UploadCodecFallbackTests
             };
         }
     }
+
+    [Fact]
+    public async Task BlindFormatRetryIsSpentOnceAcrossJobsNotOncePerJob()
+    {
+        // The HIGH finding: the format cache fills only on SUCCESS, so a permanently-4xx worker (e.g. the
+        // bare OpenRouter model slug the README warns about) used to re-upload the full audio on EVERY job.
+        // Job 1 may spend the one blind retry (2 requests); job 2 must not (1 request).
+        var handler = new CountingBadRequestHandler();
+        using var client = new HttpClient(handler);
+        var provider = new RemoteWhisperProvider(
+            NullLogger<RemoteWhisperProvider>.Instance,
+            "https://worker.example",
+            "wrong-model",
+            httpClient: client);
+
+        var wav = Path.GetTempFileName();
+        try
+        {
+            await Assert.ThrowsAnyAsync<System.Exception>(
+                () => provider.TranscribeAsync(wav, "auto", CancellationToken.None));
+            var afterFirstJob = handler.Count;
+
+            await Assert.ThrowsAnyAsync<System.Exception>(
+                () => provider.TranscribeAsync(wav, "auto", CancellationToken.None));
+            var secondJobRequests = handler.Count - afterFirstJob;
+
+            Assert.Equal(2, afterFirstJob);        // one blind retry, spent
+            Assert.Equal(1, secondJobRequests);    // budget gone: no second upload
+        }
+        finally
+        {
+            File.Delete(wav);
+        }
+    }
+
+    /// <summary>Always answers 400 with a body that names no format, and counts requests.</summary>
+    private sealed class CountingBadRequestHandler : HttpMessageHandler
+    {
+        public int Count { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Count++;
+            await Task.Yield();
+            return new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent("""{"error":"model does not exist"}"""),
+            };
+        }
+    }
 }

--- a/WhisperSubs.Tests/UploadCodecFallbackTests.cs
+++ b/WhisperSubs.Tests/UploadCodecFallbackTests.cs
@@ -1,0 +1,132 @@
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using WhisperSubs.Controller.Workers;
+using WhisperSubs.Providers;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+/// <summary>
+/// Regression locks for the 4.5.0.1 fixes.
+/// <para>
+/// The headline bug: when a FLAC/Opus re-encode falls back to the source WAV (ffmpeg missing, encode
+/// failed, or the output was not smaller), the upload was still labelled <c>audio.flac</c>/<c>audio/flac</c>.
+/// Providers sniff the format from the extension, so that sends RIFF/WAVE bytes under an OGG name and gets
+/// rejected or mis-decoded — while the log says "uploading the original WAV instead", i.e. exactly the
+/// undiagnosable state issue #138 existed to remove.
+/// </para>
+/// </summary>
+public class UploadCodecFallbackTests
+{
+    [Fact]
+    public async Task WavWorkerReportsWavAsTheEffectiveCodec()
+    {
+        var wav = Path.GetTempFileName();
+        try
+        {
+            var (path, isTemporary, effectiveCodec) = await RemoteAudioEncoder.PrepareUploadAsync(
+                wav, "wav", NullLogger.Instance, CancellationToken.None);
+
+            Assert.Equal(wav, path);
+            Assert.False(isTemporary);
+            Assert.Equal(RemoteUploadFormat.Wav, effectiveCodec);
+        }
+        finally
+        {
+            File.Delete(wav);
+        }
+    }
+
+    [Fact]
+    public async Task FailedReencodeFallsBackToWavAndSaysSo()
+    {
+        // An empty file is not decodable audio, so ffmpeg exits non-zero (and if ffmpeg is absent entirely,
+        // the exception path is taken) — both are fallbacks, and BOTH must report wav so the multipart part
+        // is labelled to match the bytes actually being sent.
+        var notAudio = Path.GetTempFileName();
+        try
+        {
+            var (path, isTemporary, effectiveCodec) = await RemoteAudioEncoder.PrepareUploadAsync(
+                notAudio, "opus", NullLogger.Instance, CancellationToken.None);
+
+            Assert.Equal(notAudio, path);
+            Assert.False(isTemporary);
+            Assert.Equal(RemoteUploadFormat.Wav, effectiveCodec);
+
+            // The label follows the EFFECTIVE codec, so the bytes and the name agree.
+            Assert.Equal("audio.wav", RemoteUploadFormat.FileName(effectiveCodec));
+            Assert.Equal("audio/wav", RemoteUploadFormat.ContentType(effectiveCodec));
+        }
+        finally
+        {
+            File.Delete(notAudio);
+        }
+    }
+
+    [Fact]
+    public async Task FallbackUploadIsSentAsWavNotAsTheConfiguredCodec()
+    {
+        // End-to-end: a worker configured for Opus whose re-encode cannot run must still POST audio.wav.
+        var handler = new RecordingUploadHandler();
+        using var client = new HttpClient(handler);
+        var provider = new RemoteWhisperProvider(
+            NullLogger<RemoteWhisperProvider>.Instance,
+            "https://worker.example",
+            "whisper-large-v3",
+            httpClient: client,
+            uploadCodec: "opus");
+
+        // Not decodable audio => the encoder falls back to this file unchanged.
+        var notAudio = Path.GetTempFileName();
+        try
+        {
+            await Assert.ThrowsAnyAsync<System.Exception>(
+                () => provider.TranscribeAsync(notAudio, "auto", CancellationToken.None));
+        }
+        finally
+        {
+            File.Delete(notAudio);
+        }
+
+        Assert.NotEmpty(handler.FileNames);
+        Assert.All(handler.FileNames, name => Assert.Equal("audio.wav", name));
+        Assert.All(handler.ContentTypes, type => Assert.Equal("audio/wav", type));
+    }
+
+    /// <summary>Captures the multipart file part's filename and media type from each request.</summary>
+    private sealed class RecordingUploadHandler : HttpMessageHandler
+    {
+        public System.Collections.Generic.List<string> FileNames { get; } = [];
+
+        public System.Collections.Generic.List<string> ContentTypes { get; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.Content is MultipartFormDataContent multipart)
+            {
+                foreach (var part in multipart)
+                {
+                    var name = part.Headers.ContentDisposition?.Name?.Trim('"');
+                    if (!string.Equals(name, "file", System.StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    FileNames.Add(part.Headers.ContentDisposition?.FileName?.Trim('"') ?? "");
+                    ContentTypes.Add(part.Headers.ContentType?.MediaType ?? "");
+                }
+            }
+
+            await Task.Yield();
+            return new HttpResponseMessage(HttpStatusCode.InternalServerError)
+            {
+                Content = new StringContent("upstream is down"),
+            };
+        }
+    }
+}

--- a/WhisperSubs.Tests/UploadPreflightTests.cs
+++ b/WhisperSubs.Tests/UploadPreflightTests.cs
@@ -65,8 +65,9 @@ public class UploadPreflightTests
     [Fact]
     public void FormatBytesIsInvariantAndReadable()
     {
-        Assert.Equal("25.0 MB", RemoteErrorGuidance.FormatBytes(25L * 1024 * 1024));
-        Assert.Equal("1.0 GB", RemoteErrorGuidance.FormatBytes(1024L * 1024 * 1024));
+        // Decimal units, matching the README, the config page and how providers quote their caps.
+        Assert.Equal("25.0 MB", RemoteErrorGuidance.FormatBytes(25_000_000));
+        Assert.Equal("1.0 GB", RemoteErrorGuidance.FormatBytes(1_000_000_000));
     }
 
     [Theory]

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>4.5.0.0</Version>
+    <Version>4.5.0.1</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
Follow-up to 4.5.0.0. An architect verification pass and an adversarial review pass ran independently and **agreed on two HIGH findings**; both were real defects in what shipped.

## Real defects fixed
1. **Upload mislabelled on every re-encode fallback (HIGH).** `PostTranscriptionAsync` used the *configured* codec for the multipart filename/Content-Type, but `PrepareUploadAsync` returns the untouched source WAV whenever the re-encode cannot run. So WAV bytes went out as `audio.ogg` — the mislabelling the code's own comment warns against. `PrepareUploadAsync` now returns the **effective** codec.
2. **ffmpeg orphaned on cancellation (HIGH).** `WaitForExitAsync` abandons the wait without stopping the child, and `TryDelete` then unlinked a file ffmpeg still held. Now kills the process tree, matching every other spawn site in the repo.
3. **Blind format retry unbounded across jobs (HIGH).** The format cache fills only on success, so a permanently-4xx worker re-uploaded the full audio on *every* job. Now spent at most once per provider instance.
4. **Oversized error body threw instead of truncating.** That lost the status, the guidance *and* the negotiation (the thrown type isn't `HttpRequestException`). Errors truncate; transcripts still throw.
5. **Guidance was truncated out of the UI.** It was appended after up to 400 chars of detail, and the config page truncates `lastError` — so the admin saw the diagnosis and never the fix. Guidance now comes first.

## Also
Sanitizer: `/` removed from the high-entropy class (it redacted legitimate endpoint paths); HTML classified by content as well as header; flatten step moved inside the fail-closed guard; `SanitizeEndpoint` doc narrowed to its real scope. MB made decimal everywhere (the field used 1048576 while docs/providers quote decimal — a ~5% dead band where pre-flight passed and the provider still 413'd). Dead code removed; README blockquote fixed.

## Verification
1290 tests, 0 warnings. Each finding has a regression test, including an end-to-end one asserting a fallback upload is sent as `audio.wav`.