### PR TITLE
fix(#138): upload codec was discarded, OpenRouter 400 on timestamp_granularities, wrong Groq cap

### DIFF
--- a/Api/SubtitleController.cs
+++ b/Api/SubtitleController.cs
@@ -509,7 +509,9 @@ namespace WhisperSubs.Api
                 content.Add(new System.Net.Http.StringContent(responseFormat), "response_format");
                 if (string.Equals(responseFormat, "verbose_json", StringComparison.Ordinal))
                 {
-                    content.Add(new System.Net.Http.StringContent("segment"), "timestamp_granularities[]");
+                    // Omitted on purpose — see RemoteWhisperProvider: redundant (segment is the default)
+                    // and rejected with 400 by some OpenRouter-routed providers. The probe must send the
+                    // same shape as a real job, or it would go green against an endpoint that rejects jobs.
                 }
 
                 using var probe = new System.Net.Http.HttpRequestMessage(System.Net.Http.HttpMethod.Post, url)

--- a/Controller/Workers/RemoteUploadFormat.cs
+++ b/Controller/Workers/RemoteUploadFormat.cs
@@ -8,7 +8,7 @@ namespace WhisperSubs.Controller.Workers
     /// Pure policy for the audio format a REMOTE worker is uploaded in (issue #138).
     /// <para>
     /// The plugin extracts 16 kHz mono s16le PCM WAV — 32,000 bytes per audio-second, i.e. 1.92 MB per
-    /// minute. Hosted providers cap uploads (OpenAI 25 MB, Groq 25 MB free / 100 MB dev), so a 40-minute
+    /// minute. Hosted providers cap uploads (OpenAI 25 MB; Groq 25 MB for a direct upload on BOTH tiers), so a 40-minute
     /// title at 76.8 MB is refused with HTTP 413 and a 2-hour film has no chance. Re-encoding for the
     /// upload fixes that without touching the extracted WAV that the LOCAL whisper-cli path uses.
     /// </para>

--- a/Controller/Workers/UploadPreflight.cs
+++ b/Controller/Workers/UploadPreflight.cs
@@ -18,7 +18,8 @@ namespace WhisperSubs.Controller.Workers
         /// A cap of 0 (the default) means "unlimited" and ALWAYS allows the upload — this is what keeps the
         /// change byte-identical for every existing install, including self-hosted workers that have no
         /// limit at all. There is deliberately no non-zero default: real caps span 440x (Groq free 25 MB,
-        /// Groq dev 100 MB, this project's own worker 8 GiB), so any guess would block working setups.
+        /// Groq 25 MB on both tiers for direct upload, this project's own worker 8 GiB), so any guess would
+        /// block working setups.
         /// </para>
         /// </summary>
         public static bool IsAllowed(long uploadBytes, long maxUploadBytes)

--- a/Controller/Workers/WorkerEndpointDedup.cs
+++ b/Controller/Workers/WorkerEndpointDedup.cs
@@ -116,6 +116,18 @@ namespace WhisperSubs.Controller.Workers
 
         private static int Clamp(int concurrency) => concurrency < 1 ? 1 : concurrency;
 
+        /// <summary>
+        /// Copies a configured row. <b>Every</b> property of <see cref="WhisperWorker"/> must be carried
+        /// across: <c>WorkerRegistry.BuildWorkers</c> reads each worker's settings off this copy, so anything
+        /// omitted here is silently reset to its default for every worker on the system — the admin's
+        /// configuration is discarded with no error anywhere.
+        /// <para>
+        /// That is not theoretical: <c>MaxUploadBytes</c> and <c>UploadCodec</c> were added in 4.5.0.0 and
+        /// missed here, so a worker set to Opus silently uploaded raw WAV (issue #138). If you add a property
+        /// to <see cref="WhisperWorker"/>, add it here too — <c>WorkerCloneCompletenessTests</c> fails by
+        /// reflection if you forget.
+        /// </para>
+        /// </summary>
         private static WhisperWorker Clone(WhisperWorker w) => new WhisperWorker
         {
             Id = w.Id,
@@ -127,6 +139,8 @@ namespace WhisperSubs.Controller.Workers
             MaxConcurrency = w.MaxConcurrency,
             CostWeight = w.CostWeight,
             CanTranslate = w.CanTranslate,
+            MaxUploadBytes = w.MaxUploadBytes,
+            UploadCodec = w.UploadCodec,
         };
     }
 }

