### PR TITLE
docs: worklog — 4.5.0.1 review findings and what they cost

### DIFF
--- a/docs/AUTOPILOT-WORKLOG.md
+++ b/docs/AUTOPILOT-WORKLOG.md
@@ -516,6 +516,24 @@ Synthesize → propose approach → implement (likely: FT integration with direc
 - Reporter follow-up: #138 comment [5104644837](https://github.com/GeiserX/whisper-subs/issues/138#issuecomment-5104644837) + closed; #139 comment [5104645330](https://github.com/GeiserX/whisper-subs/issues/139#issuecomment-5104645330) + closed. Both were thanked and asked to test the released version.
 - **Goal met and verified end to end.** Tally: 2 issues released/replied/closed; 0 open implementation/deployment items. Cancel the persistent loop.
 
+### Entry — #138 reopened: the 413 and OpenRouter (2026-07-29, v4.5.0.0)
+
+**Why reopened:** @ARLBR10 tested 4.4.0.0. Groq worked, but a 40-minute title returned HTTP 413, and OpenRouter failed with no visible reason.
+
+**Research (8-agent panel).** Root cause was payload size, not response format: the plugin uploads 16 kHz mono PCM WAV at 1.92 MB/min, so 40 min = 76.8 MB and 2 h = 219.7 MB against 25 MB hosted caps. Compounded by a diagnosability failure — `RemoteApiException` captured the provider's explanation and never surfaced it, so the admin saw a bare `HTTP 413`. The reporter's "I can't enable debug logging" was a misdiagnosis: the error was already at Error level, just empty.
+
+**Two findings that changed the design:**
+- **Measured on watchtower's own ffmpeg:** Groq's *published* FLAC command (`-acodec flac -ac 1 -ar 16000`) yields a file LARGER than PCM (19,713,918 vs 19,200,102 bytes) because ffmpeg defaults FLAC to 24-bit. `-sample_fmt s16` is mandatory. Corrected FLAC = 52.6% of PCM; Opus 24k = 9.1% (2 h film → ~20 MB, fits every hosted cap). Timing drift: FLAC 0 ms, Opus +6.5 ms fixed/non-cumulative, MP3 +84 ms (avoided).
+- **An adversarial critic rejected the first plan.** Compressing would have broken hard: duration/deadline were derived from the UPLOADED byte count (`RemoteWhisperProvider.cs:152`), which is also the segment-timestamp sanity bound — compression would have collapsed the deadline and thrown on every valid late segment. And the repo's OWN worker image ships `INSTALL_FFMPEG=false`/`CONVERT=false` (whisper.cpp decodes WAV only), so a compressed default would break all three self-hosted workers.
+
+**Shipped (PR #143, squash 7623ea5, v4.5.0.0):** source-bytes decoupling (prerequisite); `UpstreamErrorSanitizer` + `RemoteErrorGuidance` surfacing the provider's error safely (redact-before-truncate, \p{C} strip, fail-closed regex budget, 4xx/5xx + json/text-plain only, html classified, 2xx never echoed, raw body retained for negotiation); per-worker `MaxUploadBytes` (default 0 = unlimited) + pre-flight; bounded format-negotiation retry on a bare 4xx (fixes OpenRouter's srt rejection); per-worker `UploadCodec` (default wav); endpoint sanitizing (a key pasted in the URL query used to reach jellyfin.log and the config page); README size table + per-provider base URLs/model limits.
+
+**Cut deliberately:** audio chunking (Opus removes the need; 4 unresolved blockers) and any speculative OpenRouter URL change (the double-`/v1` theory is self-defeating — Groq's own base URL also ends in `/v1` and Groq worked).
+
+**Evidence:** 1252 tests, 0 warnings, on the merged main. GitGuardian green (a JWT-shaped *test fixture* tripped it; the unmerged branch was squashed to purge it). CodeRabbit clean. Back-compat proven by test: a pre-4.5 config XML deserializes to unlimited + wav, so self-hosted workers are byte-identical.
+
+**Reporter:** #138 comment [5116102015](https://github.com/GeiserX/whisper-subs/issues/138#issuecomment-5116102015) + closed. Told plainly that FLAC alone would NOT fit his 40-minute file (contradicting Groq's own recommendation) and that Opus is the answer; and that OpenRouter has no translations endpoint and OpenAI timestamps are whisper-1-only. Asked for URL/model/status + a short-clip retest, since the OpenRouter cause is unproven.
+
 ### Entry — #138 follow-up: 4.5.0.1 (2026-07-29)
 
 **Why a follow-up release.** Two independent review passes ran after 4.5.0.0 shipped (an architect verification against the acceptance criteria, and an adversarial code review). They **agreed on the same HIGH findings**, all real:

--- a/docs/AUTOPILOT-WORKLOG.md
+++ b/docs/AUTOPILOT-WORKLOG.md
@@ -515,3 +515,19 @@ Synthesize → propose approach → implement (likely: FT integration with direc
 - Live worker proof: geiserback UHD 770, Mac mini M4 Metal, and local watchtower workers are all enabled at `large-v3`, each has one real job in flight, the queue is processing, and failed count is 0. Jellyfin is healthy and recent startup has 0 WhisperSubs errors.
 - Reporter follow-up: #138 comment [5104644837](https://github.com/GeiserX/whisper-subs/issues/138#issuecomment-5104644837) + closed; #139 comment [5104645330](https://github.com/GeiserX/whisper-subs/issues/139#issuecomment-5104645330) + closed. Both were thanked and asked to test the released version.
 - **Goal met and verified end to end.** Tally: 2 issues released/replied/closed; 0 open implementation/deployment items. Cancel the persistent loop.
+
+### Entry — #138 follow-up: 4.5.0.1 (2026-07-29)
+
+**Why a follow-up release.** Two independent review passes ran after 4.5.0.0 shipped (an architect verification against the acceptance criteria, and an adversarial code review). They **agreed on the same HIGH findings**, all real:
+
+1. **Upload mislabelled on every re-encode fallback.** `PostTranscriptionAsync` used the CONFIGURED codec for the multipart filename/Content-Type, but `PrepareUploadAsync` returns the untouched source WAV whenever the re-encode cannot run (no ffmpeg, non-zero exit, output not smaller, exception). So WAV bytes went out as `audio.ogg` — providers sniff by extension — while the log said "uploading the original WAV instead". Exactly the invisible mismatch #138 was filed about. `PrepareUploadAsync` now returns the EFFECTIVE codec.
+2. **ffmpeg orphaned on cancellation.** `WaitForExitAsync` abandons the wait without stopping the child, and `TryDelete` then unlinked a file ffmpeg still held (on Unraid `/tmp` that is RAM). It was the only spawn site in the repo missing the kill every other one has.
+3. **The blind format retry was bounded only WITHIN a job.** The format cache fills only on success, so a permanently-4xx worker (the bare OpenRouter slug the README warns about) re-uploaded the full audio on EVERY job, times `JobMaxRetries` — ~614 MB per 40-minute title. Now spent once per provider instance, proven by a two-job test asserting 2 requests then 1.
+
+Also fixed: an oversized error body **threw** instead of truncating, losing the status, the guidance AND the negotiation (the thrown type is not `HttpRequestException`); guidance was appended after up to 400 chars of detail so the UI's truncation cut it off; the sanitizer's `/` in its high-entropy class redacted legitimate endpoint paths; HTML with no `Content-Type` slipped the allow-list; MB was MiB in the config field while docs/providers quote decimal (~5% dead band where pre-flight passed and the provider still 413'd).
+
+**Coverage caught two tests that were not testing what they claimed.** The truncation tests used long single-character runs, which the redaction rule collapsed to `[redacted]` before truncation was ever reached; and the bounded-read tests used `StringContent`, which always declares a length, so the streaming partial-write and undeclared-length paths were never exercised. Both rewritten; patch coverage 100%.
+
+**Process note worth keeping:** 4.5.0.0 was merged before the review agents finished, and three real defects shipped as a result. 4.5.0.1 waited for all five checks (build, GitGuardian, CodeRabbit, codecov/patch, codecov/project). Wait for the reviewers.
+
+**Evidence:** merged `63304aa`, released [v4.5.0.1](https://github.com/GeiserX/whisper-subs/releases/tag/v4.5.0.1), manifest lists it as latest. 1298 tests, 0 warnings. Reporter told to take 4.5.0.1 over 4.5.0.0: comment [5116590834](https://github.com/GeiserX/whisper-subs/issues/138#issuecomment-5116590834).


### PR DESCRIPTION
Continuity entry for the 4.5.0.1 follow-up: the three HIGH defects both review passes independently agreed on, the coverage work that exposed two tests which were not testing what they claimed, and the process note (4.5.0.0 was merged before the reviewers finished; three real defects shipped as a result). Docs-only.