### PR TITLE
fix(#149): config page dead on 4.5.0.2 — unescaped apostrophe broke the whole inline script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,23 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # The admin UI ships as an embedded resource, so nothing in the .NET build ever parses it. One stray
+  # character makes the browser skip the WHOLE inline <script> — every panel stays on its static markup
+  # and every button loses its listener, with nothing logged server-side (issue #149, shipped 4.5.0.2).
+  web-js:
+    name: Browser JS parses
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+
+      - name: Parse-check shipped browser JavaScript
+        run: node scripts/check-web-js.mjs
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -322,20 +322,50 @@ namespace WhisperSubs
             if (!writable)
             {
                 var target = string.IsNullOrEmpty(indexHtmlPath) ? "your index.html" : indexHtmlPath;
+
+                // The remediation has to match the admin's actual OS. A Windows admin handed
+                // "sudo chown root:jellyfin" has nothing to run (issue #149): on a bare-metal Windows
+                // install the web root normally sits under C:\Program Files, which the Jellyfin service
+                // account cannot write — so this branch is the COMMON case there, not an edge case.
+                var permissionFix = IsWindowsStylePath(indexHtmlPath)
+                    ? "Alternatively, grant the Jellyfin service account write access to that file and click " +
+                      "Re-inject (or restart Jellyfin). On Windows the web root usually lives under " +
+                      "C:\\Program Files, which the service account cannot write by default. From an ELEVATED " +
+                      "PowerShell: icacls \"" + target + "\" /grant \"NETWORK SERVICE:(M)\" — substitute the " +
+                      "account the service actually runs as (Services → Jellyfin Server → Properties → Log On)."
+                    : "Alternatively, make it writable by the Jellyfin service user, then click " +
+                      "Re-inject (or restart Jellyfin). On a Linux package install: sudo chown root:jellyfin \"" + target +
+                      "\" && sudo chmod 664 \"" + target + "\". On Docker the user/group differs (e.g. linuxserver.io " +
+                      "uses your PUID/PGID) and a read-only web mount must be made writable in your compose file.";
+
                 return ("error",
                     "index.html is present but NOT writable, so the client script can't be injected directly (common with " +
-                    "read-only web roots in Docker). Recommended fix: install the File Transformation plugin " +
+                    "read-only web roots in Docker, and with Windows installs under C:\\Program Files). Recommended fix: " +
+                    "install the File Transformation plugin " +
                     "(Dashboard → Plugins → Repositories → add https://www.iamparadox.dev/jellyfin/plugins/manifest.json, " +
                     "install \"File Transformation\", restart Jellyfin) — WhisperSubs then injects at serve time with no " +
-                    "permission changes. Alternatively, make it writable by the Jellyfin service user, then click " +
-                    "Re-inject (or restart Jellyfin). On a Linux package install: sudo chown root:jellyfin \"" + target +
-                    "\" && sudo chmod 664 \"" + target + "\". On Docker the user/group differs (e.g. linuxserver.io " +
-                    "uses your PUID/PGID) and a read-only web mount must be made writable in your compose file.");
+                    "permission changes. " + permissionFix);
             }
 
             return ("warning",
                 "The client script is not currently injected — a Jellyfin update may have replaced index.html. " +
                 "Click Re-inject below, then hard-refresh your browser.");
+        }
+
+        /// <summary>
+        /// Pure: is this path Windows-shaped — a drive-letter root ("C:\...") or a UNC share ("\\host\share")?
+        /// Decided from the STRING, not the running OS, so <see cref="DescribeInjection"/> stays pure and the
+        /// guidance is right even for a path that came from somewhere else. A POSIX path never matches:
+        /// a drive letter needs exactly one letter before the colon, and "/" is not a separator here.
+        /// </summary>
+        internal static bool IsWindowsStylePath(string? path)
+        {
+            if (string.IsNullOrEmpty(path)) return false;
+            if (path.StartsWith("\\\\", StringComparison.Ordinal)) return true;   // UNC: \\server\share
+            return path.Length >= 3
+                   && char.IsLetter(path[0])
+                   && path[1] == ':'
+                   && (path[2] == '\\' || path[2] == '/');                        // C:\... or C:/...
         }
 
         /// <summary>Best-effort writability probe: open the file for write without modifying it.</summary>