--- a/Providers/RemoteWhisperProvider.cs
+++ b/Providers/RemoteWhisperProvider.cs
@@ -338,10 +338,12 @@ namespace WhisperSubs.Providers
             content.Add(fileContent, "file", RemoteUploadFormat.FileName(uploadCodec));
             content.Add(new StringContent(_model), "model");
             content.Add(new StringContent(responseFormat), "response_format");
-            if (string.Equals(responseFormat, "verbose_json", StringComparison.Ordinal))
-            {
-                content.Add(new StringContent("segment"), "timestamp_granularities[]");
-            }
+            // NOTE: we deliberately do NOT send timestamp_granularities[]. verbose_json already returns
+            // segment timestamps by default (segment IS the default granularity), and we only ever read
+            // "segments" from the response — never "words". Sending it is therefore redundant for us, and
+            // actively harmful: OpenRouter accepts the field only when the requested model happens to route
+            // to an OpenAI-compatible backend and returns HTTP 400 otherwise, which made every OpenRouter
+            // transcription fail regardless of format negotiation (issue #138).
 
             if (includeLanguage
                 && !string.IsNullOrWhiteSpace(language) &&

--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ WhisperSubs extracts 16 kHz mono PCM WAV, which is **1.92 MB per minute** of aud
 
 So a 25 MB cap (OpenAI, and Groq's free tier) accepts only about **13 minutes** of the default WAV upload, and rejects anything longer with `HTTP 413`. Two per-worker settings fix that:
 
-- **Max upload size (MB)** -- what this endpoint accepts. `0` (default) means unlimited, which is right for every self-hosted worker. Set it (25 for OpenAI/Groq free, 100 for Groq dev tier) and an oversized title fails immediately with a message telling you the size, the cap and roughly how many minutes fit -- instead of uploading the whole file to earn a bare 413.
+- **Max upload size (MB)** -- what this endpoint accepts. `0` (default) means unlimited, which is right for every self-hosted worker. Set it (25 for OpenAI and for Groq on **both** tiers -- Groq's 100 MB figure applies only to their `url` parameter, which WhisperSubs does not use) and an oversized title fails immediately with a message telling you the size, the cap and roughly how many minutes fit -- instead of uploading the whole file to earn a bare 413.
 - **Upload format** -- `WAV` (default), `FLAC` (lossless, about half) or `Opus 24k` (about a tenth; a 2-hour film lands near 20 MB). **Keep WAV for self-hosted workers**: whisper.cpp's `whisper-server` decodes WAV only, and the [`worker/`](worker/README.md) image ships without ffmpeg. Only choose a compressed format on a hosted endpoint documented to accept it (Groq accepts FLAC and OGG and explicitly recommends FLAC for size reduction; OpenAI's documented list is mp3/mp4/mpeg/mpga/m4a/wav/webm).
 
 **Base URL form** -- enter only the base; WhisperSubs appends `/v1/audio/transcriptions` itself, so the URL must **not** already end in `/v1`:

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -1808,7 +1808,7 @@
                     row.appendChild(WhisperSubsConfig._workerField(
                         'Max upload size (MB)', 'number', 'wkMaxUpload', { min: '0', step: '1', placeholder: '0 = unlimited' },
                         (w.MaxUploadBytes != null && w.MaxUploadBytes > 0) ? Math.round(w.MaxUploadBytes / 1000000) : '',
-                        'Largest file this endpoint accepts. 0 (default) = unlimited. OpenAI and Groq free tier are 25; Groq dev tier 100. Oversized titles then fail fast with a clear message instead of a bare HTTP 413.'));
+                        'Largest file this endpoint accepts. 0 (default) = unlimited. OpenAI and Groq are 25 on both tiers (Groq's 100 applies only to URL-fetched audio, which is not used here). Oversized titles then fail fast with a clear message instead of a bare HTTP 413.'));
                     row.appendChild(WhisperSubsConfig._workerSelect(
                         'Upload format', 'wkUploadCodec',
                         [['wav', 'WAV (default, uncompressed)'], ['flac', 'FLAC (lossless, ~half)'], ['opus', 'Opus 24k (~a tenth)']],

--- a/WhisperSubs.Tests/RemoteTranscriptionResponseTests.cs
+++ b/WhisperSubs.Tests/RemoteTranscriptionResponseTests.cs
@@ -96,7 +96,10 @@ public class RemoteTranscriptionResponseTests
         Assert.Equal(3, handler.Requests.Count);
         Assert.Equal("srt", handler.Requests[0].Fields["response_format"]);
         Assert.Equal("verbose_json", handler.Requests[1].Fields["response_format"]);
-        Assert.Equal("segment", handler.Requests[1].Fields["timestamp_granularities[]"]);
+        // timestamp_granularities[] is deliberately NOT sent: segment is already the default for
+        // verbose_json, and OpenRouter 400s on it unless the model routes to an OpenAI-compatible
+        // backend (issue #138).
+        Assert.DoesNotContain("timestamp_granularities[]", handler.Requests[1].Fields.Keys);
         Assert.Equal("verbose_json", handler.Requests[2].Fields["response_format"]);
         Assert.Equal("es", handler.Requests[0].Fields["language"]);
         Assert.Equal("whisper-large-v3", handler.Requests[0].Fields["model"]);
@@ -651,5 +654,46 @@ public class RemoteTranscriptionResponseTests
             alignEnabled: true, requiresOptIn: provider.RequiresSpeechAlignmentOptIn, alignWithVad: false));
         Assert.True(Controller.SubtitleManager.ShouldAlignToSpeech(
             alignEnabled: true, requiresOptIn: provider.RequiresSpeechAlignmentOptIn, alignWithVad: true));
+    }
+
+    [Fact]
+    public async Task RequestNeverSendsTimestampGranularities()
+    {
+        // OpenRouter accepts timestamp_granularities[] only when the requested model happens to route to an
+        // OpenAI-compatible backend, and returns 400 otherwise — which made every OpenRouter transcription
+        // fail (issue #138). The field is redundant for us anyway: verbose_json returns segment timestamps
+        // by default and we only ever read "segments", never "words".
+        var handler = new RecordingHandler(
+            new HttpResponseMessage(HttpStatusCode.BadRequest)
+            {
+                Content = new StringContent("""{"error":"srt is not supported"}""")
+            },
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """{"segments":[{"start":0.0,"end":1.0,"text":"hola"}]}""")
+            });
+        using var client = new HttpClient(handler);
+        var provider = new RemoteWhisperProvider(
+            NullLogger<RemoteWhisperProvider>.Instance,
+            "https://worker.example",
+            "openai/whisper-large-v3",
+            httpClient: client);
+
+        var wav = CreateOneSecondWav();
+        try
+        {
+            await provider.TranscribeAsync(wav, "auto", CancellationToken.None);
+        }
+        finally
+        {
+            File.Delete(wav);
+        }
+
+        // Both the initial srt attempt and the negotiated verbose_json retry must be free of it.
+        Assert.NotEmpty(handler.Requests);
+        Assert.All(handler.Requests, r =>
+            Assert.DoesNotContain("timestamp_granularities[]", r.Fields.Keys));
+        Assert.Contains("verbose_json", handler.Requests.Select(r => r.Fields["response_format"]));
     }
 }

