### PR TITLE
fix(#153): surface whisper-cli's real complaint when it exits 0 without output

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -74,22 +74,34 @@ body:
     attributes:
       label: Setup status endpoint
       description: |
-        Go to your Jellyfin URL and open:
-        `{your-jellyfin-url}/Plugins/WhisperSubs/Setup/Status`
+        These endpoints are admin-only, so opening them straight in a browser returns
+        **401 Unauthorized with an empty page** — that is expected, not a bug.
 
-        Paste the full JSON response below.
+        To read one, create an API key in **Dashboard → API Keys**, then:
+
+        ```
+        curl -H "Authorization: MediaBrowser Token=YOUR_API_KEY" \
+          "http://your-jellyfin:8096/Plugins/WhisperSubs/Setup/Status"
+        ```
+
+        Skip this if you can't get it — the logs below matter far more.
       render: json
     validations:
-      required: true
+      required: false
 
   - type: textarea
     id: queue-status
     attributes:
       label: Queue status
       description: |
-        Open: `{your-jellyfin-url}/Plugins/WhisperSubs/Queue`
+        Same admin-only rule as above — use the API key:
 
-        Paste the response here. This shows if transcription is running, stuck, or erroring.
+        ```
+        curl -H "Authorization: MediaBrowser Token=YOUR_API_KEY" \
+          "http://your-jellyfin:8096/Plugins/WhisperSubs/Queue"
+        ```
+
+        This shows if transcription is running, stuck, or erroring. Optional.
       render: json
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -77,12 +77,16 @@ body:
         These endpoints are admin-only, so opening them straight in a browser returns
         **401 Unauthorized with an empty page** — that is expected, not a bug.
 
-        To read one, create an API key in **Dashboard → API Keys**, then:
+        To read one, create an API key in **Dashboard → API Keys**, then (use `curl.exe`
+        on Windows PowerShell, where `curl` is an alias for something else):
 
         ```
-        curl -H "Authorization: MediaBrowser Token=YOUR_API_KEY" \
-          "http://your-jellyfin:8096/Plugins/WhisperSubs/Setup/Status"
+        curl -H "Authorization: MediaBrowser Token=$JF_KEY" "http://your-jellyfin:8096/Plugins/WhisperSubs/Setup/Status"
         ```
+
+        ⚠️ **Never paste your API key into this issue** — it grants full admin access.
+        Put it in an environment variable as above rather than typing it inline, and
+        redact any file paths you would rather not make public before pasting the JSON.
 
         Skip this if you can't get it — the logs below matter far more.
       render: json
@@ -97,11 +101,14 @@ body:
         Same admin-only rule as above — use the API key:
 
         ```
-        curl -H "Authorization: MediaBrowser Token=YOUR_API_KEY" \
-          "http://your-jellyfin:8096/Plugins/WhisperSubs/Queue"
+        curl -H "Authorization: MediaBrowser Token=$JF_KEY" "http://your-jellyfin:8096/Plugins/WhisperSubs/Queue"
         ```
 
         This shows if transcription is running, stuck, or erroring. Optional.
+
+        ⚠️ This response names the media it is working on (`currentItem`, `library`) and
+        may include paths in `lastError`. Redact anything private — and never your API
+        key — before pasting.
       render: json
 
   - type: textarea

--- a/Providers/WhisperProvider.cs
+++ b/Providers/WhisperProvider.cs
@@ -780,10 +780,13 @@ namespace WhisperSubs.Providers
             if (unknown.Success)
             {
                 return $"whisper-cli rejected the argument '{unknown.Groups[1].Value}' and exited without " +
-                       "transcribing anything. whisper.cpp does not accept it — flags from the Python " +
-                       "'openai-whisper' / 'faster-whisper' projects (for example --word_timestamps) either " +
-                       "do not exist here or are spelled differently. Remove it from Custom Whisper Arguments " +
-                       "in the plugin settings; run 'whisper-cli --help' to see the flags this build accepts.";
+                       "transcribing anything. Two things can cause this. Most often the flag came from " +
+                       "Custom Whisper Arguments and whisper.cpp simply has no such option — flags from the " +
+                       "Python 'openai-whisper' / 'faster-whisper' projects (for example --word_timestamps) " +
+                       "either do not exist here or are spelled differently, so remove it from that setting. " +
+                       "Otherwise the flag is one the plugin sends itself (such as --vad or --print-progress) " +
+                       "and this whisper-cli build is too old to know it, in which case update the binary. " +
+                       "Run 'whisper-cli --help' to see exactly which flags your build accepts.";
             }
 
             // Any other pre-flight complaint whisper-cli reports before doing work. Surface its own

--- a/Providers/WhisperProvider.cs
+++ b/Providers/WhisperProvider.cs
@@ -271,6 +271,13 @@ namespace WhisperSubs.Providers
                     return srtContent;
                 }
 