--- a/Web/configPage.html
+++ b/Web/configPage.html
@@ -817,6 +817,15 @@
                         })
                         .catch(function (err) {
                             console.error('WhisperSubs: engine status check failed', err);
+                            var text = document.querySelector('#engineBinaryText');
+                            var hint = document.querySelector('#engineGpuHint');
+                            if (text) { text.textContent = 'Status unavailable'; }
+                            if (hint) {
+                                hint.textContent = 'Could not read the engine status from the server (' +
+                                    WhisperSubsConfig.describeLoadError(err) + '). The panels below stay blank ' +
+                                    'until this succeeds — check the browser console and reload.';
+                                hint.style.color = '#CC3333';
+                            }
                         });
                 },
 
@@ -826,7 +835,9 @@
                     if (status.BinaryFound && !status.BinaryFoundInPath) {
                         icon.innerHTML = '&#9745;';
                         icon.style.color = '#52B54B';
-                        text.textContent = status.BinaryPath ? status.BinaryPath.split('/').pop() : 'Installed';
+                        // Split on BOTH separators — a Windows path (D:\Whisper\whisper-cli.exe) has no
+                        // '/' at all, so splitting on '/' alone rendered the entire path here. (Issue #149.)
+                        text.textContent = status.BinaryPath ? status.BinaryPath.split(/[\\/]/).pop() : 'Installed';
                     } else if (status.BinaryFoundInPath) {
                         icon.innerHTML = '&#9745;';
                         icon.style.color = '#CC7B19';
@@ -842,7 +853,16 @@
                 loadInjectionStatus: function () {
                     WhisperSubsConfig.ajaxGet(ApiClient.getUrl('Plugins/WhisperSubs/Setup/InjectionStatus'))
                         .then(function (s) { WhisperSubsConfig.renderInjectionStatus(s); })
-                        .catch(function (err) { console.error('WhisperSubs: injection status check failed', err); });
+                        .catch(function (err) {
+                            console.error('WhisperSubs: injection status check failed', err);
+                            var icon = document.querySelector('#injectionStatusIcon');
+                            var text = document.querySelector('#injectionStatusText');
+                            if (icon) { icon.innerHTML = '&#10007;'; icon.style.color = '#CC3333'; }
+                            if (text) {
+                                text.textContent = 'Could not read the injection status from the server (' +
+                                    WhisperSubsConfig.describeLoadError(err) + ').';
+                            }
+                        });
                 },
 
                 renderInjectionStatus: function (s) {
@@ -929,8 +949,19 @@
                                 btn.disabled = true;
                                 btn.title = 'Prebuilt binaries are only available for Linux. Install whisper-cli manually.';
                                 var hint = document.querySelector('#engineGpuHint');
-                                hint.textContent = 'Auto-download is only available for Linux. Install whisper-cli manually and set the path in Advanced settings.';
-                                hint.style.color = '#CC7B19';
+                                // A manually-installed binary is a fully supported setup. Saying only
+                                // "no prebuilt binaries" made a WORKING Windows install look broken —
+                                // the reporter on issue #149 read the disabled control as the bug.
+                                var st = WhisperSubsConfig._engineStatus;
+                                if (st && (st.BinaryFound || st.BinaryFoundInPath)) {
+                                    hint.textContent = 'whisper-cli is installed and will be used. Auto-download is ' +
+                                        'only offered on Linux, so these controls stay disabled on ' +
+                                        (st.Platform || 'this platform') + ' — that is expected, not an error.';
+                                    hint.style.color = '';
+                                } else {
+                                    hint.textContent = 'Auto-download is only available for Linux. Install whisper-cli manually and set the path in Advanced settings.';
+                                    hint.style.color = '#CC7B19';
+                                }
                                 return;
                             }
                             select.disabled = false;
@@ -1125,6 +1156,13 @@
                         })
                         .catch(function (err) {
                             console.error('WhisperSubs: error loading downloaded models', err);
+                            var hint = document.querySelector('#engineModelHint');
+                            if (hint) {
+                                hint.textContent = 'Could not list installed models (' +
+                                    WhisperSubsConfig.describeLoadError(err) + '). If a model is set in ' +
+                                    'Advanced settings it is still used for transcription — only this list failed to load.';
+                                hint.style.color = '#CC3333';
+                            }
                         });
                 },
 
@@ -1396,6 +1434,15 @@
                             if (!resp.ok) throw new Error('HTTP ' + resp.status);
                             return resp.json();
                         });