--- a/WhisperSubs.Tests/WorkerCloneCompletenessTests.cs
+++ b/WhisperSubs.Tests/WorkerCloneCompletenessTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using WhisperSubs.Configuration;
+using WhisperSubs.Controller.Workers;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+/// <summary>
+/// Structural guard for <see cref="WorkerEndpointDedup.CollapseByEndpoint"/>, which returns COPIES of the
+/// configured worker rows. Every enabled row is passed through it by
+/// <c>WorkerRegistry.BuildWorkers</c>, which then reads the worker's settings off that copy — so any
+/// property the copy forgets is silently reset to its default for every worker on the system.
+/// <para>
+/// This is not hypothetical. <c>MaxUploadBytes</c> and <c>UploadCodec</c> were added in 4.5.0.0 but not to
+/// the copy (written in 4.3.1), so a worker configured for Opus silently uploaded raw WAV and its upload
+/// cap silently became "unlimited" — reported on issue #138 as "it's trying to send a WAV file even when
+/// OPUS is selected", after two releases that were supposed to fix exactly that.
+/// </para>
+/// <para>
+/// The reflection test below is the real fix: it fails the moment ANY future property is added to
+/// <see cref="WhisperWorker"/> without being carried through the copy, so this bug class cannot recur.
+/// </para>
+/// </summary>
+public class WorkerCloneCompletenessTests
+{
+    /// <summary>A value that differs from the property's default, so a dropped copy is detectable.</summary>
+    private static object DistinctValue(PropertyInfo p) => p.PropertyType switch
+    {
+        var t when t == typeof(string) => "distinct-" + p.Name,
+        var t when t == typeof(bool) => false,      // every bool on this type defaults to true
+        var t when t == typeof(int) => 7,
+        var t when t == typeof(long) => 123_456_789L,
+        var t when t == typeof(double) => 3.5,
+        _ => throw new NotSupportedException(
+            $"WhisperWorker.{p.Name} has unhandled type {p.PropertyType}; extend this test."),
+    };
+
+    [Fact]
+    public void CollapsePreservesEveryConfiguredProperty()
+    {
+        var properties = typeof(WhisperWorker)
+            .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+            .Where(p => p.CanRead && p.CanWrite)
+            .ToArray();
+
+        Assert.NotEmpty(properties);
+
+        // A single row with EVERY property set to a non-default value.
+        var source = new WhisperWorker();
+        foreach (var p in properties)
+        {
+            p.SetValue(source, DistinctValue(p));
+        }
+
+        // Enabled and a valid URL, so it survives the enabled/blank filtering the registry applies.
+        source.Enabled = true;
+        source.ApiUrl = "http://worker.example:9010";
+        source.UploadCodec = RemoteUploadFormat.Opus;   // the property that actually regressed
+        source.MaxConcurrency = 1;
+
+        var collapsed = WorkerEndpointDedup.CollapseByEndpoint([source]);
+        var result = Assert.Single(collapsed);
+
+        var dropped = properties
+            .Where(p => !Equals(p.GetValue(result), p.GetValue(source)))
+            .Select(p => $"{p.Name}: expected {p.GetValue(source)}, got {p.GetValue(result)}")
+            .ToArray();
+
+        Assert.True(
+            dropped.Length == 0,
+            "CollapseByEndpoint dropped configured settings, which silently resets them for every worker:\n  "
+            + string.Join("\n  ", dropped));
+    }
+
+    [Fact]
+    public void ConfiguredOpusSurvivesTheCollapse()
+    {
+        // The exact user-visible regression from issue #138, pinned explicitly so the intent is readable
+        // even if the reflection test above is ever weakened.
+        var worker = new WhisperWorker
+        {
+            Enabled = true,
+            ApiUrl = "https://api.groq.com/openai",
+            UploadCodec = RemoteUploadFormat.Opus,
+            MaxUploadBytes = 25_000_000,
+        };
+
+        var result = Assert.Single(WorkerEndpointDedup.CollapseByEndpoint([worker]));
+
+        Assert.Equal(RemoteUploadFormat.Opus, result.UploadCodec);
+        Assert.True(RemoteUploadFormat.RequiresReencode(result.UploadCodec),
+            "a worker configured for Opus must still require a re-encode after collapsing");
+        Assert.Equal(25_000_000, result.MaxUploadBytes);
+    }
+
+    [Fact]
+    public void DuplicateEndpointsStillCollapseAndKeepTheFirstRowsUploadSettings()
+    {
+        var first = new WhisperWorker
+        {
+            Id = "a",
+            Enabled = true,
+            ApiUrl = "https://api.groq.com/openai",
+            UploadCodec = RemoteUploadFormat.Opus,
+            MaxUploadBytes = 25_000_000,
+            MaxConcurrency = 2,
+        };
+        var duplicate = new WhisperWorker
+        {
+            Id = "b",
+            Enabled = true,
+            ApiUrl = "https://api.groq.com/openai/",
+            UploadCodec = RemoteUploadFormat.Wav,
+            MaxConcurrency = 1,
+        };
+
+        var result = Assert.Single(WorkerEndpointDedup.CollapseByEndpoint([first, duplicate]));
+
+        Assert.Equal("a", result.Id);
+        Assert.Equal(RemoteUploadFormat.Opus, result.UploadCodec);   // first row's settings win
+        Assert.Equal(25_000_000, result.MaxUploadBytes);
+        Assert.Equal(1, result.MaxConcurrency);                      // but concurrency still takes the min
+    }
+}

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>4.5.0.1</Version>
+    <Version>4.5.0.2</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
@ARLBR10 reported that 4.5.0.1 **"is trying to send a WAV file even when OPUS is selected"**, with Groq now returning **502** and OpenRouter still **400**. He was right on all three counts, and there were three distinct causes — two of them ours, one a documentation error of ours.