+                // whisper-cli can exit 0 having done nothing (its argument parser prints the error and
+                // exit(0)s), so reaching here with no output usually means it complained on stderr and
+                // that complaint is the only real diagnosis available. Prefer it over the path-not-found
+                // message, which describes the symptom rather than the cause. (Issue #153.)
+                var missingOutput = DescribeMissingOutputFailure(errorBuilder.ToString());
+                if (missingOutput != null) throw new InvalidOperationException(missingOutput);
+
                 throw new FileNotFoundException($"Subtitle file not found at expected location: {tempSrtPath}");
             }
             finally
@@ -749,6 +756,45 @@ namespace WhisperSubs.Providers
                        "\"CPU (Compatibility)\" / noavx variant on the plugin setup page, which is built " +
                        $"for CPUs without AVX2. Raw error: {(stderr ?? string.Empty).Trim()}";
             }
+            return null;
+        }
+
+        /// <summary>
+        /// Maps whisper-cli's stderr to an actionable message for the case where it exited
+        /// <b>successfully</b> but produced no subtitle file, or null when stderr says nothing useful.
+        /// <para>
+        /// This exists because whisper.cpp's argument parser prints <c>error: unknown argument: X</c>
+        /// followed by the usage text and then calls <c>exit(0)</c> — a SUCCESS code. The non-zero-exit
+        /// branch therefore never fires, the captured stderr was discarded, and the run surfaced as a
+        /// bare "Subtitle file not found at expected location", which says nothing about the real cause
+        /// and looks transient enough to burn all the retries. Verified against whisper-cli v1.8.4:
+        /// both an unknown flag and a malformed one exit 0. (Issue #153.)
+        /// </para>
+        /// Pure so the mapping is unit-testable.
+        /// </summary>
+        internal static string? DescribeMissingOutputFailure(string? stderr)
+        {
+            var text = stderr ?? string.Empty;
+
+            var unknown = Regex.Match(text, @"error:\s*unknown argument:\s*(\S+)");
+            if (unknown.Success)
+            {
+                return $"whisper-cli rejected the argument '{unknown.Groups[1].Value}' and exited without " +
+                       "transcribing anything. whisper.cpp does not accept it — flags from the Python " +
+                       "'openai-whisper' / 'faster-whisper' projects (for example --word_timestamps) either " +
+                       "do not exist here or are spelled differently. Remove it from Custom Whisper Arguments " +
+                       "in the plugin settings; run 'whisper-cli --help' to see the flags this build accepts.";
+            }
+
+            // Any other pre-flight complaint whisper-cli reports before doing work. Surface its own
+            // words rather than inventing a diagnosis for an error we have not seen before.
+            var reported = Regex.Match(text, @"^\s*error:.*$", RegexOptions.Multiline);
+            if (reported.Success)
+            {
+                return "whisper-cli exited without producing a subtitle file. It reported: " +
+                       reported.Value.Trim();
+            }
+
             return null;
         }
 