+                },
+
+                // A failed panel load must SAY so in the page. Leaving the panel on its static markup
+                // (an empty model list, the placeholder "CPU Only" option) reads as "the plugin is
+                // broken" and gives the admin nothing to report. (Issue #149.)
+                describeLoadError: function (err) {
+                    var msg = (err && (err.message || err.statusText)) || '';
+                    if (!msg && err && err.status) { msg = 'HTTP ' + err.status; }
+                    return msg || 'request failed';
                 },
 
                 // ── Library selector for auto-generation scope ───────────
@@ -1808,7 +1855,7 @@
                     row.appendChild(WhisperSubsConfig._workerField(
                         'Max upload size (MB)', 'number', 'wkMaxUpload', { min: '0', step: '1', placeholder: '0 = unlimited' },
                         (w.MaxUploadBytes != null && w.MaxUploadBytes > 0) ? Math.round(w.MaxUploadBytes / 1000000) : '',
-                        'Largest file this endpoint accepts. 0 (default) = unlimited. OpenAI and Groq are 25 on both tiers (Groq's 100 applies only to URL-fetched audio, which is not used here). Oversized titles then fail fast with a clear message instead of a bare HTTP 413.'));
+                        'Largest file this endpoint accepts. 0 (default) = unlimited. OpenAI and Groq are 25 on both tiers (the 100 MB Groq limit applies only to URL-fetched audio, which is not used here). Oversized titles then fail fast with a clear message instead of a bare HTTP 413.'));
                     row.appendChild(WhisperSubsConfig._workerSelect(
                         'Upload format', 'wkUploadCodec',
                         [['wav', 'WAV (default, uncompressed)'], ['flac', 'FLAC (lossless, ~half)'], ['opus', 'Opus 24k (~a tenth)']],

--- a/WhisperSubs.Tests/ScriptInjectionTests.cs
+++ b/WhisperSubs.Tests/ScriptInjectionTests.cs
@@ -145,4 +145,60 @@ public class ScriptInjectionTests
         Assert.Equal("warning", level);
         Assert.Contains("Re-inject", message);
     }
+
+    // ── Windows remediation (issue #149) ──────────────────────────────────────
+    // On a bare-metal Windows install the web root normally sits under C:\Program Files, which the
+    // Jellyfin service account cannot write — so "not writable" is the COMMON case there. Handing that
+    // admin a `sudo chown root:jellyfin` line gives them nothing to run.
+
+    [Theory]
+    [InlineData(@"C:\Program Files\Jellyfin\Server\jellyfin-web\index.html")]
+    [InlineData(@"D:\Jellyfin\jellyfin-web\index.html")]
+    [InlineData(@"\\nas\jellyfin\web\index.html")]
+    public void DescribeInjection_NotWritable_WindowsPath_GivesWindowsRemediation(string path)
+    {
+        var (level, message) = Plugin.DescribeInjection(
+            indexExists: true, scriptTagPresent: false, writable: false, indexHtmlPath: path);
+
+        Assert.Equal("error", level);
+        // Actionable on Windows: the real tool, the real path (quoted — these paths contain spaces).
+        Assert.Contains("icacls", message);
+        Assert.Contains("\"" + path + "\"", message);
+        // And NOT the POSIX advice, which is the whole defect being fixed.
+        Assert.DoesNotContain("sudo", message);
+        Assert.DoesNotContain("chown", message);
+        Assert.DoesNotContain("chmod", message);
+        // The File Transformation route is OS-independent and must survive on both branches.
+        Assert.Contains("File Transformation", message);
+    }
+
+    [Fact]
+    public void DescribeInjection_NotWritable_PosixPath_KeepsPosixRemediation()
+    {
+        // Guard the other side of the branch: adding Windows guidance must not weaken the Linux path.
+        var (level, message) = Plugin.DescribeInjection(
+            indexExists: true, scriptTagPresent: false, writable: false,
+            indexHtmlPath: "/usr/share/jellyfin/web/index.html");
+
+        Assert.Equal("error", level);
+        Assert.Contains("chown", message);
+        Assert.Contains("664", message);
+        Assert.DoesNotContain("icacls", message);
+    }
+
+    [Theory]
+    [InlineData(@"C:\web\index.html", true)]
+    [InlineData(@"c:/web/index.html", true)]
+    [InlineData(@"\\host\share\index.html", true)]
+    [InlineData("/usr/share/jellyfin/web/index.html", false)]
+    [InlineData("/srv/My Media/index.html", false)]
+    [InlineData("", false)]
+    [InlineData(null, false)]
+    [InlineData("C:", false)]           // too short to be a rooted path
+    [InlineData("relative/index.html", false)]
+    [InlineData("http://host/index.html", false)]  // a scheme is not a drive letter
+    public void IsWindowsStylePath_ClassifiesFromTheStringAlone(string? path, bool expected)
+    {
+        Assert.Equal(expected, Plugin.IsWindowsStylePath(path));
+    }
 }

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>4.5.0.2</Version>
+    <Version>4.5.0.3</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>