## 1. The upload codec and size cap were silently discarded (root cause)

`WorkerEndpointDedup.Clone` was written in 4.3.1 and never updated when `MaxUploadBytes` and `UploadCodec` were added in 4.5.0.0. It copies **9 of the type's 11 properties**.

`WorkerRegistry.BuildWorkers` passes *every* enabled row through `CollapseByEndpoint` (`WorkerRegistry.cs:38`) and then reads each worker's settings off the returned copy (`:49-50`). So for every configured worker:

- `UploadCodec` `"opus"` → silently `"wav"`
- `MaxUploadBytes` → silently `0` (unlimited)

That is why **two releases aimed at the 413 changed nothing for him**: the audio still went out as raw WAV (1.92 MB/min → a 40-minute title is 76.8 MB), and the pre-flight that would have explained it never fired either, because its cap had been reset in the same place. It also explains the **Groq 502** — an oversized body is rejected at the edge before Groq can return a structured error.

**The real fix is `WorkerCloneCompletenessTests`**, which sets every public property on a row to a non-default value by reflection and fails if the collapse drops any of them. Adding a future property without carrying it through can no longer silently discard an admin's configuration. All three new tests **fail against the previous code**.

## 2. `timestamp_granularities[]` made OpenRouter 400 unconditionally

We sent `timestamp_granularities[]=segment` with `verbose_json`. Per OpenRouter's docs, that field is accepted **only when the requested model routes to an OpenAI-compatible backend**, and returns 400 otherwise — so the endpoint failed regardless of the format negotiation.

It was pure redundancy for us: `segment` **is** the default granularity for `verbose_json`, and we only ever read `segments` from the response, never `words`. Removed from both the real request and the Test Connection probe (the probe must send the same shape, or it goes green against an endpoint that rejects real jobs).

## 3. We documented Groq's cap wrongly

25 MB applies to a **direct multipart upload on both tiers**. The 100 MB figure is only for their `url` parameter, which this plugin does not use. We told admins to set `100` for the dev tier — which would have let a ~77 MB upload pass pre-flight and fail upstream anyway. Corrected in the README, the config-page hint, and two code comments.

## Verification

1302 tests, 0 warnings.