--- a/WhisperSubs.Tests/MissingOutputFailureTests.cs
+++ b/WhisperSubs.Tests/MissingOutputFailureTests.cs
@@ -1,0 +1,101 @@
+using WhisperSubs.Providers;
+using Xunit;
+
+namespace WhisperSubs.Tests;
+
+/// <summary>
+/// Tests for <see cref="WhisperProvider.DescribeMissingOutputFailure"/> (issue #153).
+///
+/// whisper.cpp's argument parser prints <c>error: unknown argument: X</c>, dumps the usage text, and
+/// then calls <c>exit(0)</c> — a SUCCESS code. So a fatal config mistake never reaches the
+/// non-zero-exit branch: the captured stderr was thrown away and the user saw only "Subtitle file not
+/// found at expected location", which names the symptom and hides the cause. The reporter burned all
+/// four attempts on it without ever learning which flag was wrong.
+/// </summary>
+public class MissingOutputFailureTests
+{
+    // whisper-cli v1.8.4's real output for the flag in the report, captured from the binary.
+    private const string UnknownArgumentStderr =
+        "error: unknown argument: --word_timestamps\n" +
+        "\n" +
+        "usage: /config/whisper/whisper-cli [options] file0 file1 ...\n" +
+        "supported audio formats: flac, mp3, ogg, wav\n";
+
+    [Fact]
+    public void UnknownArgument_NamesTheOffendingFlag()
+    {
+        var message = WhisperProvider.DescribeMissingOutputFailure(UnknownArgumentStderr);
+
+        Assert.NotNull(message);
+        // The whole point: the user must learn WHICH flag killed the run.
+        Assert.Contains("--word_timestamps", message);
+    }
+
+    [Fact]
+    public void UnknownArgument_PointsAtTheSettingThatCarriesIt()
+    {
+        // A correct diagnosis the user cannot act on is still a bad error. Custom Whisper Arguments is
+        // the only place a stray flag can come from, so the message must name it.
+        var message = WhisperProvider.DescribeMissingOutputFailure(UnknownArgumentStderr);
+
+        Assert.Contains("Custom Whisper Arguments", message!);
+    }
+
+    [Theory]
+    [InlineData("--word_timestamps")]
+    [InlineData("--beam_size")]
+    [InlineData("-XYZ")]
+    public void UnknownArgument_ExtractsWhicheverFlagWasRejected(string flag)
+    {
+        var message = WhisperProvider.DescribeMissingOutputFailure($"error: unknown argument: {flag}\n");
+
+        Assert.NotNull(message);
+        Assert.Contains(flag, message);
+    }
+
+    [Fact]
+    public void OtherErrorLine_IsSurfacedVerbatim()
+    {
+        // For an error we have not characterised, repeat whisper-cli's own words rather than inventing
+        // a diagnosis — a wrong-but-confident message is worse than a raw one.
+        var message = WhisperProvider.DescribeMissingOutputFailure(
+            "whisper_init_from_file_with_params_no_state: loading model\n" +
+            "error: failed to initialize whisper context\n");
+
+        Assert.NotNull(message);
+        Assert.Contains("failed to initialize whisper context", message);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void NoStderr_ReturnsNull_SoTheCallerKeepsItsOwnMessage(string? stderr)
+    {
+        // Null means "I have nothing to add" and the caller falls back to the path-not-found error.
+        Assert.Null(WhisperProvider.DescribeMissingOutputFailure(stderr));
+    }
+
+    [Fact]
+    public void HealthyChatterWithoutAnErrorLine_ReturnsNull()
+    {
+        // whisper-cli writes ALL its normal progress to stderr, so a run that merely produced no file
+        // for some other reason must NOT be dressed up as an error that whisper never reported.
+        var chatter =
+            "whisper_init_from_file_with_params_no_state: loading model from 'ggml-large-v3-turbo.bin'\n" +
+            "whisper_model_load: model size = 1620.00 MB\n" +
+            "system_info: n_threads = 4 | AVX = 1 | AVX2 = 1\n" +
+            "whisper_print_progress_callback: progress =  100%\n";
+
+        Assert.Null(WhisperProvider.DescribeMissingOutputFailure(chatter));
+    }
+
+    [Fact]
+    public void ErrorMatchIsAnchoredToItsOwnLine_NotMatchedMidSentence()
+    {
+        // "error:" appearing inside a normal log line must not be mistaken for a reported failure.
+        var chatter = "whisper_model_load: no error: model loaded cleanly\n";
+
+        Assert.Null(WhisperProvider.DescribeMissingOutputFailure(chatter));
+    }
+}

--- a/WhisperSubs.csproj
+++ b/WhisperSubs.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>4.6.0.0</Version>
+    <Version>4.6.0.1</Version>
     <Authors>Sergio</Authors>
     <Company>Sergio</Company>
     <Product>WhisperSubs</Product>


### PR DESCRIPTION
Fixes the diagnosis reported in #153.

## Root cause

The reporter's command line ended with:

```
--max-len 42 --word_timestamps True
```

`--word_timestamps` belongs to the Python **openai-whisper / faster-whisper** projects. whisper.cpp has no such flag. So far, so much user error — except for what happens next.

whisper.cpp's argument parser prints the error, dumps usage, and then calls **`exit(0)`** — a *success* code. Verified directly against `whisper-cli` v1.8.4:

```
$ whisper-cli --word_timestamps True >/dev/null 2>/dev/null; echo $?
0
$ whisper-cli --bogus-flag-xyz >/dev/null 2>/dev/null; echo $?
0
```

The consequences in this plugin:

1. `if (process.ExitCode != 0)` never fires, so the whole exit-failure path is skipped.
2. The captured stderr — which said, in plain words, `error: unknown argument: --word_timestamps` — was **discarded**.
3. Execution fell through to `throw new FileNotFoundException("Subtitle file not found at expected location: /tmp/...")`. That is `WhisperProvider.cs:272` in v4.5.0.3, exactly where the reporter's stack trace points.
4. Because that reads as transient, the dispatcher retried 4 times, re-extracting audio each time, and the user still never learned which flag was wrong.

So a deterministic, instantly-diagnosable config mistake was reported as a mysterious missing file.

## The fix

New pure `WhisperProvider.DescribeMissingOutputFailure(stderr)`, consulted before the path-not-found throw:

- **Unknown argument** → names the rejected flag, explains that Python-Whisper flags don't exist here, and points at the **Custom Whisper Arguments** setting that carries it.
- **Any other `error:` line** → repeats whisper-cli's own words verbatim, rather than inventing a diagnosis for a failure we haven't characterised.
- **Only normal chatter** → returns `null`, so the caller keeps its existing message. whisper-cli writes all its healthy progress output to stderr, so this branch matters.

## Also: the bug-report template was unusable

The reporter wrote *"Nothing is returned. I can't figure out a URL pattern that works."* They were right, and it wasn't their fault — the template told them to open `Setup/Status` and `Queue` in a browser, but those are admin-only:

```
$ curl -o /dev/null -w "%{http_code}" .../Plugins/WhisperSubs/Setup/Status
401
```

A browser navigation carries no Jellyfin token, so it returns 401 with an empty body — for **every** reporter, always. `setup-status` was also marked `required: true`, forcing people to submit something they cannot obtain. Now documents the API-key `curl` and marks both optional, since the logs are what actually matter.

## Testing

`MissingOutputFailureTests` (11 cases), using whisper-cli's **real captured stderr** as the fixture: flag extraction, the pointer to the setting, verbatim passthrough for uncharacterised errors, null for empty/whitespace/normal chatter, and a guard that `error:` mid-sentence in a healthy log line isn't mistaken for a failure.

Negative control: breaking the unknown-argument regex fails the actionable-guidance test. Note that the flag-name assertions still pass in that state, because the generic `error:` fallback also surfaces the flag — the specific branch's distinct value is the guidance, which is what the failing test pins.

Full suite: **1337 passed / 0 failed**.

## Not changed

The retry behaviour. Four attempts at a deterministic config error is wasteful, but with a clear message the user now fixes it immediately, and narrowing retry semantics is a larger change than this bug warrants.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcription failure messages when no subtitle file is produced.
  * Unknown Whisper arguments now identify the rejected option and where to correct it.
  * Other reported transcription errors are displayed directly, while existing fallback messaging is preserved.

* **Documentation**
  * Updated the bug report template with authentication requirements and clearer API troubleshooting examples.

* **Chores**
  * Incremented the application version to 4.6.0.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->