--- a/scripts/check-web-js.mjs
+++ b/scripts/check-web-js.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+// Parse-checks every piece of browser JavaScript the plugin ships.
+//
+// Why this exists (issue #149): configPage.html carries its whole admin UI in ONE inline <script>.
+// A single stray character there — v4.5.0.2 shipped `'... (Groq's 100 ...'`, an unescaped apostrophe
+// closing a single-quoted string — is a SyntaxError, and a SyntaxError means the browser executes
+// NONE of the block. Every panel then sits on its static markup and every button loses its listener,
+// so the page looks like "the backend works but the UI never updates". Nothing server-side logs a
+// thing, and the C# test suite cannot see it: the file is an embedded resource, never parsed at build.
+//
+// Run: node scripts/check-web-js.mjs
+// Exits non-zero (and names file + line) on the first file that fails to parse.
+
+import { readFileSync } from 'node:fs';
+import { Script } from 'node:vm';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, relative } from 'node:path';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/** Files that are plain scripts, parsed as-is. */
+const SCRIPT_FILES = ['Web/whisperSubs.js'];
+
+/** Files whose inline <script> blocks are extracted and parsed. */
+const HTML_FILES = ['Web/configPage.html'];
+
+const INLINE_SCRIPT = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
+
+/** Skip blocks that aren't JavaScript (e.g. type="application/json", src-only tags). */
+function isJavaScript(attrs) {
+  const type = /type\s*=\s*["']([^"']+)["']/i.exec(attrs);
+  if (/\bsrc\s*=/i.test(attrs)) return false;
+  if (!type) return true;
+  return /^(text\/javascript|application\/javascript|module)$/i.test(type[1].trim());
+}
+
+/**
+ * Compile-only. `new Script` throws on a syntax error and never runs the code, so this is a pure
+ * parse check — no DOM, no ApiClient, no side effects.
+ * `lineOffset` maps the reported line back to the real line in the source file.
+ */
+function parse(code, filename, lineOffset) {
+  new Script(code, { filename, lineOffset });
+}
+
+let failures = 0;
+
+function report(file, err) {
+  failures++;
+  console.error(`\n✗ ${file}`);
+  console.error(`  ${err.message}`);
+  // node puts the offending source + caret in the stack preamble; surface it, it is the useful part.
+  const preamble = String(err.stack || '').split('\n').slice(0, 5).join('\n');
+  if (preamble) console.error(preamble.replace(/^/gm, '  '));
+}
+
+for (const rel of SCRIPT_FILES) {
+  const abs = join(repoRoot, rel);
+  try {
+    parse(readFileSync(abs, 'utf8'), rel, 0);
+    console.log(`✓ ${rel}`);
+  } catch (err) {
+    report(rel, err);
+  }
+}
+
+for (const rel of HTML_FILES) {
+  const abs = join(repoRoot, rel);
+  const src = readFileSync(abs, 'utf8');
+  let blocks = 0;
+  let ok = true;
+
+  for (const m of src.matchAll(INLINE_SCRIPT)) {
+    if (!isJavaScript(m[1])) continue;
+    blocks++;
+    // Line number of the block's first line within the HTML file, so errors point at the real line.
+    const lineOffset = src.slice(0, m.index + m[0].indexOf('>') + 1).split('\n').length - 1;
+    try {
+      parse(m[2], rel, lineOffset);
+    } catch (err) {
+      ok = false;
+      report(rel, err);
+    }
+  }
+
+  if (blocks === 0) {
+    failures++;
+    console.error(`\n✗ ${rel}: no inline <script> block found — the extractor is broken, not the page.`);
+  } else if (ok) {
+    console.log(`✓ ${rel} (${blocks} inline <script> block${blocks === 1 ? '' : 's'})`);
+  }
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} file(s) failed to parse. The browser would execute NONE of the ` +
+    `affected block, leaving the page on its static markup with dead buttons.`);
+  process.exit(1);
+}
+
+console.log(`\nAll shipped browser JavaScript parses.`);


### PR DESCRIPTION
Fixes #149.

## Root cause

`Web/configPage.html:1876` shipped this inside the page's single inline `<script>`:

```js
'... OpenAI and Groq are 25 on both tiers (Groq's 100 applies only to URL-fetched audio, ...'
```

The apostrophe in `Groq's` **closes the single-quoted string literal**. Everything after it is garbage,
and the block fails to parse:

```
SyntaxError: missing ) after argument list
    Web/configPage.html:1876
```

A `SyntaxError` means the browser executes **none** of that `<script>`. The config page keeps exactly
the markup it was served with, which reproduces the report symptom-for-symptom:

| Reported | Why |
|---|---|
| "Language Models remains empty" | no `pageshow` listener registered → `loadEngine`/`renderDownloadedModels` never run |
| "CPU Only stays disabled" | the variant `<select>` keeps its static `<option value="cpu">CPU Only</option>` |
| "Re-inject script has no effect" | `#btnReinjectScript` never got a click listener |
| Setup/Status returns perfect JSON | the defect is 100% client-side — the server is untouched |
| "No WhisperSubs log entries" | nothing server-side ever failed, so nothing logged |

**Only 4.5.0.2 is affected.** Introduced in 5f7f4a2 (the #138 fix); v4.5.0.0 and v4.5.0.1 parse clean —
verified by checking out each tag.

This was not Windows-specific. Every 4.5.0.2 install has a dead config page; the reporter happened to
be on Windows.

## Why no test caught it

`configPage.html` is an **embedded resource**. Nothing in the .NET build or the 1300-test suite ever
parses it, so a fatal syntax error is invisible to CI and ships green.

## Fix

1. **Reword the helptext** to drop the apostrophe.
2. **`scripts/check-web-js.mjs`** — parse-checks `whisperSubs.js` and every inline `<script>` in
   `configPage.html` via `new vm.Script` (compile-only: no DOM, no `ApiClient`, no execution), mapping
   errors back to the real line in the HTML.
3. **New `web-js` CI job** runs it on every push/PR, so this class cannot ship again.

Negative control — the guard reintroduced against the exact 4.5.0.2 defect:

```
✗ Web/configPage.html
  missing ) after argument list
  Web/configPage.html:1876
  SyntaxError: missing ) after argument list
exit=1
```

## Secondary — two real Windows defects from the same report

- **`Plugin.DescribeInjection` gave Windows admins `sudo chown root:jellyfin`.** On bare-metal Windows
  the web root is under `C:\Program Files`, which the Jellyfin service account cannot write — so
  "index.html not writable" is the *common* case there, not an edge case, and it is why the reporter has
  no "Generate Subtitles" button. Now branches on a new pure `IsWindowsStylePath` and emits an `icacls`
  command with the real quoted path. The File Transformation route (OS-independent) survives on both
  branches; the POSIX branch is byte-unchanged and pinned by a test.
- **`renderBinaryStatus` used `split('/')`** to get the binary filename — no `/` exists in
  `D:\Whisper\whisper-cli.exe`, so it rendered the entire path. Splits on both separators now.

Plus two UX corrections: a failed panel load now says so **in the page** instead of only
`console.error`, and a platform with no prebuilt binaries but an already-installed `whisper-cli` now
reads as expected rather than as an error (it is a fully supported setup).

## Verification

- `dotnet build` — **0 warnings, 0 errors**
- `dotnet test` — **1316 passed**, 0 failed (was 1302; +14 new)
- `node scripts/check-web-js.mjs` — all shipped browser JS parses
- New Windows-remediation tests **fail against the pre-fix message** (3/3) and pass after — verified by
  reverting only that branch
- `ci.yml` validated as YAML

Version bumped 4.5.0.2 → **4.5.0.3**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration-page error messages for engine, injection-status, and model-list requests.
  * Corrected display of Windows binary paths.
  * Added platform-appropriate guidance for resolving non-writable installation paths.
  * Clarified hosted-worker upload-size information.

* **Quality Improvements**
  * Added automated validation to catch browser JavaScript syntax errors.
  * Increased regression coverage for Windows and POSIX path handling.

* **Maintenance**
  * Updated the application version to 4.5.0.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->